### PR TITLE
Fix nullable operator not handled on iOS 12 & 13

### DIFF
--- a/Sources/Navigator/EPUB/Assets/fxl-spread-one.html
+++ b/Sources/Navigator/EPUB/Assets/fxl-spread-one.html
@@ -49,7 +49,7 @@
 
         // Evaluates a JavaScript in the context of a resource.
         'eval': function(href, script) {
-          if (href === '#' || href === '' || _page.link?.href === href) {
+          if (href === '#' || href === '' || (_page.link && (_page.link.href === href))) {
             return _page.eval(script);
           }
         },

--- a/Sources/Navigator/EPUB/Assets/fxl-spread-two.html
+++ b/Sources/Navigator/EPUB/Assets/fxl-spread-two.html
@@ -94,7 +94,7 @@
       function getPageWithHref(href) {
         for (position in _pages) {
           var page = _pages[position];
-          if (page.link?.href === href) {
+          if (page.link && (page.link.href === href)) {) {
             return page;
           }
         }


### PR DESCRIPTION
Some fix made on https://github.com/readium/r2-navigator-swift/pull/208 were not applied to HTML files for FXL epubs.

This was still an issue:
> Optional chaining (e.g. link?.href) is not available before iOS 13.4.