### PR TITLE
TestApp: Remove Samples support

### DIFF
--- a/Support/CocoaPods/ReadiumLCP.podspec
+++ b/Support/CocoaPods/ReadiumLCP.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.summary       = "Readium LCP"
   s.homepage      = "http://readium.github.io"
   s.author        = { "Readium" => "contact@readium.org" }
-  s.source        = { :git => "https://github.com/readium/swift-toolkit.git", :tag => "2.2.0" }
+  s.source        = { :git => "https://github.com/readium/swift-toolkit.git", :branch => "develop" }
   s.requires_arc  = true
   s.resources     = [
     'Sources/LCP/Resources/**',

--- a/Support/CocoaPods/ReadiumNavigator.podspec
+++ b/Support/CocoaPods/ReadiumNavigator.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.summary       = "R2 Navigator"
   s.homepage      = "http://readium.github.io"
   s.author        = { "Readium" => "contact@readium.org" }
-  s.source        = { :git => "https://github.com/readium/swift-toolkit.git", :tag => "2.2.0" }
+  s.source        = { :git => "https://github.com/readium/swift-toolkit.git", :branch => "develop" }
   s.requires_arc  = true
   s.resources     = ['Sources/Navigator/Resources/**', 'Sources/Navigator/EPUB/Assets']
   s.source_files  = "Sources/Navigator/**/*.{m,h,swift}"

--- a/Support/CocoaPods/ReadiumOPDS.podspec
+++ b/Support/CocoaPods/ReadiumOPDS.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.summary       = "Readium OPDS"
   s.homepage      = "http://readium.github.io"
   s.author        = { "Readium" => "contact@readium.org" }
-  s.source        = { :git => "https://github.com/readium/swift-toolkit.git", :tag => "2.2.0" }
+  s.source        = { :git => "https://github.com/readium/swift-toolkit.git", :branch => "develop" }
   s.requires_arc  = true
   s.resources     = ['Sources/OPDS/Resources/**']
   s.source_files  = "Sources/OPDS/**/*.{m,h,swift}"

--- a/Support/CocoaPods/ReadiumShared.podspec
+++ b/Support/CocoaPods/ReadiumShared.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.summary      = 'R2 Shared'
   s.homepage     = 'http://readium.github.io'
   s.author       = { "Readium" => "contact@readium.org" }
-  s.source       = { :git => 'https://github.com/readium/swift-toolkit.git', :tag => "2.2.0" }
+  s.source       = { :git => 'https://github.com/readium/swift-toolkit.git', :branch => "develop" }
   s.exclude_files = ["Sources/Shared/Toolkit/Archive/ZIPFoundation.swift"]
   s.requires_arc = true
   s.resources    = ['Sources/Shared/Resources/**']

--- a/Support/CocoaPods/ReadiumStreamer.podspec
+++ b/Support/CocoaPods/ReadiumStreamer.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.summary       = "R2 Streamer"
   s.homepage      = "http://readium.github.io"
   s.author        = { "Readium" => "contact@readium.org" }
-  s.source        = { :git => "https://github.com/readium/swift-toolkit.git", :tag => "2.2.0" }
+  s.source        = { :git => "https://github.com/readium/swift-toolkit.git", :branch => "develop" }
   s.requires_arc  = true
   s.resources     = ['Sources/Streamer/Resources/**', 'Sources/Streamer/Assets']
   s.source_files  = "Sources/Streamer/**/*.{m,h,swift}"

--- a/TestApp/Integrations/Carthage/project+lcp.yml
+++ b/TestApp/Integrations/Carthage/project+lcp.yml
@@ -18,10 +18,6 @@ targets:
     deploymentTarget: "13.6"
     sources: 
       - path: Sources
-        excludes:
-          - Resources/Samples
-      - path: Sources/Resources/Samples
-        type: folder
     dependencies:
       - carthage: R2LCPClient
       - framework: Carthage/Build/CryptoSwift.xcframework

--- a/TestApp/Integrations/Carthage/project.yml
+++ b/TestApp/Integrations/Carthage/project.yml
@@ -18,10 +18,6 @@ targets:
     deploymentTarget: "13.6"
     sources: 
       - path: Sources
-        excludes:
-          - Resources/Samples
-      - path: Sources/Resources/Samples
-        type: folder
     dependencies:
       - framework: Carthage/Build/CryptoSwift.xcframework
       - framework: Carthage/Build/DifferenceKit.xcframework

--- a/TestApp/Integrations/CocoaPods/project+lcp.yml
+++ b/TestApp/Integrations/CocoaPods/project+lcp.yml
@@ -8,9 +8,5 @@ targets:
     deploymentTarget: "13.6"
     sources: 
       - path: Sources
-        excludes:
-          - Resources/Samples
-      - path: Sources/Resources/Samples
-        type: folder
     settings:
       OTHER_SWIFT_FLAGS: $(inherited) -DLCP

--- a/TestApp/Integrations/CocoaPods/project.yml
+++ b/TestApp/Integrations/CocoaPods/project.yml
@@ -8,7 +8,3 @@ targets:
     deploymentTarget: "13.6"
     sources: 
       - path: Sources
-        excludes:
-          - Resources/Samples
-      - path: Sources/Resources/Samples
-        type: folder

--- a/TestApp/Integrations/Local/project+lcp.yml
+++ b/TestApp/Integrations/Local/project+lcp.yml
@@ -23,10 +23,6 @@ targets:
     deploymentTarget: "13.6"
     sources: 
       - path: Sources
-        excludes:
-          - Resources/Samples
-      - path: Sources/Resources/Samples
-        type: folder
     dependencies:
       - carthage: R2LCPClient
       - package: Readium

--- a/TestApp/Integrations/Local/project.yml
+++ b/TestApp/Integrations/Local/project.yml
@@ -23,10 +23,6 @@ targets:
     deploymentTarget: "13.6"
     sources: 
       - path: Sources
-        excludes:
-          - Resources/Samples
-      - path: Sources/Resources/Samples
-        type: folder
     dependencies:
       - package: Readium
         product: R2Shared

--- a/TestApp/Integrations/SPM/project+lcp.yml
+++ b/TestApp/Integrations/SPM/project+lcp.yml
@@ -24,10 +24,6 @@ targets:
     deploymentTarget: "13.6"
     sources: 
       - path: Sources
-        excludes:
-          - Resources/Samples
-      - path: Sources/Resources/Samples
-        type: folder
     dependencies:
       - carthage: R2LCPClient
       - package: Readium

--- a/TestApp/Integrations/SPM/project.yml
+++ b/TestApp/Integrations/SPM/project.yml
@@ -24,10 +24,6 @@ targets:
     deploymentTarget: "13.6"
     sources: 
       - path: Sources
-        excludes:
-          - Resources/Samples
-      - path: Sources/Resources/Samples
-        type: folder
     dependencies:
       - package: Readium
         product: R2Shared

--- a/TestApp/Sources/App/AppModule.swift
+++ b/TestApp/Sources/App/AppModule.swift
@@ -52,8 +52,6 @@ final class AppModule {
         
         // Set Readium 2's logging minimum level.
         R2EnableLog(withMinimumSeverityLevel: .debug)
-        
-        library.preloadSamples()
     }
     
     private(set) lazy var aboutViewController: UIViewController = {

--- a/TestApp/Sources/Common/Paths.swift
+++ b/TestApp/Sources/Common/Paths.swift
@@ -20,8 +20,6 @@ final class Paths {
     static let documents: URL =
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
     
-    static let samples = Bundle.main.resourceURL!.appendingPathComponent("Samples")
-    
     static let library: URL =
         FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!
     

--- a/TestApp/Sources/Library/LibraryModule.swift
+++ b/TestApp/Sources/Library/LibraryModule.swift
@@ -26,9 +26,6 @@ protocol LibraryModuleAPI {
     /// Can be used to present the library to the user.
     var rootViewController: UINavigationController { get }
     
-    /// Loads the sample publications if needed.
-    func preloadSamples()
-    
     /// Imports a new publication to the library, either from:
     /// - a local file URL
     /// - a remote URL which will be downloaded
@@ -67,17 +64,6 @@ final class LibraryModule: LibraryModuleAPI {
         library.libraryDelegate = delegate
         return library
     }()
-    
-    func preloadSamples() {
-        library.preloadSamples()
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                if case let .failure(error) = completion {
-                    self.delegate?.presentError(error, from: self.libraryViewController)
-                }
-            }) {}
-            .store(in: &subscriptions)
-    }
     
     func importPublication(from url: URL, sender: UIViewController) -> AnyPublisher<Book, LibraryError> {
         library.importPublication(from: url, sender: sender)


### PR DESCRIPTION
The samples were removed to keep the size of the repo down. Use the standard import function to add books.