### PR TITLE
Support for checking a Publication Profile conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project will be documented in this file. Take a look
 
 ## [Unreleased]
 
+### Added
+
+#### Shared
+
+* A new `Publication.conforms(to:)` API to identify the profile of a publication.
+* Support for the [`conformsTo` RWPM metadata](https://github.com/readium/webpub-manifest/issues/65), to identify the profile of a `Publication`.
+
+### Deprecated
+
+#### Shared
+
+* `Publication.format` is now deprecated in favor of the new `Publication.conforms(to:)` API which is more accurate.
+    * For example, replace `publication.format == .epub` with `publication.conforms(to: .epub)` before opening a publication with the `EPUBNavigatorViewController`.
+
 ### Fixed
 
 #### Navigator

--- a/Sources/Shared/Publication/Link.swift
+++ b/Sources/Shared/Publication/Link.swift
@@ -120,7 +120,7 @@ public struct Link: JSONEquatable, Hashable {
     }
     
     /// Media type of the linked resource.
-    var mediaType: MediaType {
+    public var mediaType: MediaType {
         MediaType.of(
             mediaType: type,
             fileExtension: URL(string: href)?.pathExtension

--- a/Sources/Shared/Publication/Link.swift
+++ b/Sources/Shared/Publication/Link.swift
@@ -119,6 +119,14 @@ public struct Link: JSONEquatable, Hashable {
         ])
     }
     
+    /// Media type of the linked resource.
+    var mediaType: MediaType {
+        MediaType.of(
+            mediaType: type,
+            fileExtension: URL(string: href)?.pathExtension
+        ) ?? .binary
+    }
+    
     /// Computes an absolute URL to the link, relative to the given `baseURL`.
     ///
     /// If the link's `href` is already absolute, the `baseURL` is ignored.
@@ -280,14 +288,14 @@ extension Array where Element == Link {
     
     /// Returns whether all the resources in the collection are matching the given media type.
     public func all(matchMediaType mediaType: MediaType) -> Bool {
-        allSatisfy { mediaType.matches($0.type) }
+        allSatisfy { mediaType.matches($0.mediaType) }
     }
     
     /// Returns whether all the resources in the collection are matching any of the given media types.
     public func all(matchMediaTypes mediaTypes: [MediaType]) -> Bool {
         allSatisfy { link in
             mediaTypes.contains { mediaType in
-                mediaType.matches(link.type)
+                mediaType.matches(link.mediaType)
             }
         }
     }

--- a/Sources/Shared/Publication/Manifest.swift
+++ b/Sources/Shared/Publication/Manifest.swift
@@ -105,9 +105,6 @@ public struct Manifest: JSONEquatable, Hashable {
     
     /// Returns whether this manifest conforms to the given Readium Web Publication Profile.
     public func conforms(to profile: Publication.Profile) -> Bool {
-        if metadata.conformsTo.contains(profile) {
-            return true
-        }
         guard !readingOrder.isEmpty else {
             return false
         }
@@ -117,11 +114,17 @@ public struct Manifest: JSONEquatable, Hashable {
             return readingOrder.allAreAudio
         case .divina:
             return readingOrder.allAreBitmap
+        case .epub:
+            // EPUB needs to be explicitly indicated in `conformsTo`, otherwise
+            // it could be a regular Web Publication.
+            return readingOrder.allAreHTML && metadata.conformsTo.contains(.epub)
         case .pdf:
             return readingOrder.all(matchMediaType: .pdf)
         default:
-            return false
+            break
         }
+        
+        return metadata.conformsTo.contains(profile)
     }
     
     /// Finds the first link with the given relation in the manifest's links.

--- a/Sources/Shared/Publication/Manifest.swift
+++ b/Sources/Shared/Publication/Manifest.swift
@@ -103,6 +103,27 @@ public struct Manifest: JSONEquatable, Hashable {
         ], additional: PublicationCollection.serializeCollections(subcollections))
     }
     
+    /// Returns whether this manifest conforms to the given Readium Web Publication Profile.
+    public func conforms(to profile: Publication.Profile) -> Bool {
+        if metadata.conformsTo.contains(profile) {
+            return true
+        }
+        guard !readingOrder.isEmpty else {
+            return false
+        }
+        
+        switch profile {
+        case .audiobook:
+            return readingOrder.allAreAudio
+        case .divina:
+            return readingOrder.allAreBitmap
+        case .pdf:
+            return readingOrder.all(matchMediaType: .pdf)
+        default:
+            return false
+        }
+    }
+    
     /// Finds the first link with the given relation in the manifest's links.
     public func link(withRel rel: LinkRelation) -> Link? {
         return readingOrder.first(withRel: rel)

--- a/Sources/Shared/Publication/Metadata.swift
+++ b/Sources/Shared/Publication/Metadata.swift
@@ -20,6 +20,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger {
 
     public let identifier: String?  // URI
     public let type: String?  // URI (@type)
+    public let conformsTo: [Publication.Profile]
     
     public let localizedTitle: LocalizedString
     public var title: String { localizedTitle.string }
@@ -64,6 +65,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger {
     public init(
         identifier: String? = nil,
         type: String? = nil,
+        conformsTo: [Publication.Profile] = [],
         title: LocalizedStringConvertible,
         subtitle: LocalizedStringConvertible? = nil,
         modified: Date? = nil,
@@ -95,6 +97,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger {
     ) {
         self.identifier = identifier
         self.type = type
+        self.conformsTo = conformsTo
         self.localizedTitle = title.localizedString
         self.localizedSubtitle = subtitle?.localizedString
         self.modified = modified
@@ -141,6 +144,8 @@ public struct Metadata: Hashable, Loggable, WarningLogger {
         
         self.identifier = json.pop("identifier") as? String
         self.type = json.pop("@type") as? String ?? json.pop("type") as? String
+        self.conformsTo = parseArray(json.pop("conformsTo"), allowingSingle: true)
+            .map { Publication.Profile($0) }
         self.localizedTitle = title
         self.localizedSubtitle = try? LocalizedString(json: json.pop("subtitle"), warnings: warnings)
         self.modified = parseDate(json.pop("modified"))
@@ -175,6 +180,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger {
         return makeJSON([
             "identifier": encodeIfNotNil(identifier),
             "@type": encodeIfNotNil(type),
+            "conformsTo": encodeIfNotEmpty(conformsTo.map { $0.uri }),
             "title": localizedTitle.json,
             "subtitle": encodeIfNotNil(localizedSubtitle?.json),
             "modified": encodeIfNotNil(modified?.iso8601),
@@ -242,6 +248,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger {
     public func copy(
         identifier: String?? = nil,
         type: String?? = nil,
+        conformsTo: [Publication.Profile]? = nil,
         title: LocalizedStringConvertible? = nil,
         subtitle: LocalizedStringConvertible?? = nil,
         modified: Date?? = nil,
@@ -274,6 +281,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger {
         return Metadata(
             identifier: identifier ?? self.identifier,
             type: type ?? self.type,
+            conformsTo: conformsTo ?? self.conformsTo,
             title: title ?? self.localizedTitle,
             subtitle: subtitle ?? self.localizedSubtitle,
             modified: modified ?? self.modified,

--- a/Sources/Shared/Publication/Publication+Deprecated.swift
+++ b/Sources/Shared/Publication/Publication+Deprecated.swift
@@ -16,6 +16,13 @@ public typealias WebPublication = Publication
 
 extension Publication {
     
+    @available(*, deprecated, message: "format and formatVersion are deprecated", renamed: "init(manifest:fetcher:servicesBuilder:)")
+    public convenience init(manifest: Manifest, fetcher: Fetcher = EmptyFetcher(), servicesBuilder: PublicationServicesBuilder = .init(), format: Format = .unknown, formatVersion: String? = nil) {
+        self.init(manifest: manifest, fetcher: fetcher, servicesBuilder: servicesBuilder)
+        self.format = format
+        self.formatVersion = formatVersion
+    }
+    
     @available(*, unavailable, renamed: "init(manifest:)")
     public convenience init() {
         self.init(manifest: Manifest(metadata: Metadata(title: "")))
@@ -24,9 +31,7 @@ extension Publication {
     @available(*, unavailable, renamed: "init(format:formatVersion:manifest:)")
     public convenience init(format: Format = .unknown, formatVersion: String? = nil, positionListFactory: @escaping (Publication) -> [Locator] = { _ in [] }, context: [String] = [], metadata: Metadata, links: [Link] = [], readingOrder: [Link] = [], resources: [Link] = [], tableOfContents: [Link] = [], otherCollections: [String: [PublicationCollection]] = [:]) {
         self.init(
-            manifest: Manifest(context: context, metadata: metadata, links: links, readingOrder: readingOrder, resources: resources, tableOfContents: tableOfContents, subcollections: otherCollections),
-            format: format,
-            formatVersion: formatVersion
+            manifest: Manifest(context: context, metadata: metadata, links: links, readingOrder: readingOrder, resources: resources, tableOfContents: tableOfContents, subcollections: otherCollections)
         )
     }
     

--- a/Sources/Shared/Publication/Publication+Deprecated.swift
+++ b/Sources/Shared/Publication/Publication+Deprecated.swift
@@ -36,14 +36,7 @@ extension Publication {
     }
     
     @available(*, unavailable, renamed: "formatVersion")
-    public var version: Double {
-        guard let versionString = formatVersion,
-            let version = Double(versionString) else
-        {
-            return 0
-        }
-        return version
-    }
+    public var version: Double { 0 }
 
     /// Factory used to build lazily the `positionList`.
     /// By default, a parser will set this to parse the `positionList` from the publication. But the host app might want to overwrite this with a custom closure to implement for example a cache mechanism.
@@ -56,25 +49,8 @@ extension Publication {
     @available(*, unavailable, message: "This is not used anymore, don't set it")
     public var updatedDate: Date { Date() }
     
-    @available(*, unavailable, message: "Check the publication's type using `format` instead")
-    public var internalData: [String: String] {
-        // The code in the testapp used to check a property in `publication.internalData["type"]` to know which kind of publication this is.
-        // To avoid breaking any app, we reproduce this value here:
-        return [
-            "type": {
-                switch format {
-                case .epub:
-                    return "epub"
-                case .cbz:
-                    return "cbz"
-                case .pdf:
-                    return "pdf"
-                default:
-                    return "unknown"
-                }
-            }()
-        ]
-    }
+    @available(*, unavailable, message: "Check the publication's type using `conforms(to:)` instead")
+    public var internalData: [String: String] { [:] }
     
     @available(*, unavailable, renamed: "json")
     public var manifestCanonical: String { jsonManifest ?? "" }

--- a/Sources/Shared/Publication/Publication.swift
+++ b/Sources/Shared/Publication/Publication.swift
@@ -14,10 +14,12 @@ import Foundation
 
 /// Shared model for a Readium Publication.
 public class Publication: Loggable {
-
+    
     /// Format of the publication, if specified.
+    @available(*, deprecated, message: "Use publication.conforms(to:) to check the profile of a Publication")
     public var format: Format = .unknown
     /// Version of the publication's format, eg. 3 for EPUB 3
+    @available(*, deprecated, message: "This API will be removed in a future version. If you still need it, please explain your use case at https://github.com/readium/swift-toolkit/issues/new")
     public var formatVersion: String?
     
     private var manifest: Manifest

--- a/Sources/Shared/Publication/Publication.swift
+++ b/Sources/Shared/Publication/Publication.swift
@@ -86,23 +86,7 @@ public class Publication: Loggable {
     
     /// Returns whether this publication conforms to the given Readium Web Publication Profile.
     public func conforms(to profile: Profile) -> Bool {
-        if metadata.conformsTo.contains(profile) {
-            return true
-        }
-        guard !readingOrder.isEmpty else {
-            return false
-        }
-        
-        switch profile {
-        case .audiobook:
-            return readingOrder.allAreAudio
-        case .divina:
-            return readingOrder.allAreBitmap
-        case .pdf:
-            return readingOrder.all(matchMediaType: .pdf)
-        default:
-            return false
-        }
+        return manifest.conforms(to: profile)
     }
     
     /// The URL where this publication is served, computed from the `Link` with `self` relation.

--- a/Sources/Shared/Publication/Publication.swift
+++ b/Sources/Shared/Publication/Publication.swift
@@ -50,9 +50,7 @@ public class Publication: Loggable {
     public init(
         manifest: Manifest,
         fetcher: Fetcher = EmptyFetcher(),
-        servicesBuilder: PublicationServicesBuilder = .init(),
-        format: Format = .unknown,
-        formatVersion: String? = nil
+        servicesBuilder: PublicationServicesBuilder = .init()
     ) {
         let weakPublication = Weak<Publication>()
 
@@ -69,8 +67,6 @@ public class Publication: Loggable {
         self.manifest = manifest
         self.fetcher = fetcher
         self.services = services
-        self.format = format
-        self.formatVersion = formatVersion
 
         weakPublication.ref = self
     }
@@ -347,9 +343,9 @@ public class Publication: Loggable {
             let publication = Publication(
                 manifest: manifest,
                 fetcher: fetcher,
-                servicesBuilder: servicesBuilder
+                servicesBuilder: servicesBuilder,
+                format: format
             )
-            publication.format = format
             setupPublication?(publication)
             return publication
         }

--- a/Sources/Shared/Publication/Publication.swift
+++ b/Sources/Shared/Publication/Publication.swift
@@ -86,7 +86,23 @@ public class Publication: Loggable {
     
     /// Returns whether this publication conforms to the given Readium Web Publication Profile.
     public func conforms(to profile: Profile) -> Bool {
-        manifest.metadata.conformsTo.contains(profile)
+        if metadata.conformsTo.contains(profile) {
+            return true
+        }
+        guard !readingOrder.isEmpty else {
+            return false
+        }
+        
+        switch profile {
+        case .audiobook:
+            return readingOrder.allAreAudio
+        case .divina:
+            return readingOrder.allAreBitmap
+        case .pdf:
+            return readingOrder.all(matchMediaType: .pdf)
+        default:
+            return false
+        }
     }
     
     /// The URL where this publication is served, computed from the `Link` with `self` relation.

--- a/Sources/Shared/Publication/Publication.swift
+++ b/Sources/Shared/Publication/Publication.swift
@@ -84,6 +84,11 @@ public class Publication: Loggable {
         serializeJSONString(manifest.json)
     }
     
+    /// Returns whether this publication conforms to the given Readium Web Publication Profile.
+    public func conforms(to profile: Profile) -> Bool {
+        manifest.metadata.conformsTo.contains(profile)
+    }
+    
     /// The URL where this publication is served, computed from the `Link` with `self` relation.
     ///
     /// e.g. https://provider.com/pub1293/manifest.json gives https://provider.com/pub1293/
@@ -177,7 +182,28 @@ public class Publication: Loggable {
             ), at: 0)
         }
     }
-
+    
+    /// Represents a Readium Web Publication Profile a `Publication` can conform to.
+    ///
+    /// For a list of supported profiles, see the registry:
+    /// https://readium.org/webpub-manifest/profiles/
+    public struct Profile: Hashable {
+        public let uri: String
+        
+        public init(_ uri: String) {
+            self.uri = uri
+        }
+        
+        /// Profile for EPUB publications.
+        public static let epub = Profile("https://readium.org/webpub-manifest/profiles/epub")
+        /// Profile for audiobooks.
+        public static let audiobook = Profile("https://readium.org/webpub-manifest/profiles/audiobook")
+        /// Profile for visual narratives (comics, manga and bandes dessinées).
+        public static let divina = Profile("https://readium.org/webpub-manifest/profiles/divina")
+        /// Profile for PDF documents.
+        public static let pdf = Profile("https://readium.org/webpub-manifest/profiles/pdf")
+    }
+    
     public enum Format: Equatable, Hashable {
         /// Formats natively supported by Readium.
         case cbz, epub, pdf, webpub

--- a/Sources/Shared/Toolkit/Media Type/MediaType.swift
+++ b/Sources/Shared/Toolkit/Media Type/MediaType.swift
@@ -322,14 +322,3 @@ public struct MediaType: Hashable, Loggable {
     }
 
 }
-
-
-public extension Link {
-    
-    /// Media type of the linked resource.
-    var mediaType: MediaType {
-        type.flatMap { MediaType.of(mediaType: $0, fileExtension: URL(string: href)?.pathExtension) }
-            ?? .binary
-    }
-
-}

--- a/Sources/Shared/Toolkit/Media Type/MediaTypeSniffer.swift
+++ b/Sources/Shared/Toolkit/Media Type/MediaTypeSniffer.swift
@@ -229,14 +229,14 @@ public extension MediaType {
         if let (isManifest, rwpm) = readRWPM() {
             let isLCPProtected = context.containsArchiveEntry(at: "/license.lcpl")
 
-            if rwpm.metadata.type == "http://schema.org/Audiobook" || rwpm.readingOrder.allAreAudio {
+            if rwpm.conforms(to: .audiobook) {
                 return isManifest ? .readiumAudiobookManifest :
                     isLCPProtected ? .lcpProtectedAudiobook : .readiumAudiobook
             }
-            if rwpm.readingOrder.allAreBitmap {
+            if rwpm.conforms(to: .divina) {
                 return isManifest ? .divinaManifest : .divina
             }
-            if isLCPProtected, rwpm.readingOrder.all(matchMediaType: .pdf) {
+            if isLCPProtected, rwpm.conforms(to: .pdf) {
                 return .lcpProtectedPDF
             }
             if rwpm.link(withRel: .`self`)?.type == "application/webpub+json" {

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -38,6 +38,7 @@ public final class AudioParser: PublicationParser {
             format: .cbz,
             manifest: Manifest(
                 metadata: Metadata(
+                    conformsTo: [.audiobook],
                     title: fetcher.guessTitle(ignoring: ignores) ?? asset.name
                 ),
                 readingOrder: readingOrder

--- a/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
@@ -49,6 +49,7 @@ final class EPUBMetadataParser: Loggable {
         
         return Metadata(
             identifier: uniqueIdentifier,
+            conformsTo: [.epub],
             title: mainTitle ?? fallbackTitle,
             subtitle: subtitle,
             modified: modifiedDate,

--- a/Sources/Streamer/Parser/Image/ImageParser.swift
+++ b/Sources/Streamer/Parser/Image/ImageParser.swift
@@ -41,6 +41,7 @@ public final class ImageParser: PublicationParser {
             format: .cbz,
             manifest: Manifest(
                 metadata: Metadata(
+                    conformsTo: [.divina],
                     title: fetcher.guessTitle(ignoring: ignores) ?? asset.name
                 ),
                 readingOrder: readingOrder

--- a/TestApp/Sources/Reader/CBZ/CBZModule.swift
+++ b/TestApp/Sources/Reader/CBZ/CBZModule.swift
@@ -23,8 +23,8 @@ final class CBZModule: ReaderFormatModule {
         self.delegate = delegate
     }
     
-    var publicationFormats: [Publication.Format] {
-        return [.cbz]
+    func supports(_ publication: Publication) -> Bool {
+        return publication.conforms(to: .divina)
     }
     
     func makeReaderViewController(for publication: Publication, locator: Locator?, bookId: Book.Id, books: BookRepository, bookmarks: BookmarkRepository, resourcesServer: ResourcesServer) throws -> UIViewController {

--- a/TestApp/Sources/Reader/EPUB/EPUBModule.swift
+++ b/TestApp/Sources/Reader/EPUB/EPUBModule.swift
@@ -23,8 +23,9 @@ final class EPUBModule: ReaderFormatModule {
         self.delegate = delegate
     }
 
-    var publicationFormats: [Publication.Format] {
-        return [.epub, .webpub]
+    func supports(_ publication: Publication) -> Bool {
+        return publication.conforms(to: .epub)
+            || publication.readingOrder.allAreHTML
     }
     
     func makeReaderViewController(for publication: Publication, locator: Locator?, bookId: Book.Id, books: BookRepository, bookmarks: BookmarkRepository, resourcesServer: ResourcesServer) throws -> UIViewController {

--- a/TestApp/Sources/Reader/PDF/PDFModule.swift
+++ b/TestApp/Sources/Reader/PDF/PDFModule.swift
@@ -26,8 +26,8 @@ final class PDFModule: ReaderFormatModule {
         self.delegate = delegate
     }
     
-    var publicationFormats: [Publication.Format] {
-        return [.pdf]
+    func supports(_ publication: Publication) -> Bool {
+        return publication.conforms(to: .pdf)
     }
     
     func makeReaderViewController(for publication: Publication, locator: Locator?, bookId: Book.Id, books: BookRepository, bookmarks: BookmarkRepository, resourcesServer: ResourcesServer) throws -> UIViewController {

--- a/TestApp/Sources/Reader/ReaderFormatModule.swift
+++ b/TestApp/Sources/Reader/ReaderFormatModule.swift
@@ -20,8 +20,8 @@ protocol ReaderFormatModule {
     
     var delegate: ReaderFormatModuleDelegate? { get }
     
-    /// Publication types handled by this sub-module.
-    var publicationFormats: [Publication.Format] { get }
+    /// Returns whether the given publication is supported by this module.
+    func supports(_ publication: Publication) -> Bool
     
     /// Creates the view controller to present the publication.
     func makeReaderViewController(for publication: Publication, locator: Locator?, bookId: Book.Id, books: BookRepository, bookmarks: BookmarkRepository, resourcesServer: ResourcesServer) throws -> UIViewController

--- a/TestApp/Sources/Reader/ReaderModule.swift
+++ b/TestApp/Sources/Reader/ReaderModule.swift
@@ -72,7 +72,7 @@ final class ReaderModule: ReaderModuleAPI {
             navigationController.pushViewController(viewController, animated: true)
         }
         
-        guard let module = self.formatModules.first(where:{ $0.publicationFormats.contains(publication.format) }) else {
+        guard let module = self.formatModules.first(where:{ $0.supports(publication) }) else {
             delegate.presentError(ReaderError.formatNotSupported, from: navigationController)
             completion()
             return

--- a/Tests/SharedTests/Publication/LinkTests.swift
+++ b/Tests/SharedTests/Publication/LinkTests.swift
@@ -214,6 +214,20 @@ class LinkTests: XCTestCase {
             ]
         )
     }
+    
+    func testUnknownMediaType() {
+        XCTAssertEqual(Link(href: "file").mediaType, .binary)
+    }
+    
+    func testMediaTypeFromType() {
+        XCTAssertEqual(Link(href: "file", type: "application/epub+zip").mediaType, .epub)
+        XCTAssertEqual(Link(href: "file", type: "application/pdf").mediaType, .pdf)
+    }
+    
+    func testMediaTypeFromExtension() {
+        XCTAssertEqual(Link(href: "file.epub").mediaType, .epub)
+        XCTAssertEqual(Link(href: "file.pdf").mediaType, .pdf)
+    }
 
     func testURLRelativeToBaseURL() {
         XCTAssertEqual(

--- a/Tests/SharedTests/Publication/MetadataTests.swift
+++ b/Tests/SharedTests/Publication/MetadataTests.swift
@@ -17,6 +17,7 @@ class MetadataTests: XCTestCase {
     let fullMetadata = Metadata(
         identifier: "1234",
         type: "epub",
+        conformsTo: [.epub, .pdf],
         title: ["en": "Title", "fr": "Titre"],
         subtitle: ["en": "Subtitle", "fr": "Sous-titre"],
         modified: Date(timeIntervalSinceReferenceDate: 45387),
@@ -75,6 +76,10 @@ class MetadataTests: XCTestCase {
             try Metadata(json: [
                 "identifier": "1234",
                 "@type": "epub",
+                "conformsTo": [
+                    "https://readium.org/webpub-manifest/profiles/epub",
+                    "https://readium.org/webpub-manifest/profiles/pdf",
+                ],
                 "title": ["en": "Title", "fr": "Titre"],
                 "subtitle": ["en": "Subtitle", "fr": "Sous-titre"],
                 "modified": "2001-01-01T12:36:27+0000",
@@ -113,6 +118,19 @@ class MetadataTests: XCTestCase {
     
     func testParseInvalidJSON() {
         XCTAssertThrowsError(try Metadata(json: []))
+    }
+    
+    func testParseJSONWithSingleProfile() {
+        XCTAssertEqual(
+            try Metadata(json: [
+                "title": "Title",
+                "conformsTo": "https://readium.org/webpub-manifest/profiles/divina"
+            ]),
+            Metadata(
+                conformsTo: [.divina],
+                title: "Title"
+            )
+        )
     }
     
     func testParseJSONWithSingleLanguage() {
@@ -162,6 +180,10 @@ class MetadataTests: XCTestCase {
             [
                 "identifier": "1234",
                 "@type": "epub",
+                "conformsTo": [
+                    "https://readium.org/webpub-manifest/profiles/epub",
+                    "https://readium.org/webpub-manifest/profiles/pdf",
+                ],
                 "title": ["en": "Title", "fr": "Titre"],
                 "subtitle": ["en": "Subtitle", "fr": "Sous-titre"],
                 "modified": "2001-01-01T12:36:27+0000",
@@ -245,6 +267,7 @@ class MetadataTests: XCTestCase {
         let copy = metadata.copy(
             identifier: "copy-identifier",
             type: "copy-type",
+            conformsTo: [.audiobook],
             title: "copy-title",
             subtitle: "copy-subtitle",
             modified: Date(timeIntervalSince1970: 42),
@@ -282,6 +305,9 @@ class MetadataTests: XCTestCase {
             [
                 "identifier": "copy-identifier",
                 "@type": "copy-type",
+                "conformsTo": [
+                    "https://readium.org/webpub-manifest/profiles/audiobook"
+                ],
                 "title": "copy-title",
                 "subtitle": "copy-subtitle",
                 "modified": "1970-01-01T00:00:42+0000",

--- a/Tests/SharedTests/Publication/PublicationTests.swift
+++ b/Tests/SharedTests/Publication/PublicationTests.swift
@@ -35,7 +35,7 @@ class PublicationTests: XCTestCase {
         )
     }
     
-    func testConformsToProfile() {
+    func testConformsToExplicitProfile() {
         func makePub(_ conformsTo: [Publication.Profile]) -> Publication {
             Publication(manifest: Manifest(metadata: Metadata(conformsTo: conformsTo, title: "")))
         }
@@ -46,6 +46,27 @@ class PublicationTests: XCTestCase {
         XCTAssertTrue(makePub([.epub]).conforms(to: .epub))
         XCTAssertTrue(makePub([.pdf, .epub]).conforms(to: .epub))
         XCTAssertFalse(makePub([.epub]).conforms(to: .pdf))
+    }
+    
+    func testConformsToImplicitProfile() {
+        func makePub(_ readingOrder: [String]) -> Publication {
+            Publication(manifest: Manifest(
+                metadata: Metadata(title: ""),
+                readingOrder: readingOrder.map { Link(href: $0) }
+            ))
+        }
+        
+        XCTAssertTrue(makePub(["c1.mp3", "c2.aac"]).conforms(to: .audiobook))
+        XCTAssertTrue(makePub(["c1.jpg", "c2.png"]).conforms(to: .divina))
+        XCTAssertTrue(makePub(["c1.pdf", "c2.pdf"]).conforms(to: .pdf))
+        
+        // Mixed media types disable implicit conformance.
+        XCTAssertFalse(makePub(["c1.mp3", "c2.jpg"]).conforms(to: .audiobook))
+        XCTAssertFalse(makePub(["c1.mp3", "c2.jpg"]).conforms(to: .divina))
+        
+        // XHTML could be EPUB or a Web Publication, so we can't implicitly conform.
+        XCTAssertFalse(makePub(["c1.xhtml", "c2.xhtml"]).conforms(to: .epub))
+        XCTAssertFalse(makePub(["c1.html", "c2.html"]).conforms(to: .epub))
     }
     
     func testBaseURL() {

--- a/Tests/SharedTests/Publication/PublicationTests.swift
+++ b/Tests/SharedTests/Publication/PublicationTests.swift
@@ -35,6 +35,19 @@ class PublicationTests: XCTestCase {
         )
     }
     
+    func testConformsToProfile() {
+        func makePub(_ conformsTo: [Publication.Profile]) -> Publication {
+            Publication(manifest: Manifest(metadata: Metadata(conformsTo: conformsTo, title: "")))
+        }
+        
+        XCTAssertTrue(makePub([.audiobook]).conforms(to: .audiobook))
+        XCTAssertTrue(makePub([.divina]).conforms(to: .divina))
+        XCTAssertTrue(makePub([.pdf]).conforms(to: .pdf))
+        XCTAssertTrue(makePub([.epub]).conforms(to: .epub))
+        XCTAssertTrue(makePub([.pdf, .epub]).conforms(to: .epub))
+        XCTAssertFalse(makePub([.epub]).conforms(to: .pdf))
+    }
+    
     func testBaseURL() {
         XCTAssertEqual(
             makePublication(links: [
@@ -256,7 +269,7 @@ class PublicationTests: XCTestCase {
         
         XCTAssertEqual(requestedLink, Link(href: "test?query=param", type: "text/html", templated: false))
     }
-
+    
     private func makePublication(
         metadata: Metadata = Metadata(title: ""),
         links: [Link] = [],

--- a/Tests/StreamerTests/Parser/Audio/AudioParserTests.swift
+++ b/Tests/StreamerTests/Parser/Audio/AudioParserTests.swift
@@ -48,6 +48,12 @@ class AudioParserTests: XCTestCase {
         XCTAssertNotNil(try parser.parse(asset: mp3Asset, fetcher: mp3Fetcher, warnings: nil))
     }
     
+    func testConformsToAudiobook() throws {
+        let publication = try XCTUnwrap(parser.parse(asset: zabAsset, fetcher: zabFetcher, warnings: nil)?.build())
+        
+        XCTAssertEqual(publication.metadata.conformsTo, [.audiobook])
+    }
+    
     /// The reading order is sorted alphabetically, ignores Thumbs.db, hidden files and non-audio
     /// files.
     func testReadingOrderIsSortedAlphabetically() throws {

--- a/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
@@ -24,6 +24,7 @@ class EPUBMetadataParserTests: XCTestCase {
 
         XCTAssertEqual(sut, Metadata(
             identifier: "urn:uuid:7408D53A-5383-40AA-8078-5256C872AE41",
+            conformsTo: [.epub],
             title: "Alice's Adventures in Wonderland",
             subtitle: "Alice returns to the magical world from her childhood adventure",
             modified: "2012-04-02T12:47:00Z".dateFromISO8601,
@@ -71,6 +72,7 @@ class EPUBMetadataParserTests: XCTestCase {
         let sut = try parseMetadata("minimal")
         
         XCTAssertEqual(sut, Metadata(
+            conformsTo: [.epub],
             title: "Alice's Adventures in Wonderland",
             otherMetadata: [
                 "presentation": [
@@ -88,6 +90,7 @@ class EPUBMetadataParserTests: XCTestCase {
         let sut = try parseMetadata("with-namespaces-prefix")
         
         XCTAssertEqual(sut, Metadata(
+            conformsTo: [.epub],
             title: "Alice's Adventures in Wonderland",
             otherMetadata: [
                 "presentation": [
@@ -165,6 +168,7 @@ class EPUBMetadataParserTests: XCTestCase {
         let sut = try parseMetadata("contributors")
         
         XCTAssertEqual(sut, Metadata(
+            conformsTo: [.epub],
             title: "Alice's Adventures in Wonderland",
             authors: [
                 Contributor(name: "Author 1"),

--- a/Tests/StreamerTests/Parser/EPUB/OPFParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/OPFParserTests.swift
@@ -23,6 +23,7 @@ class OPFParserTests: XCTestCase {
         
         XCTAssertEqual(sut.manifest, Manifest(
             metadata: Metadata(
+                conformsTo: [.epub],
                 title: "Alice's Adventures in Wonderland",
                 otherMetadata: [
                     "presentation": [

--- a/Tests/StreamerTests/Parser/Image/ImageParserTests.swift
+++ b/Tests/StreamerTests/Parser/Image/ImageParserTests.swift
@@ -47,6 +47,12 @@ class ImageParserTests: XCTestCase {
     func testAcceptsJPG() {
         XCTAssertNotNil(try parser.parse(asset: jpgAsset, fetcher: jpgFetcher, warnings: nil))
     }
+    
+    func testConformsToDivina() throws {
+        let publication = try XCTUnwrap(parser.parse(asset: cbzAsset, fetcher: cbzFetcher, warnings: nil)?.build())
+        
+        XCTAssertEqual(publication.metadata.conformsTo, [.divina])
+    }
 
     /// The reading order is sorted alphabetically, ignores Thumbs.db, hidden files and non-bitmap
     /// files.


### PR DESCRIPTION
### Added

#### Shared

* A new `Publication.conforms(to:)` API to identify the profile of a publication.
* Support for the [`conformsTo` RWPM metadata](https://github.com/readium/webpub-manifest/issues/65), to identify the profile of a `Publication`.

### Deprecated

#### Shared

* `Publication.format` is now deprecated in favor of the new `Publication.conforms(to:)` API which is more accurate.
    * For example, replace `publication.format == .epub` with `publication.conforms(to: .epub)` before opening a publication with the `EPUBNavigatorViewController`.