### PR TITLE
add SelectableNavigator to PDFViewController, connect SelectableNavig…

### DIFF
--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -829,11 +829,11 @@ extension EPUBNavigatorViewController: EditingActionsControllerDelegate {
     }
 
     func editingActions(_ editingActions: EditingActionsController, shouldShowMenuForSelection selection: Selection) -> Bool {
-        true
+        return delegate?.navigator(self, shouldShowMenuForSelection: selection) ?? true
     }
 
     func editingActions(_ editingActions: EditingActionsController, canPerformAction action: EditingAction, for selection: Selection) -> Bool {
-        true
+        return delegate?.navigator(self, canPerformAction: action, for: selection) ?? true
     }
 }
 

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -15,12 +15,12 @@ import UIKit
 import R2Shared
 
 
-public protocol PDFNavigatorDelegate: VisualNavigatorDelegate { }
+public protocol PDFNavigatorDelegate: VisualNavigatorDelegate, SelectableNavigatorDelegate { }
 
 
 /// A view controller used to render a PDF `Publication`.
 @available(iOS 11.0, *)
-open class PDFNavigatorViewController: UIViewController, VisualNavigator, Loggable {
+open class PDFNavigatorViewController: UIViewController, VisualNavigator, SelectableNavigator, Loggable {
     
     enum Error: Swift.Error {
         case openPDFFailed
@@ -230,7 +230,15 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Loggab
         return positions[pageNumber - 1]
     }
     
-    
+    // MARK: – SelectableNavigator
+
+    public var currentSelection: Selection? { editingActions.selection }
+
+    public func clearSelection() {
+        pdfView.clearSelection()
+    }
+
+
     // MARK: - User Selection
 
     @objc func selectionDidChange(_ note: Notification) {
@@ -348,11 +356,11 @@ extension PDFNavigatorViewController: EditingActionsControllerDelegate {
     }
 
     func editingActions(_ editingActions: EditingActionsController, shouldShowMenuForSelection selection: Selection) -> Bool {
-        true
+        return delegate?.navigator(self, shouldShowMenuForSelection: selection) ?? true
     }
 
     func editingActions(_ editingActions: EditingActionsController, canPerformAction action: EditingAction, for selection: Selection) -> Bool {
-        true
+        return delegate?.navigator(self, canPerformAction: action, for: selection) ?? true
     }
 }
 


### PR DESCRIPTION
Editing actions are now connected to the delegate and can be used like:

extension ReaderViewController: NavigatorDelegate {
    func navigator(_ navigator: SelectableNavigator, shouldShowMenuForSelection selection: Selection) -> Bool {
        ...
    }
}