### PR TITLE
PDF support for reading progression hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Shared
 
 * Get the sanitized `Locator` text ready for user display with `locator.text.sanitized()`.
+* Support for right-to-left PDF documents by extracting the reading progression from the `ViewerPreferences/Direction` metadata.
 
 ### Fixed
 

--- a/Sources/Shared/Toolkit/PDF/PDFDocument.swift
+++ b/Sources/Shared/Toolkit/PDF/PDFDocument.swift
@@ -29,6 +29,9 @@ public protocol PDFDocument {
     /// The first page rendered as a cover.
     var cover: UIImage? { get }
     
+    /// Reading progression set with the "Binding" property in Acrobat.
+    var readingProgression: ReadingProgression? { get }
+    
     
     // Values extracted from the document information dictionary, defined in PDF specification.
     

--- a/Sources/Shared/Toolkit/PDF/PDFKit.swift
+++ b/Sources/Shared/Toolkit/PDF/PDFKit.swift
@@ -20,6 +20,8 @@ extension PDFKit.PDFDocument: PDFDocument {
 
     public var cover: UIImage? { documentRef?.cover }
     
+    public var readingProgression: ReadingProgression? { documentRef?.readingProgression }
+    
     public var title: String? { documentRef?.title }
     
     public var author: String? { documentRef?.author }

--- a/Sources/Streamer/Parser/PDF/PDFParser.swift
+++ b/Sources/Streamer/Parser/PDF/PDFParser.swift
@@ -60,6 +60,7 @@ public final class PDFParser: PublicationParser, Loggable {
                     identifier: document.identifier,
                     title: document.title ?? asset.name,
                     authors: authors,
+                    readingProgression: document.readingProgression ?? .auto,
                     numberOfPages: document.pageCount
                 ),
                 readingOrder: readingOrder,


### PR DESCRIPTION
### Added

#### Shared

* Support for right-to-left PDF documents by extracting the reading progression from the `ViewerPreferences/Direction` metadata.