### PR TITLE
Associate the `HTTPResponse` with the source `HTTPRequest`

### DIFF
--- a/Sources/Shared/Toolkit/HTTP/DefaultHTTPClient.swift
+++ b/Sources/Shared/Toolkit/HTTP/DefaultHTTPClient.swift
@@ -328,7 +328,7 @@ public final class DefaultHTTPClient: NSObject, HTTPClient, Loggable, URLSession
                 return
             }
 
-            var response = HTTPResponse(response: urlResponse, url: url)
+            var response = HTTPResponse(request: request, response: urlResponse, url: url)
 
             if let kind = HTTPError.Kind(statusCode: response.statusCode) {
                 state = .failure(kind: kind, cause: nil, response: response)

--- a/Sources/Shared/Toolkit/HTTP/HTTPClient.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPClient.swift
@@ -122,6 +122,9 @@ public extension HTTPClient {
 /// Represents a successful HTTP response received from a server.
 public struct HTTPResponse: Equatable {
 
+    /// Request associated with the response.
+    public let request: HTTPRequest
+
     /// URL for the response, after any redirect.
     public let url: URL
 
@@ -138,7 +141,8 @@ public struct HTTPResponse: Equatable {
     /// Response body content, when available.
     public var body: Data?
 
-    public init(url: URL, statusCode: Int, headers: [String: String], mediaType: MediaType, body: Data?) {
+    public init(request: HTTPRequest, url: URL, statusCode: Int, headers: [String: String], mediaType: MediaType, body: Data?) {
+        self.request = request
         self.url = url
         self.statusCode = statusCode
         self.headers = headers
@@ -146,7 +150,7 @@ public struct HTTPResponse: Equatable {
         self.body = body
     }
 
-    public init(response: HTTPURLResponse, url: URL, body: Data? = nil) {
+    public init(request: HTTPRequest, response: HTTPURLResponse, url: URL, body: Data? = nil) {
         var headers: [String: String] = [:]
         for (k, v) in response.allHeaderFields {
             if let ks = k as? String, let vs = v as? String {
@@ -155,6 +159,7 @@ public struct HTTPResponse: Equatable {
         }
 
         self.init(
+            request: request,
             url: url,
             statusCode: response.statusCode,
             headers: headers,


### PR DESCRIPTION
This is useful to get access to the original request HTTP headers or the `userInfo` dictionary.

I used this in the context of [Authentication for OPDS](https://drafts.opds.io/authentication-for-opds-1.0.html), to retrieve the Authentication Document identifier from the request's `userInfo`.