### PR TITLE
Fixed bug where changing scrolling mode in epub loses position

### DIFF
--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -378,12 +378,12 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
 
         let location = self.currentLocation
         for (_, view) in self.paginationView.loadedViews {
-            (view as? EPUBSpreadView)?.applyUserSettingsStyle()
-        }
-
-        // Re-positions the navigator to the location before applying the settings
-        if let location = location {
-            self.go(to: location)
+            (view as? EPUBSpreadView)?.applyUserSettingsStyle {
+                // Re-positions the navigator to the location before applying the settings
+                if let location = location {
+                    self.go(to: location)
+                }
+            }
         }
     }
 

--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -74,7 +74,7 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
         webView.load(URLRequest(url: url))
     }
 
-    override func applyUserSettingsStyle() {
+    override func applyUserSettingsStyle(completion: @escaping () -> Void = {}) {
         super.applyUserSettingsStyle()
         
         let properties = userSettings.userProperties.properties
@@ -91,8 +91,12 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
             return script + "readium.setProperty(\"\(property.name)\", \"\(value)\");\n"
         }
         evaluateScript(propertiesScript) { res in
-            if case .failure(let error) = res {
+            switch res {
+            case .success:
+                completion()
+            case .failure(let error):
                 self.log(.error, error)
+           
             }
         }
 

--- a/Sources/Navigator/EPUB/EPUBSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBSpreadView.swift
@@ -281,7 +281,7 @@ class EPUBSpreadView: UIView, Loggable, PageView {
 
     /// Update webview style to userSettings.
     /// To override in subclasses.
-    func applyUserSettingsStyle() {
+    func applyUserSettingsStyle(completion: @escaping () -> Void = {}) {
         assert(Thread.isMainThread, "User settings must be updated from the main thread")
     }
     


### PR DESCRIPTION
When changing the scroll mode in the user settings, the scroll position is not retained due to the time it takes for the applying of the CSS properties to complete, which means the position is scrolled to before the layout is changed, thus scrolling back to the start. I've added a closure as to make sure the JavaScrpit ran sucessfully before attempting to scroll to the position.