### PR TITLE
Added namespace to fix mac Catalyst build

### DIFF
--- a/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
@@ -482,7 +482,7 @@ final class EPUBMetadataParser: Loggable {
     /// Returns the given `dc:` tag in the `metadata` element.
     ///
     /// This looks under `metadata/dc-metadata` as well, to be compatible with old EPUB 2 files.
-    private func dcElement(tag: String) -> XMLElement? {
+    private func dcElement(tag: String) -> Fuzi.XMLElement? {
         return metadataElement?
             .firstChild(xpath:"(.|opf:dc-metadata)/dc:\(tag)")
     }


### PR DESCRIPTION
Added namespace Fuzi to  XMLElement, as this is giving error when we build for Mac Catalyst.