### PR TITLE
Upgrade to `R2LCPClient` version 3.0.0

### DIFF
--- a/TestApp/.gitignore
+++ b/TestApp/.gitignore
@@ -9,3 +9,5 @@ Cartfile.resolved
 Pods/
 Podfile
 Podfile.lock
+
+R2LCPClient/

--- a/TestApp/Integrations/Carthage/project+lcp.yml
+++ b/TestApp/Integrations/Carthage/project+lcp.yml
@@ -19,12 +19,12 @@ targets:
     sources: 
       - path: Sources
     dependencies:
-      - carthage: R2LCPClient
       - framework: Carthage/Build/CryptoSwift.xcframework
       - framework: Carthage/Build/DifferenceKit.xcframework
       - framework: Carthage/Build/Fuzi.xcframework
       - framework: Carthage/Build/GCDWebServer.xcframework
       - framework: Carthage/Build/Minizip.xcframework
+      - framework: Carthage/Build/R2LCPClient.xcframework
       - framework: Carthage/Build/R2Navigator.xcframework
       - framework: Carthage/Build/R2Shared.xcframework
       - framework: Carthage/Build/R2Streamer.xcframework

--- a/TestApp/Integrations/Local/project+lcp.yml
+++ b/TestApp/Integrations/Local/project+lcp.yml
@@ -4,6 +4,8 @@ options:
 packages:
   Readium:
     path: ..
+  R2LCPClient:
+    path: R2LCPClient
   GRDB:
     url: https://github.com/groue/GRDB.swift.git
     from: 5.8.0
@@ -24,7 +26,8 @@ targets:
     sources: 
       - path: Sources
     dependencies:
-      - carthage: R2LCPClient
+      - package: R2LCPClient
+        product: R2LCPClient
       - package: Readium
         product: R2Shared
       - package: Readium

--- a/TestApp/Integrations/SPM/project+lcp.yml
+++ b/TestApp/Integrations/SPM/project+lcp.yml
@@ -5,6 +5,8 @@ packages:
   Readium:
     url: https://github.com/readium/swift-toolkit.git
     VERSION
+  R2LCPClient:
+    path: R2LCPClient
   GRDB:
     url: https://github.com/groue/GRDB.swift.git
     from: 5.8.0
@@ -25,7 +27,8 @@ targets:
     sources: 
       - path: Sources
     dependencies:
-      - carthage: R2LCPClient
+      - package: R2LCPClient
+        product: R2LCPClient
       - package: Readium
         product: R2Shared
       - package: Readium
@@ -42,4 +45,3 @@ targets:
       - package: SwiftSoup
     settings:
       OTHER_SWIFT_FLAGS: -DLCP
-

--- a/TestApp/Makefile
+++ b/TestApp/Makefile
@@ -22,12 +22,12 @@ clean:
 	@rm -rf Pods
 	@rm -rf TestApp.xcodeproj
 	@rm -rf TestApp.xcworkspace
+	@rm -rf R2LCPClient
 
 spm: clean
 ifdef lcp
-	@echo "binary \"$(lcp)\"" > Cartfile
-	carthage update --platform ios --cache-builds
 	@cp Integrations/SPM/project+lcp.yml project.yml
+	curl --create-dirs --output R2LCPClient/Package.swift "$(lcp)"
 else
 	@cp Integrations/SPM/project.yml .
 endif
@@ -72,8 +72,7 @@ endif
 dev: clean
 ifdef lcp
 	@cp Integrations/Local/project+lcp.yml project.yml
-	@echo "binary \"$(lcp)\"" > Cartfile
-	carthage update --platform ios --cache-builds
+	curl --create-dirs --output R2LCPClient/Package.swift "$(lcp)"
 else
 	@cp Integrations/Local/project.yml .
 endif

--- a/TestApp/README.md
+++ b/TestApp/README.md
@@ -52,8 +52,8 @@ Building with Readium LCP requires additional dependencies, including the librar
 
 1. [Contact EDRLab](mailto:contact@edrlab.org) to request your private `R2LCPClient.framework`.
 2. If you integrate Readium with Swift Package Manager or Git submodules, install [Carthage](https://github.com/Carthage/Carthage). `R2LCPClient.framework` is only available for Carthage or CocoaPods.
-3. Generate the Xcode project with `make`, providing the URL given by EDRLab as the `url` parameter (`.json` for Carthage or SPM and `.podspec` for CocoaPods).
+3. Generate the Xcode project with `make`, providing the URL given by EDRLab as the `url` parameter (`Package.swift` for SPM, `liblcp.json` for Carthage and `latest.podspec` for CocoaPods).
     ```sh
-    make spm lcp=https://...json
+    make spm lcp=https://.../Package.swift
     ```
 


### PR DESCRIPTION
The new 3.0.0 version of `R2LCPClient` now provides an XCFramework as well as a `Package.swift` example that can be used to skip the Carthage requirement.