### PR TITLE
Audiobook: Don't use `metadata.duration` for computing the progression

### DIFF
--- a/Sources/Navigator/Audiobook/AudioNavigator.swift
+++ b/Sources/Navigator/Audiobook/AudioNavigator.swift
@@ -30,8 +30,9 @@ open class _AudioNavigator: _MediaNavigator, _AudioSessionUser, Loggable {
             ?? publication.readingOrder.first.flatMap { publication.locate($0) }
         
         let durations = publication.readingOrder.map { $0.duration ?? 0 }
+        let totalDuration = durations.reduce(0, +)
+        
         self.durations = durations
-        let totalDuration = publication.metadata.duration ?? durations.reduce(0, +)
         self.totalDuration = (totalDuration > 0) ? totalDuration : nil
     }
     


### PR DESCRIPTION
The metadata `publication.metadata.duration` was used in the audiobook navigator to compute the current percentage progression. However, this value can (and is in production) incorrect. Instead, we need to sum up all the `link.duration` to calculate the total duration.

The [RWPM audiobook profile](https://github.com/readium/webpub-manifest/blob/master/profiles/audiobook.md) also specifies:

> The `duration` of an audiobook as expressed in `metadata` is purely a hint and **must not** be used by the User Agent for anything else than informing the user.
