### PR TITLE
LCP: Do not require the presence of a `hint` link in a license

### DIFF
--- a/Sources/LCP/License/Model/LicenseDocument.swift
+++ b/Sources/LCP/License/Model/LicenseDocument.swift
@@ -83,8 +83,8 @@ public struct LicenseDocument {
         self.json = jsonString
         self.data = data
 
-        /// Check that links contain rel for Hint and Publication.
-        guard link(for: .hint) != nil, link(for: .publication) != nil else {
+        /// Checks that `links` contains at least one link with `publication` relation.
+        guard link(for: .publication) != nil else {
             throw ParsingError.licenseDocument
         }
     }


### PR DESCRIPTION
The LCP specification requires the presence of a link with `hint` relation in a license document. This used to be enforced in the Swift toolkit which blocked opening the license when it was missing.

Instead, we want to allow opening invalid licenses (as long as the signature matches of course) and leave the validation to the server certification.