### PR TITLE
Fix serving EPUB hrefs with anchor or query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * Fixed memory leaks in the EPUB and PDF navigators.
+* [#61](https://github.com/readium/swift-toolkit/issues/61) Fixed serving EPUB resources when the HREF contains an anchor or query parameters.
 
 #### Streamer
 

--- a/Sources/Shared/Fetcher/ArchiveFetcher.swift
+++ b/Sources/Shared/Fetcher/ArchiveFetcher.swift
@@ -1,12 +1,7 @@
 //
-//  ArchiveFetcher.swift
-//  r2-shared-swift
-//
-//  Created by Mickaël Menu on 11/05/2020.
-//
-//  Copyright 2020 Readium Foundation. All rights reserved.
-//  Use of this source code is governed by a BSD-style license which is detailed
-//  in the LICENSE file present in the project repository where this source code is maintained.
+//  Copyright 2022 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
 //
 
 import Foundation
@@ -31,13 +26,26 @@ public final class ArchiveFetcher: Fetcher, Loggable {
 
     public func get(_ link: Link) -> Resource {
         guard
-            let entry = archive.entry(at: link.href),
-            let reader = archive.readEntry(at: link.href)
+            let entry = findEntry(at: link.href),
+            let reader = archive.readEntry(at: entry.path)
         else {
             return FailureResource(link: link, error: .notFound(nil))
         }
 
         return ArchiveResource(link: link, entry: entry, reader: reader)
+    }
+    
+    private func findEntry(at href: String) -> ArchiveEntry? {
+        if let entry = archive.entry(at: href) {
+            return entry
+        }
+        
+        // Try after removing query parameters and anchors from the href.
+        guard let href = href.components(separatedBy: .init(charactersIn: "#?")).first else {
+            return nil
+        }
+        
+        return archive.entry(at: href)
     }
     
     public func close() {}

--- a/Tests/SharedTests/Fetcher/ArchiveFetcherTests.swift
+++ b/Tests/SharedTests/Fetcher/ArchiveFetcherTests.swift
@@ -1,12 +1,7 @@
 //
-//  ArchiveFetcherTests.swift
-//  r2-shared-swift
-//
-//  Created by Mickaël Menu on 11/05/2020.
-//
-//  Copyright 2020 Readium Foundation. All rights reserved.
-//  Use of this source code is governed by a BSD-style license which is detailed
-//  in the LICENSE file present in the project repository where this source code is maintained.
+//  Copyright 2022 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
 //
 
 import XCTest
@@ -104,4 +99,19 @@ class ArchiveFetcherTests: XCTestCase {
         )
     }
     
+    /// When the HREF contains query parameters, the fetcher should first be able to remove them as
+    /// a fallback.
+    func testHREFWithQueryParameters() {
+        let resource = fetcher.get(Link(href: "/mimetype?query=param"))
+        let result = resource.readAsString(encoding: .ascii)
+        XCTAssertEqual(result.getOrNil(), "application/epub+zip")
+    }
+    
+    /// When the HREF contains an anchor, the fetcher should first be able to remove them as
+    /// a fallback.
+    func testHREFWithAnchor() {
+        let resource = fetcher.get(Link(href: "/mimetype#anchor"))
+        let result = resource.readAsString(encoding: .ascii)
+        XCTAssertEqual(result.getOrNil(), "application/epub+zip")
+    }
 }


### PR DESCRIPTION
### Fixed

#### Navigator

* [#61](https://github.com/readium/swift-toolkit/issues/61) Fixed serving EPUB resources when the HREF contains an anchor or query parameters.

---

* Fixes #61 

Some EPUBs are requesting resources with an additional query parameter (e.g. `?V=0.3.1` in the example from the linked issue). This failed when serving the resource from a ZIP archive or exploded directory.

I fixed this in the `ArchiveFetcher` as the `HTTPFetcher` or other fetchers might handle the query parameters differently.

Twin PR: https://github.com/readium/kotlin-toolkit/pull/132