### PR TITLE
fix: resource requests with query parameters

### DIFF
--- a/Sources/Streamer/Server/PublicationServer.swift
+++ b/Sources/Streamer/Server/PublicationServer.swift
@@ -227,6 +227,14 @@ public class PublicationServer: ResourcesServer {
 
             let resource = publication.get(href.removingPercentEncoding ?? href)
             let range = request.hasByteRange() ? request.byteRange : nil
+            switch resource.length {
+            case .failure:
+                if let count = request.url.query?.count, count > 0, let link = publication.link(withHREF: href) {
+                    resource = publication.get(link)
+                }
+            default:
+                break
+            }
             return WebServerResourceResponse(
                 resource: resource,
                 range: range,


### PR DESCRIPTION
## Fixed Bug
#61 

Some epubs access their resource by adding query parameter like (/xyzfilename.js?V=2.7.3). This was failing because the resources served were just file. So I added a fallback that if resources request fails to ResourceFailure then try getting the same resource again without query parameters and if this also doesn't work then go with the normal flow.

Also thanks to @vishalgupta7.
Thanks
