### PR TITLE
Fix performance with EPUB FXL spreads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this project will be documented in this file. Take a look
 
 * Fixed memory leaks in the EPUB and PDF navigators.
 * [#61](https://github.com/readium/swift-toolkit/issues/61) Fixed serving EPUB resources when the HREF contains an anchor or query parameters.
+* Performance issue with EPUB fixed-layout when spreads are enabled.
+* Disable scrolling in EPUB fixed-layout resources, in case the viewport is incorrectly set.
 
 #### Streamer
 

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed-wrapper-one.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed-wrapper-one.js
@@ -12,6 +12,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "FixedPage": () => (/* binding */ FixedPage)
 /* harmony export */ });
+//
+//  Copyright 2022 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
 // Manages a fixed layout resource embedded in an iframe.
 function FixedPage(iframeId) {
   // Fixed dimensions for the page, extracted from the viewport meta tag.
@@ -95,10 +100,12 @@ function FixedPage(iframeId) {
       page.isLoading = true;
 
       function loaded() {
-        _iframe.removeEventListener("load", loaded); // Waiting for the next animation frame seems to do the trick to make sure the page is fully rendered.
+        _iframe.removeEventListener("load", loaded); // Timeout to wait for the page to be laid out.
+        // Note that using `requestAnimationFrame()` instead causes performance
+        // issues in some FXL EPUBs with spreads.
 
 
-        _iframe.contentWindow.requestAnimationFrame(function () {
+        setTimeout(function () {
           page.isLoading = false;
 
           _iframe.contentWindow.eval("readium.link = ".concat(JSON.stringify(resource.link), ";"));
@@ -106,7 +113,7 @@ function FixedPage(iframeId) {
           if (completion) {
             completion();
           }
-        });
+        }, 100);
       }
 
       _iframe.addEventListener("load", loaded);

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed-wrapper-two.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed-wrapper-two.js
@@ -12,6 +12,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "FixedPage": () => (/* binding */ FixedPage)
 /* harmony export */ });
+//
+//  Copyright 2022 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
 // Manages a fixed layout resource embedded in an iframe.
 function FixedPage(iframeId) {
   // Fixed dimensions for the page, extracted from the viewport meta tag.
@@ -95,10 +100,12 @@ function FixedPage(iframeId) {
       page.isLoading = true;
 
       function loaded() {
-        _iframe.removeEventListener("load", loaded); // Waiting for the next animation frame seems to do the trick to make sure the page is fully rendered.
+        _iframe.removeEventListener("load", loaded); // Timeout to wait for the page to be laid out.
+        // Note that using `requestAnimationFrame()` instead causes performance
+        // issues in some FXL EPUBs with spreads.
 
 
-        _iframe.contentWindow.requestAnimationFrame(function () {
+        setTimeout(function () {
           page.isLoading = false;
 
           _iframe.contentWindow.eval("readium.link = ".concat(JSON.stringify(resource.link), ";"));
@@ -106,7 +113,7 @@ function FixedPage(iframeId) {
           if (completion) {
             completion();
           }
-        });
+        }, 100);
       }
 
       _iframe.addEventListener("load", loaded);

--- a/Sources/Navigator/EPUB/Assets/fxl-spread-one.html
+++ b/Sources/Navigator/EPUB/Assets/fxl-spread-one.html
@@ -27,7 +27,8 @@
 </head>
 
 <body>
-  <iframe id="page"></iframe>
+  <!-- Prevents scrolling if the viewport doesn't match the body width in the resource. -->
+  <iframe id="page" scrolling="no"></iframe>
   <script type="text/javascript" src="/r2-navigator/epub/scripts/readium-fixed-wrapper-one.js"></script>
 </body>
 </html>

--- a/Sources/Navigator/EPUB/Assets/fxl-spread-two.html
+++ b/Sources/Navigator/EPUB/Assets/fxl-spread-two.html
@@ -62,13 +62,13 @@
 
 <body>
   <div id="viewport-left" class="viewport">
-    <iframe id="page-left" class="page"></iframe>
+    <iframe id="page-left" class="page" scrolling="no"></iframe>
   </div>
   <div id="viewport-right" class="viewport">
-    <iframe id="page-right" class="page"></iframe>
+    <iframe id="page-right" class="page" scrolling="no"></iframe>
   </div>
   <div id="viewport-center" class="viewport">
-    <iframe id="page-center" class="page"></iframe>
+    <iframe id="page-center" class="page" scrolling="no"></iframe>
   </div>
   
   <script type="text/javascript" src="/r2-navigator/epub/scripts/readium-fixed-wrapper-two.js"></script>

--- a/Sources/Navigator/EPUB/Scripts/src/fixed-page.js
+++ b/Sources/Navigator/EPUB/Scripts/src/fixed-page.js
@@ -1,3 +1,9 @@
+//
+//  Copyright 2022 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
 // Manages a fixed layout resource embedded in an iframe.
 export function FixedPage(iframeId) {
   // Fixed dimensions for the page, extracted from the viewport meta tag.
@@ -82,8 +88,10 @@ export function FixedPage(iframeId) {
       function loaded() {
         _iframe.removeEventListener("load", loaded);
 
-        // Waiting for the next animation frame seems to do the trick to make sure the page is fully rendered.
-        _iframe.contentWindow.requestAnimationFrame(function () {
+        // Timeout to wait for the page to be laid out.
+        // Note that using `requestAnimationFrame()` instead causes performance
+        // issues in some FXL EPUBs with spreads.
+        setTimeout(function () {
           page.isLoading = false;
           _iframe.contentWindow.eval(
             `readium.link = ${JSON.stringify(resource.link)};`
@@ -91,7 +99,7 @@ export function FixedPage(iframeId) {
           if (completion) {
             completion();
           }
-        });
+        }, 100);
       }
 
       _iframe.addEventListener("load", loaded);


### PR DESCRIPTION
### Fixed

#### Navigator

* Performance issue with EPUB fixed-layout when spreads are enabled.
* Disable scrolling in EPUB fixed-layout resources, in case the viewport is incorrectly set.