### PR TITLE
Fix vertically bouncing EPUB resources in iOS 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file. Take a look
 * [#61](https://github.com/readium/swift-toolkit/issues/61) Fixed serving EPUB resources when the HREF contains an anchor or query parameters.
 * Performance issue with EPUB fixed-layout when spreads are enabled.
 * Disable scrolling in EPUB fixed-layout resources, in case the viewport is incorrectly set.
+* Fix vertically bouncing EPUB resources in iOS 16.
 
 #### Streamer
 

--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -35,7 +35,13 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
 
     override func setupWebView() {
         super.setupWebView()
+        
         scrollView.bounces = false
+        // Since iOS 16, the default value of alwaysBounceX seems to be true
+        // for web views.
+        scrollView.alwaysBounceVertical = false
+        scrollView.alwaysBounceHorizontal = false
+
         scrollView.isPagingEnabled = !isScrollEnabled
         
         webView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
### Fixed

#### Navigator

* Fix vertically bouncing EPUB resources in iOS 16.