### PR TITLE
Fix broken SQLite.swift dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -4,5 +4,5 @@ github "krzyzanowskim/CryptoSwift" == 1.5.1 # From 1.6.0, the build fails in Git
 github "ra1028/DifferenceKit" ~> 1.3.0
 github "readium/GCDWebServer" ~> 3.7.3
 github "scinfu/SwiftSoup" ~> 2.4.3
-github "stephencelis/SQLite.swift" ~> 0.13.3
+github "stephencelis/SQLite.swift" == 0.13.3 # 0.14 introduces a breaking change
 github "weichsel/ZIPFoundation" == 0.9.11 # 0.9.12 requires iOS 12+

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,8 @@ let package = Package(
         .package(url: "https://github.com/ra1028/DifferenceKit.git", from: "1.3.0"),
         .package(url: "https://github.com/readium/GCDWebServer.git", from: "3.7.3"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.4.3"),
-        .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.13.3"),
+        // 0.14 introduced a breaking change
+        .package(url: "https://github.com/stephencelis/SQLite.swift.git", "0.12.0"..<"0.13.3"),
         // 0.9.12 requires iOS 12+
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", "0.9.0"..<"0.9.12"),
     ],

--- a/Support/CocoaPods/ReadiumLCP.podspec
+++ b/Support/CocoaPods/ReadiumLCP.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.dependency 'R2Shared' 
 
   s.dependency 'ZIPFoundation', '<= 0.9.11' # 0.9.12 requires iOS 12+
-  s.dependency 'SQLite.swift', '~> 0.13'
+  s.dependency 'SQLite.swift', '<= 0.13.3' # 0.14 introduces breaking changes
   s.dependency 'CryptoSwift', '<= 1.5.1' # From 1.6.0, the build fails in GitHub actions with Carthage
 end


### PR DESCRIPTION
SQLite.swift 0.14 introduced a breaking change for the toolkit.