### PR TITLE
Fix the EPUB parsing of accessibility profiles

### DIFF
--- a/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
@@ -207,8 +207,9 @@ final class EPUBMetadataParser: Loggable {
     }
     
     private func accessibilityProfiles() -> [Accessibility.Profile] {
-        metas["conformsTo", in: .dcterms]
-            .compactMap { accessibilityProfile(from: $0.content) }
+        let hrefs = metas["conformsTo", in: .dcterms].map { $0.content }
+            + metas.links(withRel: "conformsTo", in: .dcterms).map { $0.href }
+        return hrefs.compactMap { accessibilityProfile(from: $0) }
     }
     
     private func accessibilityProfile(from value: String) -> Accessibility.Profile? {


### PR DESCRIPTION
EPUB parsing of accessibility profiles failed when they were documented as OPF links.