### PR TITLE
Add the `define` editing action for iOS 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file. Take a look
 
 ## [Unreleased]
 
+### Changed
+
+#### Navigator
+
+* The `define` editing action replaces `lookup` on iOS 16+. When enabled, it will show both the "Look Up" and "Search Web" menu items.
+
 ### Fixed
 
 #### Navigator

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -266,6 +266,12 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         reloadSpreads(at: initialLocation)
     }
     
+    @available(iOS 13.0, *)
+    open override func buildMenu(with builder: UIMenuBuilder) {
+        editingActions.buildMenu(with: builder)
+        super.buildMenu(with: builder)
+    }
+    
     /// Intercepts tap gesture when the web views are not loaded.
     @objc private func didTapBackground(_ gesture: UITapGestureRecognizer) {
         guard state == .loading else { return }

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -17,14 +17,21 @@ public struct EditingAction: Hashable {
 
     /// Default editing actions enabled in the navigator.
     public static var defaultActions: [EditingAction] {
-        [copy, share, lookup, translate]
+        [copy, share, define, lookup, translate]
     }
 
     /// Copy the text selection.
     public static let copy = EditingAction(kind: .native("copy:"))
 
-    /// Look up the text selection in the dictionary.
+    /// Look up the text selection in the dictionary and other sources.
+    ///
+    /// Not available on iOS 16+
     public static let lookup = EditingAction(kind: .native("_lookup:"))
+
+    /// Look up the text selection in the dictionary (and other sources on iOS 16+).
+    ///
+    /// On iOS 16+, enabling this action will show two items: Look Up and Search Web.
+    public static let define = EditingAction(kind: .native("_define:"))
 
     /// Translate the text selection.
     public static let translate = EditingAction(kind: .native("_translate:"))
@@ -120,6 +127,15 @@ final class EditingActionsController {
 
     func canPerformAction(_ action: EditingAction) -> Bool {
         canPerformAction(action.action)
+    }
+    
+    @available(iOS 13.0, *)
+    func buildMenu(with builder: UIMenuBuilder) {
+        // On iOS 16, there's a new "Search Web" menu item which is required
+        // to enable the define action.
+        if #available(iOS 16.0, *), !actions.contains(.define) {
+            builder.remove(menu: .lookup)
+        }
     }
 
     func updateSharedMenuController() {

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -122,6 +122,12 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
             })
         }
     }
+    
+    @available(iOS 13.0, *)
+    open override func buildMenu(with builder: UIMenuBuilder) {
+        editingActions.buildMenu(with: builder)
+        super.buildMenu(with: builder)
+    }
 
     /// Override to customize the PDFDocumentView.
     open func setupPDFView() {


### PR DESCRIPTION
### Changed

#### Navigator

* The `define` editing action replaces `lookup` on iOS 16+. When enabled, it will show both the "Look Up" and "Search Web" menu items.

---

Unfortunately, we can't have Look Up without Search Web on iOS 16.

<img width="441" alt="Screenshot 2022-11-14 at 13 58 04" src="https://user-images.githubusercontent.com/58686775/201666299-ac9dd74b-0cd9-4957-9526-0efcfb3914ae.png">



<img width="276" alt="Screenshot 2022-11-14 at 13 58 14" src="https://user-images.githubusercontent.com/58686775/201666193-f387c52e-4919-4517-be7a-9276a4a4a273.png">