### PR TITLE
Fix crash with `PublicationSpeechSynthesizer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * Fixed a race condition issue with the `AVTTSEngine`, when pausing utterances.
+* Fixed crash with `PublicationSpeechSynthesizer`, when the currently played word cannot be resolved.
 
 
 ## [2.4.0]

--- a/Sources/Navigator/TTS/PublicationSpeechSynthesizer.swift
+++ b/Sources/Navigator/TTS/PublicationSpeechSynthesizer.swift
@@ -237,7 +237,15 @@ public class PublicationSpeechSynthesizer: Loggable {
                 state = .playing(
                     utterance,
                     range: utterance.locator.copy(
-                        text: { $0 = utterance.locator.text[range] }
+                        text: { text in
+                            guard
+                                let highlight = text.highlight,
+                                highlight.startIndex <= range.lowerBound && highlight.endIndex >= range.upperBound
+                            else {
+                                return
+                            }
+                            text = text[range]
+                        }
                     )
                 )
             },


### PR DESCRIPTION
### Fixed

#### Navigator

* Fixed crash with `PublicationSpeechSynthesizer`, when the currently played word cannot be resolved.