### PR TITLE
Prevent navigation in the EPUB while it is being loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * The `define` editing action replaces `lookup` on iOS 16+. When enabled, it will show both the "Look Up" and "Search Web" menu items.
+* Prevent navigation in the EPUB while it is being loaded.
 
 ### Fixed
 

--- a/Sources/Navigator/Toolkit/PaginationView.swift
+++ b/Sources/Navigator/Toolkit/PaginationView.swift
@@ -219,7 +219,7 @@ final class PaginationView: UIView, Loggable {
         }
     }
 
-    private func loadNextPage(completion: @escaping () -> Void = {}) {
+    private func loadNextPage(completion: @escaping () -> Void) {
         guard let (index, location) = loadingIndexQueue.popFirst() else {
             completion()
             return
@@ -240,8 +240,7 @@ final class PaginationView: UIView, Loggable {
         }
 
         view.go(to: location) {
-            completion()
-            self.loadNextPage()
+            self.loadNextPage(completion: completion)
         }
     }
 


### PR DESCRIPTION
### Changed

#### Navigator

* Prevent navigation in the EPUB while it is being loaded.

---

* Fixes https://github.com/readium/swift-toolkit/issues/256

User interaction and navigation with an EPUB is now prevented while its resources are being preloaded. This is to prevent this graphical bug: 

https://user-images.githubusercontent.com/58686775/202733130-6d5d25bd-7bdf-41c3-a72f-b18628bd1eda.mov
