### PR TITLE
Fix CGPDF returning unlocked pdf instead of error

### DIFF
--- a/Sources/Shared/Toolkit/PDF/CGPDF.swift
+++ b/Sources/Shared/Toolkit/PDF/CGPDF.swift
@@ -302,7 +302,7 @@ public class CGPDFDocumentFactory: PDFDocumentFactory, Loggable {
     }
     
     private func open(document: CGPDFDocument, password: String?) throws -> PDFDocument {
-        if (document.isEncrypted) {
+        if (document.isEncrypted && !document.isUnlocked) {
             guard
                 let password = password?.cString(using: .utf8),
                 document.unlockWithPassword(password) else


### PR DESCRIPTION
There was an issue while trying to open PDF with `CGPDFDocumentFactory` open function (line 304). If the PDF was encrypted but already unlocked, it would try to open it anyway with an empty password, then failing.

Add code to check if PDF is encrypted but not already unlocked.

[Here are 3 PDF samples you can use to test cases (non-encrypted, encrypted, and encrypted but unlocked)](https://file.io/j11FW9hHhAYK)
Password for encrypted files is 1234