### PR TITLE
Fix EPUB tap event sent twice when using a mouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 * Fixed a race condition issue with the `AVTTSEngine`, when pausing utterances.
 * Fixed crash with `PublicationSpeechSynthesizer`, when the currently played word cannot be resolved.
+* Fixed EPUB tap event sent twice when using a mouse (e.g. on Apple Silicon or with a mouse on an iPad).
 
 
 ## [2.4.0]

--- a/Sources/Navigator/EPUB/EPUBSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBSpreadView.swift
@@ -93,7 +93,9 @@ class EPUBSpreadView: UIView, Loggable, PageView {
         addSubview(webView)
         setupWebView()
 
-        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapBackground)))
+        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapBackground))
+        gestureRecognizer.delegate = self
+        addGestureRecognizer(gestureRecognizer)
         
         for script in scripts {
             webView.configuration.userContentController.addUserScript(script)
@@ -511,6 +513,14 @@ extension EPUBSpreadView: WKUIDelegate {
     func webView(_ webView: WKWebView, shouldPreviewElement elementInfo: WKPreviewElementInfo) -> Bool {
         // Preview allowed only if the link is not internal
         return (elementInfo.linkURL?.host != publication.baseURL?.host)
+    }
+}
+
+extension EPUBSpreadView: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        // Prevents the tap event from being triggered by the fallback tap
+        // gesture recognizer when it is also recognized by the web view.
+        true
     }
 }
 

--- a/TestApp/Integrations/Carthage/project+lcp.yml
+++ b/TestApp/Integrations/Carthage/project+lcp.yml
@@ -39,4 +39,5 @@ targets:
     settings:
       LIBRARY_SEARCH_PATHS: $(PROJECT_DIR)/Carthage
       OTHER_SWIFT_FLAGS: -DLCP
+      DEVELOPMENT_TEAM: ${RD_DEVELOPMENT_TEAM}
 

--- a/TestApp/Integrations/Carthage/project.yml
+++ b/TestApp/Integrations/Carthage/project.yml
@@ -34,4 +34,5 @@ targets:
       - package: MBProgressHUD
     settings:
       LIBRARY_SEARCH_PATHS: $(PROJECT_DIR)/Carthage
+      DEVELOPMENT_TEAM: ${RD_DEVELOPMENT_TEAM}
 

--- a/TestApp/Integrations/CocoaPods/project+lcp.yml
+++ b/TestApp/Integrations/CocoaPods/project+lcp.yml
@@ -10,3 +10,4 @@ targets:
       - path: Sources
     settings:
       OTHER_SWIFT_FLAGS: $(inherited) -DLCP
+      DEVELOPMENT_TEAM: ${RD_DEVELOPMENT_TEAM}

--- a/TestApp/Integrations/CocoaPods/project.yml
+++ b/TestApp/Integrations/CocoaPods/project.yml
@@ -8,3 +8,5 @@ targets:
     deploymentTarget: "14.0"
     sources: 
       - path: Sources
+    settings:
+      DEVELOPMENT_TEAM: ${RD_DEVELOPMENT_TEAM}

--- a/TestApp/Integrations/Local/project+lcp.yml
+++ b/TestApp/Integrations/Local/project+lcp.yml
@@ -44,4 +44,5 @@ targets:
       - package: SwiftSoup
     settings:
       OTHER_SWIFT_FLAGS: -DLCP
+      DEVELOPMENT_TEAM: ${RD_DEVELOPMENT_TEAM}
 

--- a/TestApp/Integrations/Local/project.yml
+++ b/TestApp/Integrations/Local/project.yml
@@ -36,4 +36,6 @@ targets:
       - package: Kingfisher
       - package: MBProgressHUD
       - package: SwiftSoup
+    settings:
+      DEVELOPMENT_TEAM: ${RD_DEVELOPMENT_TEAM}
 

--- a/TestApp/Integrations/SPM/project+lcp.yml
+++ b/TestApp/Integrations/SPM/project+lcp.yml
@@ -45,3 +45,4 @@ targets:
       - package: SwiftSoup
     settings:
       OTHER_SWIFT_FLAGS: -DLCP
+      DEVELOPMENT_TEAM: ${RD_DEVELOPMENT_TEAM}

--- a/TestApp/Integrations/SPM/project.yml
+++ b/TestApp/Integrations/SPM/project.yml
@@ -36,4 +36,6 @@ targets:
       - package: GRDB
       - package: Kingfisher
       - package: MBProgressHUD
+    settings:
+      DEVELOPMENT_TEAM: ${RD_DEVELOPMENT_TEAM}
 

--- a/TestApp/Sources/Info.plist
+++ b/TestApp/Sources/Info.plist
@@ -213,7 +213,7 @@
 		<string>armv7</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/TestApp/Sources/Library/LibraryViewController.swift
+++ b/TestApp/Sources/Library/LibraryViewController.swift
@@ -101,7 +101,7 @@ class LibraryViewController: UIViewController, Loggable {
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        collectionView.collectionViewLayout.invalidateLayout()
+        collectionView?.collectionViewLayout.invalidateLayout()
     }
 
     static let iPadLayoutNumberPerRow:[ScreenOrientation: Int] = [.portrait: 4, .landscape: 5]


### PR DESCRIPTION
### Fixed

#### Navigator

* Fixed EPUB tap event sent twice when using a mouse (e.g. on Apple Silicon or with a mouse on an iPad).