### PR TITLE
EPUB FXL `auto` spread setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to this project will be documented in this file. Take a look
 
 * The Readium toolkit now requires iOS 11.0+.
 
+### Added
+
+#### Navigator
+
+* The `auto` spread setting is now available for fixed-layout EPUBs. It will display two pages in landscape and a single one in portrait.
+
+### Fixed
+
+#### Navigator
+
+* Fixed the PDF `auto` spread setting and scaling pages when rotating the screen.
+
+
 ## [2.5.0]
 
 ### Added

--- a/Sources/Navigator/EPUB/CSS/CSSLayout.swift
+++ b/Sources/Navigator/EPUB/CSS/CSSLayout.swift
@@ -10,13 +10,13 @@ import R2Shared
 /// Readium CSS layout variant to use.
 ///
 /// See https://github.com/readium/readium-css/tree/master/css/dist
-struct CSSLayout: Equatable {
+struct CSSLayout: Hashable {
     let language: Language?
     let stylesheets: Stylesheets
     let readingProgression: ReadingProgression
 
     /// Readium CSS stylesheet variants.
-    enum Stylesheets {
+    enum Stylesheets: Hashable {
         /// Left to right
         case `default`
         /// Right to left

--- a/Sources/Navigator/EPUB/EPUBFixedSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBFixedSpreadView.swift
@@ -47,7 +47,7 @@ final class EPUBFixedSpreadView: EPUBSpreadView {
         scrollView.backgroundColor = UIColor.clear
 
         // Loads the wrapper page into the web view.
-        let spreadFile = "fxl-spread-\(spread.pageCount.rawValue)"
+        let spreadFile = "fxl-spread-\(spread.spread ? "two" : "one")"
         if
             let wrapperPageURL = Bundle.module.url(forResource: spreadFile, withExtension: "html", subdirectory: "Assets"),
             var wrapperPage = try? String(contentsOf: wrapperPageURL, encoding: .utf8)

--- a/Sources/Navigator/EPUB/Preferences/EPUBPreferencesEditor.swift
+++ b/Sources/Navigator/EPUB/Preferences/EPUBPreferencesEditor.swift
@@ -44,7 +44,8 @@ public final class EPUBPreferencesEditor: StatefulPreferencesEditor<EPUBPreferen
             isEffective: { [unowned self] _ in preferences.backgroundColor != nil }
         )
 
-    /// Number of reflowable columns to display (one-page view or two-page spread).
+    /// Number of reflowable columns to display (one-page view or two-page
+    /// spread).
     ///
     /// Only effective when:
     ///  - the publication is reflowable
@@ -72,7 +73,8 @@ public final class EPUBPreferencesEditor: StatefulPreferencesEditor<EPUBPreferen
 
     /// Base text font size as a percentage. Default to 100%.
     ///
-    /// Note that allowing a font size that is too large could break the pagination.
+    /// Note that allowing a font size that is too large could break the
+    /// pagination.
     ///
     /// Only effective with reflowable publications.
     public lazy var fontSize: AnyRangePreference<Double> =
@@ -87,8 +89,8 @@ public final class EPUBPreferencesEditor: StatefulPreferencesEditor<EPUBPreferen
 
     /// Default boldness for the text as a percentage.
     ///
-    /// If you want to change the boldness of all text, including headers, you can use this with
-    /// `textNormalization`.
+    /// If you want to change the boldness of all text, including headers, you
+    /// can use this with `textNormalization`.
     ///
     /// Only effective with reflowable publications.
     public lazy var fontWeight: AnyRangePreference<Double> =
@@ -256,8 +258,8 @@ public final class EPUBPreferencesEditor: StatefulPreferencesEditor<EPUBPreferen
             format: \.percentageString
         )
 
-    /// Indicates whether the original publisher styles should be observed. Many advanced settings
-    /// require this to be off.
+    /// Indicates whether the original publisher styles should be observed.
+    /// Many advanced settings require this to be off.
     ///
     /// Only effective with reflowable publications.
     public lazy var publisherStyles: AnyPreference<Bool> =
@@ -278,8 +280,8 @@ public final class EPUBPreferencesEditor: StatefulPreferencesEditor<EPUBPreferen
             supportedValues: [.ltr, .rtl]
         )
 
-    /// Indicates if the overflow of resources should be handled using scrolling instead of synthetic
-    /// pagination.
+    /// Indicates if the overflow of resources should be handled using
+    /// scrolling instead of synthetic pagination.
     ///
     /// Only effective with reflowable publications.
     public lazy var scroll: AnyPreference<Bool> =
@@ -289,8 +291,8 @@ public final class EPUBPreferencesEditor: StatefulPreferencesEditor<EPUBPreferen
             isEffective: { [unowned self] _ in layout == .reflowable }
         )
 
-    /// Indicates if the fixed-layout publication should be rendered with a synthetic spread
-    /// (dual-page).
+    /// Indicates if the fixed-layout publication should be rendered with a
+    /// synthetic spread (dual-page).
     ///
     /// Only effective with fixed-layout publications.
     public lazy var spread: AnyEnumPreference<Spread> =
@@ -298,7 +300,7 @@ public final class EPUBPreferencesEditor: StatefulPreferencesEditor<EPUBPreferen
             preference: \.spread,
             setting: \.spread,
             isEffective: { [unowned self] _ in layout == .fixed },
-            supportedValues: [.never, .always]
+            supportedValues: [.auto, .never, .always]
         )
 
     /// Page text alignment.
@@ -377,8 +379,9 @@ public final class EPUBPreferencesEditor: StatefulPreferencesEditor<EPUBPreferen
             format: { $0.formatDecimal(maximumFractionDigits: 5) }
         )
 
-    /// Indicates whether the text should be laid out vertically. This is used for example with CJK
-    /// languages. This setting is automatically derived from the language if no preference is given.
+    /// Indicates whether the text should be laid out vertically. This is used
+    /// for example with CJK languages. This setting is automatically derived
+    /// from the language if no preference is given.
     ///
     /// Only effective with reflowable publications.
     public lazy var verticalText: AnyPreference<Bool> =

--- a/Sources/Navigator/EPUB/Preferences/EPUBSettings.swift
+++ b/Sources/Navigator/EPUB/Preferences/EPUBSettings.swift
@@ -161,8 +161,9 @@ public struct EPUBSettings: ConfigurableSettings {
                 ?? defaults.scroll
                 ?? false,
             spread: preferences.spread
+                ?? Spread(metadata.presentation.spread)
                 ?? defaults.spread
-                ?? .never,
+                ?? .auto,
             textAlign: preferences.textAlign
                 ?? defaults.textAlign,
             textColor: preferences.textColor,

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -199,18 +199,17 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
         super.viewWillTransition(to: size, with: coordinator)
 
         if let pdfView = pdfView, scalesDocumentToFit {
-            // Reset the PDF view to update the spread if needed.
-            if settings.spread == .auto {
-                // FIXME: Threshold
-                resetPDFView(at: currentLocation)
-            }
-
             // Makes sure that the PDF is always properly scaled down when rotating the screen, if the user didn't zoom in.
             let isAtMinScaleFactor = (pdfView.scaleFactor == pdfView.minScaleFactor)
             coordinator.animate(alongsideTransition: { _ in
                 self.updateScaleFactors()
                 if isAtMinScaleFactor {
                     pdfView.scaleFactor = pdfView.minScaleFactor
+                }
+
+                // Reset the PDF view to update the spread if needed.
+                if self.settings.spread == .auto {
+                    self.resetPDFView(at: self.currentLocation)
                 }
             })
         }

--- a/Sources/Navigator/Preferences/Configurable.swift
+++ b/Sources/Navigator/Preferences/Configurable.swift
@@ -29,10 +29,10 @@ public protocol Configurable {
 }
 
 /// Marker interface for the setting properties holder.
-public protocol ConfigurableSettings {}
+public protocol ConfigurableSettings: Hashable {}
 
 /// Marker interface for the `Preferences` properties holder.
-public protocol ConfigurablePreferences: Codable, Equatable {
+public protocol ConfigurablePreferences: Codable, Hashable {
     /// Empty set of preferences.
     static var empty: Self { get }
 

--- a/Sources/Navigator/Preferences/Types.swift
+++ b/Sources/Navigator/Preferences/Types.swift
@@ -23,6 +23,20 @@ public enum Spread: String, Codable, Hashable {
     case never
     /// The publication should always be displayed in a spread.
     case always
+
+    init?(_ spread: R2Shared.Presentation.Spread?) {
+        guard let spread = spread else {
+            return nil
+        }
+        switch spread {
+        case .both:
+            self = .always
+        case .none:
+            self = .never
+        case .auto, .landscape:
+            self = .auto
+        }
+    }
 }
 
 /// Direction of the reading progression across resources.


### PR DESCRIPTION
### Added

#### Navigator

* The `auto` spread setting is now available for fixed-layout EPUBs. It will display two pages in landscape and a single one in portrait.

### Fixed

#### Navigator

* Fixed the PDF `auto` spread setting and scaling pages when rotating the screen.
