### PR TITLE
Fix one chapter audiobook navigation issue

### DIFF
--- a/Sources/Navigator/Audiobook/AudioNavigator.swift
+++ b/Sources/Navigator/Audiobook/AudioNavigator.swift
@@ -249,8 +249,7 @@ open class _AudioNavigator: _MediaNavigator, _AudioSessionUser, Loggable {
             }
 
             // Seeks to time
-            let time = locator.time(forDuration: resourceDuration) ?? 0
-            if time > 0 {
+            if let time = locator.time(forDuration: resourceDuration) {
                 player.seek(to: CMTime(seconds: time, preferredTimescale: 1000))
             }
 


### PR DESCRIPTION
### It's not possible to navigate to the first chapter when an audio book has only one chapter, this small PR will fix for that issue.

**Hot to reproduce:**
1. Open an audiobook which has only one chapter
2. Play the audio book
3. Try to navigate to the first chapter

**Expected result:** The audio navigator should start playing from beginning.

**Actual result:** The player remains on current position, nothing get changed.