### PR TITLE
Make `WKWebView` inspectable on iOS 16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ All notable changes to this project will be documented in this file. Take a look
 
 * Fixed the PDF `auto` spread setting and scaling pages when rotating the screen.
 * Prevent auto-playing videos in EPUB publications.
-* Fix various memory leaks and data races.
+* Fixed various memory leaks and data races.
+* The `WKWebView` is now inspectable again with Safari starting from iOS 16.4.
 
 
 ## [2.5.0]

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed.js
@@ -8308,7 +8308,7 @@ const SELECTOR_PATTERN = [
     _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.nthoftype,
     _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.tag,
     _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.id,
-    _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType["class"],
+    _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.class,
     _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.attribute,
     _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.nthchild
 ];
@@ -9045,7 +9045,7 @@ __webpack_require__.r(__webpack_exports__);
 const DEFAULT_OPTIONS = {
     selectors: [
         _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.id,
-        _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType["class"],
+        _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.class,
         _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.tag,
         _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.attribute,
     ],

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
@@ -8308,7 +8308,7 @@ const SELECTOR_PATTERN = [
     _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.nthoftype,
     _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.tag,
     _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.id,
-    _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType["class"],
+    _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.class,
     _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.attribute,
     _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.nthchild
 ];
@@ -9045,7 +9045,7 @@ __webpack_require__.r(__webpack_exports__);
 const DEFAULT_OPTIONS = {
     selectors: [
         _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.id,
-        _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType["class"],
+        _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.class,
         _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.tag,
         _types_js__WEBPACK_IMPORTED_MODULE_0__.CssSelectorType.attribute,
     ],

--- a/Sources/Navigator/Toolkit/WebView.swift
+++ b/Sources/Navigator/Toolkit/WebView.swift
@@ -19,7 +19,7 @@ final class WebView: WKWebView {
         config.mediaTypesRequiringUserActionForPlayback = .all
         super.init(frame: .zero, configuration: config)
 
-        #if DEBUG
+        #if DEBUG && swift(>=5.8)
             if #available(macOS 13.3, iOS 16.4, *) {
                 isInspectable = true
             }

--- a/Sources/Navigator/Toolkit/WebView.swift
+++ b/Sources/Navigator/Toolkit/WebView.swift
@@ -18,6 +18,12 @@ final class WebView: WKWebView {
         let config = WKWebViewConfiguration()
         config.mediaTypesRequiringUserActionForPlayback = .all
         super.init(frame: .zero, configuration: config)
+
+        #if DEBUG
+            if #available(macOS 13.3, iOS 16.4, *) {
+                isInspectable = true
+            }
+        #endif
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
### Fixed

#### Navigator

* The `WKWebView` is now inspectable again with Safari starting from iOS 16.4.