### PR TITLE
Add `HTTPError.serverUnreachable`

### DIFF
--- a/Sources/Shared/Fetcher/Resource/Resource.swift
+++ b/Sources/Shared/Fetcher/Resource/Resource.swift
@@ -172,7 +172,7 @@ public enum ResourceError: LocalizedError {
             switch error.kind {
             case .malformedRequest, .badRequest:
                 return .badRequest(error)
-            case .timeout, .offline:
+            case .timeout, .offline, .serverUnreachable:
                 return .unavailable(error)
             case .unauthorized, .forbidden:
                 return .forbidden(error)

--- a/Sources/Shared/Resources/en.lproj/Localizable.strings
+++ b/Sources/Shared/Resources/en.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "R2Shared.HTTPError.notFound" = "Page not found";
 "R2Shared.HTTPError.clientError" = "A client error occurred";
 "R2Shared.HTTPError.serverError" = "A server error occurred, please try again later";
+"R2Shared.HTTPError.serverUnreachable" = "Could not reach the server.";
 "R2Shared.HTTPError.offline" = "Your Internet connection appears to be offline";
 "R2Shared.HTTPError.ioError" = "Failed to access the disk storage";
 "R2Shared.HTTPError.cancelled" = "The request was cancelled";

--- a/Sources/Shared/Toolkit/HTTP/HTTPError.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPError.swift
@@ -31,6 +31,8 @@ public struct HTTPError: LocalizedError, Equatable, Loggable {
         case clientError
         /// (5xx) Server errors
         case serverError
+        /// Cannot connect to the server, or the host cannot be resolved.
+        case serverUnreachable
         /// The device is offline.
         case offline
         /// IO error while accessing the disk.
@@ -78,6 +80,8 @@ public struct HTTPError: LocalizedError, Equatable, Loggable {
                     self = .malformedResponse
                 case .notConnectedToInternet, .networkConnectionLost:
                     self = .offline
+                case .cannotConnectToHost, .cannotFindHost:
+                    self = .serverUnreachable
                 case .timedOut:
                     self = .timeout
                 case .userAuthenticationRequired, .appTransportSecurityRequiresSecureConnection, .noPermissionsToReadFile:
@@ -168,6 +172,8 @@ public struct HTTPError: LocalizedError, Equatable, Loggable {
             return R2SharedLocalizedString("HTTPError.clientError")
         case .serverError:
             return R2SharedLocalizedString("HTTPError.serverError")
+        case .serverUnreachable:
+            return R2SharedLocalizedString("HTTPError.serverUnreachable")
         case .cancelled:
             return R2SharedLocalizedString("HTTPError.cancelled")
         case .offline:


### PR DESCRIPTION
Adds a new `HTTPError.serverUnreachable` error case to differentiate a bad response from an unreachable host.