### PR TITLE
Fix injecting the `dir` attribute when already present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. Take a look
 * The `WKWebView` is now inspectable again with Safari starting from iOS 16.4.
 * Fixed crash in the `PublicationSpeechSynthesizer` when closing the navigator without stopping it first.
 * Fixed the audio session kept opened while the app is in the background and paused.
+* Fixed the **Attribute dir redefined** error when the EPUB resource already has a `dir` attribute.
 
 ## [2.5.0]
 

--- a/Sources/Navigator/EPUB/CSS/ReadiumCSS.swift
+++ b/Sources/Navigator/EPUB/CSS/ReadiumCSS.swift
@@ -88,6 +88,12 @@ extension ReadiumCSS {
 }
 
 extension ReadiumCSS: HTMLInjectable {
+    func willInject(in html: String) -> String {
+        // Removes any dir attributes in html/body.
+        let range = NSRange(html.startIndex..., in: html)
+        return dirRegex.stringByReplacingMatches(in: html, options: [], range: range, withTemplate: "$1")
+    }
+
     /// https://github.com/readium/readium-css/blob/develop/docs/CSS06-stylesheets_order.md
     func injections(for html: String) throws -> [HTMLInjection] {
         let document = try parse(html)
@@ -200,3 +206,8 @@ private extension Element {
         return code.map { Language(code: .bcp47($0)) }
     }
 }
+
+private let dirRegex = try! NSRegularExpression(
+    pattern: "(<(?:html|body)[^>]*)\\s+dir=[\"']\\w*[\"']",
+    options: [.caseInsensitive, .anchorsMatchLines]
+)

--- a/Sources/Navigator/Toolkit/HTMLInjection.swift
+++ b/Sources/Navigator/Toolkit/HTMLInjection.swift
@@ -10,13 +10,18 @@ import ReadiumInternal
 
 /// An object that can be injected into an HTML document.
 protocol HTMLInjectable {
+    /// Extension point to do treatment on the HTML document before injection.
+    func willInject(in html: String) -> String
+
     func injections(for html: String) throws -> [HTMLInjection]
 }
 
 extension HTMLInjectable {
+    func willInject(in html: String) -> String { html }
+
     /// Injects the receiver in the given `html` document.
     func inject(in html: String) throws -> String {
-        var result = html
+        var result = willInject(in: html)
         for injection in try injections(for: html) {
             result = try injection.inject(in: result)
         }

--- a/Tests/NavigatorTests/EPUB/CSS/ReadiumCSSTests.swift
+++ b/Tests/NavigatorTests/EPUB/CSS/ReadiumCSSTests.swift
@@ -302,4 +302,32 @@ class ReadiumCSSTests: XCTestCase {
             ]
         )
     }
+
+    func testInjectDirAttributeWhenAlreadyPresent() {
+        let css = ReadiumCSS(
+            layout: CSSLayout(language: Language(code: .bcp47("en"))),
+            baseURL: baseURL
+        )
+
+        XCTAssertEqual(
+            try css.inject(in: """
+            <?xml version="1.0" encoding="utf-8"?>
+            <html xmlns="http://www.w3.org/1999/xhtml">
+                <head>
+                    <title>Publication</title>
+                </head>
+                <body dir="rtl" lang="fr"></body>
+            </html>
+            """),
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <html xml:lang="fr" dir="ltr" style="" xmlns="http://www.w3.org/1999/xhtml">
+                <head><link rel="stylesheet" href="https://readium/assets/ReadiumCSS-before.css" type="text/css"/>
+                    <title>Publication</title>
+                <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0"/><link rel="stylesheet" href="https://readium/assets/ReadiumCSS-default.css" type="text/css"/><link rel="stylesheet" href="https://readium/assets/ReadiumCSS-after.css" type="text/css"/><style type="text/css">audio[controls] { width: revert; height: revert; }</style></head>
+                <body dir="ltr" lang="fr"></body>
+            </html>
+            """
+        )
+    }
 }


### PR DESCRIPTION
### Fixed

#### Navigator

* Fixed the **Attribute dir redefined** error when the EPUB resource already has a `dir` attribute.