### PR TITLE
HTML Content Iterator improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ All notable changes to this project will be documented in this file. Take a look
 
 * The `auto` spread setting is now available for fixed-layout EPUBs. It will display two pages in landscape and a single one in portrait.
 
+#### Streamer
+
+* The EPUB content iterator now returns `audio` and `video` elements and fill in the `progression` and `totalProgression` locator properties.
+
+### Changed
+
+#### Navigator
+
+* `EPUBNavigatorViewController.firstVisibleElementLocator()` now returns the first *block* element that is visible on the screen, even if it starts on previous pages.
+    * This is used to make sure the user will not miss any context when restoring a TTS session in the middle of a resource.
+
 ### Fixed
 
 #### Navigator
@@ -27,6 +38,10 @@ All notable changes to this project will be documented in this file. Take a look
 * Fixed the audio session kept opened while the app is in the background and paused.
 * Fixed the **Attribute dir redefined** error when the EPUB resource already has a `dir` attribute.
 * [#309](https://github.com/readium/swift-toolkit/issues/309) Fixed restoring the EPUB location when the application was killed in the background (contributed by [@triin-ko](https://github.com/readium/swift-toolkit/pull/311)).
+
+#### Streamer
+
+* Fix issue with the TTS starting from the beginning of the chapter instead of the current position.
 
 
 ## [2.5.0]

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed.js
@@ -1624,9 +1624,6 @@ function findNearestInteractiveElement(element) {
 /// the screen.
 function findFirstVisibleLocator() {
   const element = findElement(document.body);
-  if (!element) {
-    return undefined;
-  }
   return {
     href: "#",
     type: "application/xhtml+xml",
@@ -1639,55 +1636,34 @@ function findFirstVisibleLocator() {
   };
 }
 function findElement(rootElement) {
-  var foundElement = undefined;
-  for (var i = rootElement.children.length - 1; i >= 0; i--) {
+  for (var i = 0; i < rootElement.children.length; i++) {
     const child = rootElement.children[i];
-    const position = elementRelativePosition(child, undefined);
-    if (position == 0) {
-      if (!shouldIgnoreElement(child)) {
-        foundElement = child;
-      }
-    } else if (position < 0) {
-      if (!foundElement) {
-        foundElement = child;
-      }
-      break;
+    if (!shouldIgnoreElement(child) && isElementVisible(child)) {
+      return findElement(child);
     }
-  }
-  if (foundElement) {
-    return findElement(foundElement);
   }
   return rootElement;
 }
-
-// See computeVisibility_() in r2-navigator-js
-function elementRelativePosition(element, domRect /* nullable */) {
+function isElementVisible(element) {
   if (readium.isFixedLayout) return true;
   if (element === document.body || element === document.documentElement) {
-    return -1;
+    return true;
   }
   if (!document || !document.documentElement || !document.body) {
-    return 1;
+    return false;
   }
-  const rect = domRect || element.getBoundingClientRect();
+  const rect = element.getBoundingClientRect();
   if ((0,_utils__WEBPACK_IMPORTED_MODULE_0__.isScrollModeEnabled)()) {
-    return rect.top >= 0 && rect.top <= document.documentElement.clientHeight;
+    return rect.bottom > 0 && rect.top < window.innerHeight;
   } else {
-    const pageWidth = window.innerWidth;
-    if (rect.left >= pageWidth) {
-      return 1;
-    } else if (rect.left >= 0) {
-      return 0;
-    } else {
-      return -1;
-    }
+    return rect.right > 0 && rect.left < window.innerWidth;
   }
 }
 function shouldIgnoreElement(element) {
   const elStyle = getComputedStyle(element);
   if (elStyle) {
     const display = elStyle.getPropertyValue("display");
-    if (display === "none") {
+    if (display != "block") {
       return true;
     }
     // Cannot be relied upon, because web browser engine reports invisible when out of view in

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
@@ -1624,9 +1624,6 @@ function findNearestInteractiveElement(element) {
 /// the screen.
 function findFirstVisibleLocator() {
   const element = findElement(document.body);
-  if (!element) {
-    return undefined;
-  }
   return {
     href: "#",
     type: "application/xhtml+xml",
@@ -1639,55 +1636,34 @@ function findFirstVisibleLocator() {
   };
 }
 function findElement(rootElement) {
-  var foundElement = undefined;
-  for (var i = rootElement.children.length - 1; i >= 0; i--) {
+  for (var i = 0; i < rootElement.children.length; i++) {
     const child = rootElement.children[i];
-    const position = elementRelativePosition(child, undefined);
-    if (position == 0) {
-      if (!shouldIgnoreElement(child)) {
-        foundElement = child;
-      }
-    } else if (position < 0) {
-      if (!foundElement) {
-        foundElement = child;
-      }
-      break;
+    if (!shouldIgnoreElement(child) && isElementVisible(child)) {
+      return findElement(child);
     }
-  }
-  if (foundElement) {
-    return findElement(foundElement);
   }
   return rootElement;
 }
-
-// See computeVisibility_() in r2-navigator-js
-function elementRelativePosition(element, domRect /* nullable */) {
+function isElementVisible(element) {
   if (readium.isFixedLayout) return true;
   if (element === document.body || element === document.documentElement) {
-    return -1;
+    return true;
   }
   if (!document || !document.documentElement || !document.body) {
-    return 1;
+    return false;
   }
-  const rect = domRect || element.getBoundingClientRect();
+  const rect = element.getBoundingClientRect();
   if ((0,_utils__WEBPACK_IMPORTED_MODULE_0__.isScrollModeEnabled)()) {
-    return rect.top >= 0 && rect.top <= document.documentElement.clientHeight;
+    return rect.bottom > 0 && rect.top < window.innerHeight;
   } else {
-    const pageWidth = window.innerWidth;
-    if (rect.left >= pageWidth) {
-      return 1;
-    } else if (rect.left >= 0) {
-      return 0;
-    } else {
-      return -1;
-    }
+    return rect.right > 0 && rect.left < window.innerWidth;
   }
 }
 function shouldIgnoreElement(element) {
   const elStyle = getComputedStyle(element);
   if (elStyle) {
     const display = elStyle.getPropertyValue("display");
-    if (display === "none") {
+    if (display != "block") {
       return true;
     }
     // Cannot be relied upon, because web browser engine reports invisible when out of view in

--- a/Sources/Navigator/EPUB/Scripts/src/dom.js
+++ b/Sources/Navigator/EPUB/Scripts/src/dom.js
@@ -54,10 +54,6 @@ export function findNearestInteractiveElement(element) {
 /// the screen.
 export function findFirstVisibleLocator() {
   const element = findElement(document.body);
-  if (!element) {
-    return undefined;
-  }
-
   return {
     href: "#",
     type: "application/xhtml+xml",
@@ -71,52 +67,30 @@ export function findFirstVisibleLocator() {
 }
 
 function findElement(rootElement) {
-  var foundElement = undefined;
-  for (var i = rootElement.children.length - 1; i >= 0; i--) {
+  for (var i = 0; i < rootElement.children.length; i++) {
     const child = rootElement.children[i];
-    const position = elementRelativePosition(child, undefined);
-    if (position == 0) {
-      if (!shouldIgnoreElement(child)) {
-        foundElement = child;
-      }
-    } else if (position < 0) {
-      if (!foundElement) {
-        foundElement = child;
-      }
-      break;
+    if (!shouldIgnoreElement(child) && isElementVisible(child)) {
+      return findElement(child);
     }
-  }
-
-  if (foundElement) {
-    return findElement(foundElement);
   }
   return rootElement;
 }
 
-// See computeVisibility_() in r2-navigator-js
-function elementRelativePosition(element, domRect /* nullable */) {
+function isElementVisible(element) {
   if (readium.isFixedLayout) return true;
 
   if (element === document.body || element === document.documentElement) {
-    return -1;
+    return true;
   }
   if (!document || !document.documentElement || !document.body) {
-    return 1;
+    return false;
   }
 
-  const rect = domRect || element.getBoundingClientRect();
-
+  const rect = element.getBoundingClientRect();
   if (isScrollModeEnabled()) {
-    return rect.top >= 0 && rect.top <= document.documentElement.clientHeight;
+    return rect.bottom > 0 && rect.top < window.innerHeight;
   } else {
-    const pageWidth = window.innerWidth;
-    if (rect.left >= pageWidth) {
-      return 1;
-    } else if (rect.left >= 0) {
-      return 0;
-    } else {
-      return -1;
-    }
+    return rect.right > 0 && rect.left < window.innerWidth;
   }
 }
 
@@ -124,7 +98,7 @@ function shouldIgnoreElement(element) {
   const elStyle = getComputedStyle(element);
   if (elStyle) {
     const display = elStyle.getPropertyValue("display");
-    if (display === "none") {
+    if (display != "block") {
       return true;
     }
     // Cannot be relied upon, because web browser engine reports invisible when out of view in

--- a/Sources/Shared/Publication/Services/Content/Content.swift
+++ b/Sources/Shared/Publication/Services/Content/Content.swift
@@ -43,6 +43,37 @@ public extension Content {
 public protocol ContentElement: ContentAttributesHolder {
     /// Locator targeting this element in the Publication.
     var locator: Locator { get }
+
+    /// Returns whether the receiver is equivalent to `other`.
+    func isEqualTo(_ other: ContentElement) -> Bool
+}
+
+public extension ContentElement where Self: Equatable {
+    func isEqualTo(_ other: ContentElement) -> Bool {
+        guard let otherElement = other as? Self else { return false }
+        return self == otherElement
+    }
+}
+
+/// A type-erasing `ContentElement` object which implements `Equatable`.
+public struct AnyEquatableContentElement: Equatable, ContentElement {
+    private let element: ContentElement
+
+    public init<E: ContentElement>(_ element: E) {
+        self.element = element
+    }
+
+    public var locator: Locator { element.locator }
+
+    public var attributes: [ContentAttribute] { element.attributes }
+
+    public func isEqualTo(_ other: ContentElement) -> Bool {
+        element.isEqualTo(other)
+    }
+
+    public static func == (lhs: AnyEquatableContentElement, rhs: AnyEquatableContentElement) -> Bool {
+        lhs.element.isEqualTo(rhs.element)
+    }
 }
 
 /// An element which can be represented as human-readable text.
@@ -64,7 +95,7 @@ public protocol EmbeddedContentElement: ContentElement {
 }
 
 /// An audio clip.
-public struct AudioContentElement: EmbeddedContentElement, TextualContentElement {
+public struct AudioContentElement: Hashable, EmbeddedContentElement, TextualContentElement {
     public var locator: Locator
     public var embeddedLink: Link
     public var attributes: [ContentAttribute]
@@ -77,7 +108,7 @@ public struct AudioContentElement: EmbeddedContentElement, TextualContentElement
 }
 
 /// A video clip.
-public struct VideoContentElement: EmbeddedContentElement, TextualContentElement {
+public struct VideoContentElement: Hashable, EmbeddedContentElement, TextualContentElement {
     public var locator: Locator
     public var embeddedLink: Link
     public var attributes: [ContentAttribute]
@@ -90,7 +121,7 @@ public struct VideoContentElement: EmbeddedContentElement, TextualContentElement
 }
 
 /// A bitmap image.
-public struct ImageContentElement: EmbeddedContentElement, TextualContentElement {
+public struct ImageContentElement: Hashable, EmbeddedContentElement, TextualContentElement {
     public var locator: Locator
     public var embeddedLink: Link
 
@@ -115,7 +146,7 @@ public struct ImageContentElement: EmbeddedContentElement, TextualContentElement
 ///
 /// @param role Purpose of this element in the broader context of the document.
 /// @param segments Ranged portions of text with associated attributes.
-public struct TextContentElement: TextualContentElement {
+public struct TextContentElement: Hashable, TextualContentElement {
     public var locator: Locator
     public var role: Role
     public var segments: [Segment]
@@ -133,7 +164,7 @@ public struct TextContentElement: TextualContentElement {
     }
 
     /// Represents a purpose of an element in the broader context of the document.
-    public enum Role {
+    public enum Role: Hashable {
         /// Title of a section with its level (1 being the highest).
         case heading(level: Int)
 
@@ -152,7 +183,7 @@ public struct TextContentElement: TextualContentElement {
     /// @param locator Locator to the segment of text.
     /// @param text Text in the segment.
     /// @param attributes Attributes associated with this segment, e.g. language.
-    public struct Segment: ContentAttributesHolder {
+    public struct Segment: Hashable, ContentAttributesHolder {
         public var locator: Locator
         public var text: String
         public var attributes: [ContentAttribute]
@@ -168,7 +199,7 @@ public struct TextContentElement: TextualContentElement {
 /// An attribute key identifies uniquely a type of attribute.
 ///
 /// The `V` phantom type is there to perform static type checking when requesting an attribute.
-public struct ContentAttributeKey<V> {
+public struct ContentAttributeKey<V>: Hashable {
     public static var accessibilityLabel: ContentAttributeKey<String> { .init("accessibilityLabel") }
     public static var language: ContentAttributeKey<Language> { .init("language") }
 

--- a/Sources/Shared/Publication/Services/Content/Iterators/HTMLResourceContentIterator.swift
+++ b/Sources/Shared/Publication/Services/Content/Iterators/HTMLResourceContentIterator.swift
@@ -7,52 +7,82 @@
 import Foundation
 import SwiftSoup
 
-// FIXME: Custom skipped elements
-
 /// Iterates an HTML `resource`, starting from the given `locator`.
 ///
-/// If you want to start mid-resource, the `locator` must contain a `cssSelector` key in its
-/// `Locator.Locations` object.
+/// If you want to start mid-resource, the `locator` must contain a
+/// `cssSelector` key in its `Locator.Locations` object.
 ///
-/// If you want to start from the end of the resource, the `locator` must have a `progression` of 1.0.
+/// If you want to start from the end of the resource, the `locator` must have
+/// a `progression` of 1.0.
 public class HTMLResourceContentIterator: ContentIterator {
-    /// Creates a new factory for `HTMLResourceContentIterator`.
-    public static func makeFactory() -> ResourceContentIteratorFactory {
-        { resource, locator in
+    /// Factory for an `HTMLResourceContentIterator`.
+    public class Factory: ResourceContentIteratorFactory {
+        public init() {}
+
+        public func make(
+            publication: Publication,
+            readingOrderIndex: Int,
+            resource: Resource,
+            locator: Locator
+        ) -> ContentIterator? {
             guard resource.link.mediaType.isHTML else {
                 return nil
             }
-            return HTMLResourceContentIterator(resource: resource, locator: locator)
+
+            let positions = publication.positionsByReadingOrder
+            return HTMLResourceContentIterator(
+                resource: resource,
+                totalProgressionRange: positions.getOrNil(readingOrderIndex)?
+                    .first?.locations.totalProgression
+                    .map { start in
+                        let end = positions.getOrNil(readingOrderIndex + 1)?
+                            .first?.locations.totalProgression
+                            ?? 1.0
+
+                        return start ... end
+                    },
+                locator: locator
+            )
         }
     }
 
     private let resource: Resource
+    private let totalProgressionRange: ClosedRange<Double>?
     private let locator: Locator
+    private let beforeMaxLength: Int = 50
 
-    public init(resource: Resource, locator: Locator) {
+    public init(
+        resource: Resource,
+        totalProgressionRange: ClosedRange<Double>?,
+        locator: Locator
+    ) {
         self.resource = resource
+        self.totalProgressionRange = totalProgressionRange
         self.locator = locator
     }
 
     public func previous() throws -> ContentElement? {
-        try next(by: -1)
-    }
-
-    public func next() throws -> ContentElement? {
-        try next(by: +1)
-    }
-
-    private func next(by delta: Int) throws -> ContentElement? {
         let elements = try elements.get()
-        let index = currentIndex.map { $0 + delta }
-            ?? elements.startIndex
+        let index = (currentIndex ?? elements.startIndex) - 1
 
-        guard elements.elements.indices.contains(index) else {
+        guard let content = elements.elements.getOrNil(index) else {
             return nil
         }
 
         currentIndex = index
-        return elements.elements[index]
+        return content
+    }
+
+    public func next() throws -> ContentElement? {
+        let elements = try elements.get()
+        let index = (currentIndex ?? (elements.startIndex - 1)) + 1
+
+        guard let content = elements.elements.getOrNil(index) else {
+            return nil
+        }
+
+        currentIndex = index
+        return content
     }
 
     private var currentIndex: Int?
@@ -64,30 +94,56 @@ public class HTMLResourceContentIterator: ContentIterator {
             .readAsString()
             .eraseToAnyError()
             .tryMap { try SwiftSoup.parse($0) }
-            .tryMap { try ContentParser.parse(document: $0, locator: locator) }
+            .tryMap { try ContentParser.parse(document: $0, locator: locator, beforeMaxLength: beforeMaxLength) }
+            .map { adjustProgressions(of: $0) }
         resource.close()
         return result
     }
 
-    /// Holds the result of parsing the HTML resource into a list of `ContentElement`.
+    /// Holds the result of parsing the HTML resource into a list of
+    /// `ContentElement`.
     ///
-    /// The `startIndex` will be calculated from the element matched by the base `locator`, if possible. Defaults to
-    /// 0.
-    private typealias ParsedElements = (elements: [ContentElement], startIndex: Int)
+    /// The `startIndex` will be calculated from the element matched by the
+    /// base `locator`, if possible. Defaults to 0.
+    private struct ParsedElements {
+        var elements: [ContentElement]
+        var startIndex: Int
+    }
+
+    private func adjustProgressions(of elements: ParsedElements) -> ParsedElements {
+        let count = Double(elements.elements.count)
+        guard count > 0 else {
+            return elements
+        }
+
+        var elements = elements
+        elements.elements = elements.elements.enumerated().map { index, element in
+            let progression = Double(index) / count
+            return element.copy(
+                progression: progression,
+                totalProgression: totalProgressionRange.map { range in
+                    range.lowerBound + progression * (range.upperBound - range.lowerBound)
+                }
+            )
+        }
+        return elements
+    }
 
     private class ContentParser: NodeVisitor {
-        static func parse(document: Document, locator: Locator) throws -> ParsedElements {
+        static func parse(document: Document, locator: Locator, beforeMaxLength: Int) throws -> ParsedElements {
             let parser = try ContentParser(
                 baseLocator: locator,
                 startElement: locator.locations.cssSelector
                     .flatMap {
-                        // The JS third-party library used to generate the CSS Selector sometimes adds
-                        // :root >, which doesn't work with JSoup.
+                        // The JS third-party library used to generate the CSS
+                        // Selector sometimes adds `:root >`, which doesn't work
+                        // with SwiftSoup.
                         try document.select($0.removingPrefix(":root > ")).first()
-                    }
+                    },
+                beforeMaxLength: beforeMaxLength
             )
 
-            try document.traverse(parser)
+            try (document.body() ?? document).traverse(parser)
 
             return ParsedElements(
                 elements: parser.elements,
@@ -97,137 +153,194 @@ public class HTMLResourceContentIterator: ContentIterator {
             )
         }
 
+        private init(baseLocator: Locator, startElement: Element?, beforeMaxLength: Int) {
+            self.baseLocator = baseLocator
+            self.startElement = startElement
+            self.beforeMaxLength = beforeMaxLength
+        }
+
         private let baseLocator: Locator
         private let startElement: Element?
+        private let beforeMaxLength: Int
 
         private var elements: [ContentElement] = []
         private var startIndex = 0
-        private var currentElement: Element?
 
+        /// Segments accumulated for the current element.
         private var segmentsAcc: [TextContentElement.Segment] = []
-        private var textAcc = StringBuilder()
-        private var wholeRawTextAcc: String = ""
-        private var elementRawTextAcc: String = ""
-        private var rawTextAcc: String = ""
-        private var currentLanguage: Language?
-        private var currentCSSSelector: String?
-        private var ignoredNode: Node?
 
-        private init(baseLocator: Locator, startElement: Element?) {
-            self.baseLocator = baseLocator
-            self.startElement = startElement
-        }
+        /// Text since the beginning of the current segment, after coalescing
+        /// whitespaces.
+        private var textAcc = StringBuilder()
+
+        /// Text content since the beginning of the resource, including
+        /// whitespaces.
+        private var wholeRawTextAcc: String?
+
+        /// Text content since the beginning of the current element, including
+        /// whitespaces.
+        private var elementRawTextAcc = ""
+
+        /// Text content since the beginning of the current segment, including
+        /// whitespaces.
+        private var rawTextAcc = ""
+
+        /// Language of the current segment.
+        private var currentLanguage: Language?
+
+        /// CSS selector of the current element.
+        private var currentCSSSelector: String?
+
+        /// LIFO stack of the current element's block ancestors.
+        private var breadcrumbs: [Element] = []
 
         public func head(_ node: Node, _ depth: Int) throws {
-            guard ignoredNode == nil else {
-                return
-            }
-            guard !node.isHidden else {
-                ignoredNode = node
-                return
-            }
+            if let node = node as? Element {
+                if node.isBlock() {
+                    breadcrumbs.append(node)
+                }
 
-            if let elem = node as? Element {
-                currentElement = elem
+                let tag = node.tagNameNormal()
 
-                let tag = elem.tagNameNormal()
+                lazy var elementLocator: Locator = baseLocator.copy(
+                    locations: {
+                        $0.otherLocations = [
+                            "cssSelector": (try? node.cssSelector()) as Any,
+                        ]
+                    }
+                )
 
                 if tag == "br" {
                     flushText()
+
                 } else if tag == "img" {
                     flushText()
-
-                    if
-                        let href = try elem.attr("src")
-                        .takeUnlessEmpty()
-                        .map({ HREF($0, relativeTo: baseLocator.href).string })
-                    {
+                    try node.srcRelativeToHREF(baseLocator.href).map { href in
                         var attributes: [ContentAttribute] = []
-                        if let alt = try elem.attr("alt").takeUnlessEmpty() {
+                        if let alt = try node.attr("alt").takeUnlessEmpty() {
                             attributes.append(ContentAttribute(key: .accessibilityLabel, value: alt))
                         }
 
                         elements.append(ImageContentElement(
-                            locator: baseLocator.copy(
-                                locations: {
-                                    $0 = Locator.Locations(
-                                        otherLocations: ["cssSelector": (try? elem.cssSelector()) as Any]
-                                    )
-                                }
-                            ),
+                            locator: elementLocator,
                             embeddedLink: Link(href: href),
                             caption: nil, // FIXME: Get the caption from figcaption
                             attributes: attributes
                         ))
                     }
 
-                } else if elem.isBlock() {
-                    segmentsAcc.removeAll()
-                    textAcc.clear()
-                    rawTextAcc = ""
-                    currentCSSSelector = try elem.cssSelector()
+                } else if tag == "audio" || tag == "video" {
+                    flushText()
+
+                    let link: Link? = try {
+                        if let href = try node.srcRelativeToHREF(baseLocator.href) {
+                            return Link(href: href)
+                        } else {
+                            let sources = try node.select("source")
+                                .compactMap { source in
+                                    try source.srcRelativeToHREF(baseLocator.href).map { href in
+                                        try Link(href: href, type: source.attr("type").takeUnlessEmpty())
+                                    }
+                                }
+
+                            return sources.first?.copy(alternates: Array(sources.dropFirst(1)))
+                        }
+                    }()
+
+                    if let link = link {
+                        switch tag {
+                        case "audio":
+                            elements.append(AudioContentElement(locator: elementLocator, embeddedLink: link))
+                        case "video":
+                            elements.append(VideoContentElement(locator: elementLocator, embeddedLink: link))
+                        default:
+                            break
+                        }
+                    }
+
+                } else if node.isBlock() {
+                    flushText()
+                    currentCSSSelector = try node.cssSelector()
                 }
             }
         }
 
         func tail(_ node: Node, _ depth: Int) throws {
-            if ignoredNode == node {
-                ignoredNode = nil
-            }
-
             if let node = node as? TextNode {
+                let wholeText = node.getWholeText()
+                guard !wholeText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    return
+                }
+
                 let language = try node.language().map { Language(code: .bcp47($0)) }
                 if currentLanguage != language {
                     flushSegment()
                     currentLanguage = language
                 }
 
-                rawTextAcc += try Parser.unescapeEntities(node.getWholeText(), false)
-                try appendNormalisedText(of: node)
+                let text = try Parser.unescapeEntities(wholeText, false)
+                rawTextAcc += text
+                try appendNormalisedText(text)
 
             } else if let node = node as? Element {
                 if node.isBlock() {
+                    assert(breadcrumbs.last == node)
                     flushText()
+                    breadcrumbs.removeLast()
                 }
             }
         }
 
-        private func appendNormalisedText(of textNode: TextNode) throws {
-            let text = try Parser.unescapeEntities(textNode.getWholeText(), false)
-            return StringUtil.appendNormalisedWhitespace(textAcc, string: text, stripLeading: lastCharIsWhitespace())
+        private func appendNormalisedText(_ text: String) throws {
+            StringUtil.appendNormalisedWhitespace(textAcc, string: text, stripLeading: lastCharIsWhitespace())
         }
 
         private func lastCharIsWhitespace() -> Bool {
-            textAcc.toString().last?.isWhitespace ?? false
+            guard let lastChar = textAcc.toString().last else {
+                return false
+            }
+
+            return lastChar.isWhitespace || lastChar.isNewline
         }
 
         private func flushText() {
             flushSegment()
+
+            if startIndex == 0, startElement != nil, breadcrumbs.last == startElement {
+                startIndex = elements.count
+            }
+
             guard !segmentsAcc.isEmpty else {
                 return
             }
 
-            if startElement != nil, currentElement == startElement {
-                startIndex = elements.count
+            // Trim the end of the last segment's text to get a cleaner output
+            // for the TextContentElement. Only whitespaces between the
+            // segments are meaningful.
+            if var segment = segmentsAcc.last {
+                segment.text = segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                segmentsAcc[segmentsAcc.count - 1] = segment
             }
-            elements.append(TextContentElement(
-                locator: baseLocator.copy(
-                    locations: { [self] in
-                        $0 = Locator.Locations(
-                            otherLocations: [
-                                "cssSelector": currentCSSSelector as Any,
-                            ]
-                        )
-                    },
-                    text: { [self] in
-                        $0 = Locator.Text(
-                            highlight: elementRawTextAcc
-                        )
-                    }
-                ),
-                role: .body,
-                segments: segmentsAcc
-            ))
+
+            elements.append(
+                TextContentElement(
+                    locator: baseLocator.copy(
+                        locations: {
+                            if let selector = self.currentCSSSelector {
+                                $0.otherLocations["cssSelector"] = selector
+                            }
+                        },
+                        text: {
+                            $0 = Locator.Text.trimming(
+                                text: self.elementRawTextAcc,
+                                before: self.segmentsAcc.first?.locator.text.before
+                            )
+                        }
+                    ),
+                    role: .body,
+                    segments: segmentsAcc
+                )
+            )
             elementRawTextAcc = ""
             segmentsAcc.removeAll()
         }
@@ -236,7 +349,7 @@ public class HTMLResourceContentIterator: ContentIterator {
             var text = textAcc.toString()
             let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-            if !text.isEmpty {
+            if !trimmedText.isEmpty {
                 if segmentsAcc.isEmpty {
                     let whitespaceSuffix = text.last
                         .takeIf { $0.isWhitespace || $0.isNewline }
@@ -254,16 +367,14 @@ public class HTMLResourceContentIterator: ContentIterator {
                 segmentsAcc.append(TextContentElement.Segment(
                     locator: baseLocator.copy(
                         locations: { [self] in
-                            $0 = Locator.Locations(
-                                otherLocations: [
-                                    "cssSelector": currentCSSSelector as Any,
-                                ]
-                            )
+                            $0.otherLocations = [
+                                "cssSelector": currentCSSSelector as Any,
+                            ]
                         },
                         text: { [self] in
-                            $0 = Locator.Text(
-                                before: String(wholeRawTextAcc.suffix(50)),
-                                highlight: rawTextAcc // FIXME: custom length
+                            $0 = Locator.Text.trimming(
+                                text: rawTextAcc,
+                                before: (wholeRawTextAcc?.suffix(beforeMaxLength)).map { String($0) }
                             )
                         }
                     ),
@@ -272,8 +383,10 @@ public class HTMLResourceContentIterator: ContentIterator {
                 ))
             }
 
-            wholeRawTextAcc += rawTextAcc
-            elementRawTextAcc += rawTextAcc
+            if rawTextAcc != "" {
+                wholeRawTextAcc = (wholeRawTextAcc ?? "") + rawTextAcc
+                elementRawTextAcc += rawTextAcc
+            }
             rawTextAcc = ""
             textAcc.clear()
         }
@@ -281,8 +394,10 @@ public class HTMLResourceContentIterator: ContentIterator {
 }
 
 private extension Node {
-    // FIXME: Setup ignore conditions
-    var isHidden: Bool { false }
+    func srcRelativeToHREF(_ baseHREF: String) throws -> String? {
+        try attr("src").takeUnlessEmpty()
+            .map { HREF($0, relativeTo: baseHREF).string }
+    }
 
     func language() throws -> String? {
         try attr("xml:lang").takeUnlessEmpty()
@@ -299,5 +414,60 @@ private extension Node {
 private extension String {
     func takeUnlessEmpty() -> String? {
         isEmpty ? nil : self
+    }
+}
+
+private extension ContentElement {
+    func copy(progression: Double?, totalProgression: Double?) -> ContentElement {
+        func update(_ locator: Locator) -> Locator {
+            locator.copy(locations: {
+                $0.progression = progression
+                $0.totalProgression = totalProgression
+            })
+        }
+
+        switch self {
+        case var e as TextContentElement:
+            e.locator = update(e.locator)
+            e.segments = e.segments.map { segment in
+                var segment = segment
+                segment.locator = update(segment.locator)
+                return segment
+            }
+            return e
+
+        case var e as AudioContentElement:
+            e.locator = update(e.locator)
+            return e
+
+        case var e as ImageContentElement:
+            e.locator = update(e.locator)
+            return e
+
+        case var e as VideoContentElement:
+            e.locator = update(e.locator)
+            return e
+
+        default:
+            return self
+        }
+    }
+}
+
+private extension Locator.Text {
+    static func trimming(text: String, before: String?) -> Locator.Text {
+        let leadingWhitespaceIdx = text.firstIndex { !$0.isWhitespace && !$0.isNewline } ?? text.startIndex
+        let leadingWhitespace = String(text[..<leadingWhitespaceIdx])
+
+        let trailingWhitespaceIdx = text.lastIndex { !$0.isWhitespace && !$0.isNewline }
+            .map { text.index(after: $0) }
+            ?? text.endIndex
+        let trailingWhitespace = String(text[trailingWhitespaceIdx...])
+
+        return Locator.Text(
+            after: trailingWhitespace.takeUnlessEmpty(),
+            before: ((before ?? "") + leadingWhitespace).takeUnlessEmpty(),
+            highlight: String(text[leadingWhitespaceIdx ..< trailingWhitespaceIdx])
+        )
     }
 }

--- a/Sources/Shared/Publication/Services/Content/Iterators/PublicationContentIterator.swift
+++ b/Sources/Shared/Publication/Services/Content/Iterators/PublicationContentIterator.swift
@@ -6,11 +6,18 @@
 
 import Foundation
 
-/// Creates a `ContentIterator` instance for the `resource`, starting from the given `locator`.
-///
-/// - Returns: nil if the resource format is not supported.
-public typealias ResourceContentIteratorFactory =
-    (_ resource: Resource, _ locator: Locator) -> ContentIterator?
+public protocol ResourceContentIteratorFactory {
+    /// Creates a `ContentIterator` instance for the `resource`, starting from
+    /// the given `locator`.
+    ///
+    /// - Returns: nil if the resource format is not supported.
+    func make(
+        publication: Publication,
+        readingOrderIndex: Int,
+        resource: Resource,
+        locator: Locator
+    ) -> ContentIterator?
+}
 
 /// A composite [Content.Iterator] which iterates through a whole [publication] and delegates the
 /// iteration inside a given resource to media type-specific iterators.
@@ -117,7 +124,14 @@ public class PublicationContentIterator: ContentIterator, Loggable {
 
         let resource = publication.get(link)
         return resourceContentIteratorFactories
-            .first { factory in factory(resource, locator) }
+            .first { factory in
+                factory.make(
+                    publication: publication,
+                    readingOrderIndex: index,
+                    resource: resource,
+                    locator: locator
+                )
+            }
             .map { IndexedIterator(index: index, iterator: $0) }
     }
 }

--- a/Sources/Streamer/Parser/EPUB/EPUBParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBParser.swift
@@ -81,7 +81,7 @@ public final class EPUBParser: PublicationParser {
             servicesBuilder: .init(
                 content: DefaultContentService.makeFactory(
                     resourceContentIteratorFactories: [
-                        HTMLResourceContentIterator.makeFactory(),
+                        HTMLResourceContentIterator.Factory(),
                     ]
                 ),
                 positions: EPUBPositionsService.makeFactory(reflowableStrategy: reflowablePositionsStrategy),

--- a/Sources/Streamer/Parser/Readium/ReadiumWebPubParser.swift
+++ b/Sources/Streamer/Parser/Readium/ReadiumWebPubParser.swift
@@ -99,7 +99,7 @@ public class ReadiumWebPubParser: PublicationParser, Loggable {
                     $0.setSearchServiceFactory(_StringSearchService.makeFactory())
                     $0.setContentServiceFactory(DefaultContentService.makeFactory(
                         resourceContentIteratorFactories: [
-                            HTMLResourceContentIterator.makeFactory(),
+                            HTMLResourceContentIterator.Factory(),
                         ]
                     ))
                 }

--- a/Tests/SharedTests/Publication/Services/Content/Iterators/HTMLResourceContentIteratorTests.swift
+++ b/Tests/SharedTests/Publication/Services/Content/Iterators/HTMLResourceContentIteratorTests.swift
@@ -209,7 +209,10 @@ class HTMLResourceContentIteratorTest: XCTestCase {
 
     func testStartingFromCSSSelector() {
         let iter = iterator(html, start: locator(selector: "#pgepubid00498 > p:nth-child(3)"))
-        XCTAssertEqual(Array(elements[2...]), iter.elements())
+        XCTAssertEqual(elements[2], try iter.next()?.equatable())
+        XCTAssertEqual(elements[3], try iter.next()?.equatable())
+        XCTAssertEqual(elements[4], try iter.next()?.equatable())
+        XCTAssertNil(try iter.next())
     }
 
     func testCallingPreviousWhenStartingFromCSSSelector() {
@@ -320,7 +323,10 @@ class HTMLResourceContentIteratorTest: XCTestCase {
             ).equatable(),
         ]
 
-        XCTAssertEqual(expectedElements, iterator(html).elements())
+        let iter = iterator(html)
+        XCTAssertEqual(expectedElements[0], try iter.next()?.equatable())
+        XCTAssertEqual(expectedElements[1], try iter.next()?.equatable())
+        XCTAssertNil(try iter.next())
     }
 
     func testIteratingOverAudioElements() {
@@ -354,7 +360,10 @@ class HTMLResourceContentIteratorTest: XCTestCase {
             ).equatable(),
         ]
 
-        XCTAssertEqual(expectedElements, iterator(html).elements())
+        let iter = iterator(html)
+        XCTAssertEqual(expectedElements[0], try iter.next()?.equatable())
+        XCTAssertEqual(expectedElements[1], try iter.next()?.equatable())
+        XCTAssertNil(try iter.next())
     }
 
     func testIteratingOverVideoElements() {
@@ -388,7 +397,10 @@ class HTMLResourceContentIteratorTest: XCTestCase {
             ).equatable(),
         ]
 
-        XCTAssertEqual(expectedElements, iterator(html).elements())
+        let iter = iterator(html)
+        XCTAssertEqual(expectedElements[0], try iter.next()?.equatable())
+        XCTAssertEqual(expectedElements[1], try iter.next()?.equatable())
+        XCTAssertNil(try iter.next())
     }
 
     func testIteratingOverElementContainingTextAndChildElements() {
@@ -485,16 +497,6 @@ class HTMLResourceContentIteratorTest: XCTestCase {
         XCTAssertEqual(expectedElements[1], try iter.next()?.equatable())
         XCTAssertEqual(expectedElements[2], try iter.next()?.equatable())
         XCTAssertNil(try iter.next())
-    }
-}
-
-private extension ContentIterator {
-    func elements() -> [AnyEquatableContentElement] {
-        var elements: [AnyEquatableContentElement] = []
-        while let next = try? next() {
-            elements.append(AnyEquatableContentElement(next))
-        }
-        return elements
     }
 }
 

--- a/Tests/SharedTests/Publication/Services/Content/Iterators/HTMLResourceContentIteratorTests.swift
+++ b/Tests/SharedTests/Publication/Services/Content/Iterators/HTMLResourceContentIteratorTests.swift
@@ -1,0 +1,505 @@
+//
+//  Copyright 2023 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import R2Shared
+import XCTest
+
+class HTMLResourceContentIteratorTest: XCTestCase {
+    private let link = Link(href: "/dir/res.xhtml", type: "application/xhtml+xml")
+    private let locator = Locator(href: "/dir/res.xhtml", type: "application/xhtml+xml")
+
+    private let html = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE html>
+    <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="en">
+        <head>
+            <title>Section IV: FAIRY STORIES—MODERN FANTASTIC TALES</title>
+            <link href="css/epub.css" type="text/css" rel="stylesheet" />
+        </head>
+        <body>
+             <section id="pgepubid00498">
+                 <div class="center"><span epub:type="pagebreak" title="171" id="Page_171">171</span></div>
+                 <h3>INTRODUCTORY</h3>
+
+                 <p>The difficulties of classification are very apparent here, and once more it must be noted that illustrative and practical purposes rather than logical ones are served by the arrangement adopted. The modern fanciful story is here placed next to the real folk story instead of after all the groups of folk products. The Hebrew stories at the beginning belong quite as well, perhaps even better, in Section V, while the stories at the end of Section VI shade off into the more modern types of short tales.</p>
+                 <p><span>The child's natural literature.</span> The world has lost certain secrets as the price of an advancing civilization.</p>
+                 <p>Without discussing the limits of the culture-epoch theory of human development as a complete guide in education, it is clear that the young child passes through a period when his mind looks out upon the world in a manner analogous to that of the folk as expressed in their literature.</p>
+            </section>
+        </body>
+    </html>
+    """
+
+    private lazy var elements: [AnyEquatableContentElement] = [
+        TextContentElement(
+            locator: locator(
+                progression: 0.0,
+                selector: "#pgepubid00498 > div.center",
+                before: nil,
+                highlight: "171"
+            ),
+            role: .body,
+            segments: [
+                TextContentElement.Segment(
+                    locator: locator(
+                        progression: 0.0,
+                        selector: "#pgepubid00498 > div.center",
+                        before: nil,
+                        highlight: "171"
+                    ),
+                    text: "171",
+                    attributes: [ContentAttribute(key: .language, value: Language("en"))]
+                ),
+            ]
+        ).equatable(),
+        TextContentElement(
+            locator: locator(
+                progression: 0.2,
+                selector: "#pgepubid00498 > h3",
+                before: "171",
+                highlight: "INTRODUCTORY"
+            ),
+            role: .body,
+            segments: [
+                TextContentElement.Segment(
+                    locator: locator(
+                        progression: 0.2,
+                        selector: "#pgepubid00498 > h3",
+                        before: "171",
+                        highlight: "INTRODUCTORY"
+                    ),
+                    text: "INTRODUCTORY",
+                    attributes: [ContentAttribute(key: .language, value: Language("en"))]
+                ),
+            ]
+        ).equatable(),
+        TextContentElement(
+            locator: locator(
+                progression: 0.4,
+                selector: "#pgepubid00498 > p:nth-child(3)",
+                before: "171INTRODUCTORY",
+                highlight: "The difficulties of classification are very apparent here, and once more it must be noted that illustrative and practical purposes rather than logical ones are served by the arrangement adopted. The modern fanciful story is here placed next to the real folk story instead of after all the groups of folk products. The Hebrew stories at the beginning belong quite as well, perhaps even better, in Section V, while the stories at the end of Section VI shade off into the more modern types of short tales."
+            ),
+            role: .body,
+            segments: [
+                TextContentElement.Segment(
+                    locator: locator(
+                        progression: 0.4,
+                        selector: "#pgepubid00498 > p:nth-child(3)",
+                        before: "171INTRODUCTORY",
+                        highlight: "The difficulties of classification are very apparent here, and once more it must be noted that illustrative and practical purposes rather than logical ones are served by the arrangement adopted. The modern fanciful story is here placed next to the real folk story instead of after all the groups of folk products. The Hebrew stories at the beginning belong quite as well, perhaps even better, in Section V, while the stories at the end of Section VI shade off into the more modern types of short tales."
+                    ),
+                    text: "The difficulties of classification are very apparent here, and once more it must be noted that illustrative and practical purposes rather than logical ones are served by the arrangement adopted. The modern fanciful story is here placed next to the real folk story instead of after all the groups of folk products. The Hebrew stories at the beginning belong quite as well, perhaps even better, in Section V, while the stories at the end of Section VI shade off into the more modern types of short tales.",
+                    attributes: [ContentAttribute(key: .language, value: Language("en"))]
+                ),
+            ]
+        ).equatable(),
+        TextContentElement(
+            locator: locator(
+                progression: 0.6,
+                selector: "#pgepubid00498 > p:nth-child(4)",
+                before: "ade off into the more modern types of short tales.",
+                highlight: "The child's natural literature. The world has lost certain secrets as the price of an advancing civilization."
+            ),
+            role: .body,
+            segments: [
+                TextContentElement.Segment(
+                    locator: locator(
+                        progression: 0.6,
+                        selector: "#pgepubid00498 > p:nth-child(4)",
+                        before: "ade off into the more modern types of short tales.",
+                        highlight: "The child's natural literature. The world has lost certain secrets as the price of an advancing civilization."
+                    ),
+                    text: "The child's natural literature. The world has lost certain secrets as the price of an advancing civilization.",
+                    attributes: [ContentAttribute(key: .language, value: Language("en"))]
+                ),
+            ]
+        ).equatable(),
+        TextContentElement(
+            locator: locator(
+                progression: 0.8,
+                selector: "#pgepubid00498 > p:nth-child(5)",
+                before: "secrets as the price of an advancing civilization.",
+                highlight: "Without discussing the limits of the culture-epoch theory of human development as a complete guide in education, it is clear that the young child passes through a period when his mind looks out upon the world in a manner analogous to that of the folk as expressed in their literature."
+            ),
+            role: .body,
+            segments: [
+                TextContentElement.Segment(
+                    locator: locator(
+                        progression: 0.8,
+                        selector: "#pgepubid00498 > p:nth-child(5)",
+                        before: "secrets as the price of an advancing civilization.",
+                        highlight: "Without discussing the limits of the culture-epoch theory of human development as a complete guide in education, it is clear that the young child passes through a period when his mind looks out upon the world in a manner analogous to that of the folk as expressed in their literature."
+                    ),
+                    text: "Without discussing the limits of the culture-epoch theory of human development as a complete guide in education, it is clear that the young child passes through a period when his mind looks out upon the world in a manner analogous to that of the folk as expressed in their literature.",
+                    attributes: [ContentAttribute(key: .language, value: Language("en"))]
+                ),
+            ]
+        ).equatable(),
+    ]
+
+    private func locator(
+        progression: Double? = nil,
+        selector: String? = nil,
+        before: String? = nil,
+        highlight: String? = nil,
+        after: String? = nil
+    ) -> Locator {
+        locator.copy(
+            locations: {
+                $0.progression = progression
+                if let selector = selector {
+                    $0.otherLocations = ["cssSelector": selector]
+                }
+            },
+            text: {
+                $0.after = after
+                $0.before = before
+                $0.highlight = highlight
+            }
+        )
+    }
+
+    private func iterator(
+        _ html: String,
+        start startLocator: Locator? = nil,
+        totalProgressionRange: ClosedRange<Double>? = nil
+    ) -> HTMLResourceContentIterator {
+        HTMLResourceContentIterator(
+            resource: DataResource(link: link, string: html),
+            totalProgressionRange: totalProgressionRange,
+            locator: startLocator ?? locator()
+        )
+    }
+
+    func testIterateFromStartToFinish() throws {
+        let iter = iterator(html)
+        XCTAssertEqual(elements[0], try iter.next()?.equatable())
+        XCTAssertEqual(elements[1], try iter.next()?.equatable())
+        XCTAssertEqual(elements[2], try iter.next()?.equatable())
+        XCTAssertEqual(elements[3], try iter.next()?.equatable())
+        XCTAssertEqual(elements[4], try iter.next()?.equatable())
+        XCTAssertNil(try iter.next())
+    }
+
+    func testPreviousIsNullFromTheBeginning() {
+        let iter = iterator(html)
+        XCTAssertNil(try iter.previous())
+    }
+
+    func testNextReturnsTheFirstElementFromTheBeginning() {
+        let iter = iterator(html)
+        XCTAssertEqual(elements[0], try iter.next()?.equatable())
+    }
+
+    func testNextThenPreviousReturnsNull() {
+        let iter = iterator(html)
+        XCTAssertEqual(elements[0], try iter.next()?.equatable())
+        XCTAssertNil(try iter.previous())
+    }
+
+    func testNextTwiceThenPreviousReturnsTheFirstElement() {
+        let iter = iterator(html)
+        XCTAssertEqual(elements[0], try iter.next()?.equatable())
+        XCTAssertEqual(elements[1], try iter.next()?.equatable())
+        XCTAssertEqual(elements[0], try iter.previous()?.equatable())
+    }
+
+    func testStartingFromCSSSelector() {
+        let iter = iterator(html, start: locator(selector: "#pgepubid00498 > p:nth-child(3)"))
+        XCTAssertEqual(Array(elements[2...]), iter.elements())
+    }
+
+    func testCallingPreviousWhenStartingFromCSSSelector() {
+        let iter = iterator(html, start: locator(selector: "#pgepubid00498 > p:nth-child(3)"))
+        XCTAssertEqual(elements[1], try iter.previous()?.equatable())
+    }
+
+    func testStartingFromCSSSelectorToBlockElementContainingInlineElement() {
+        let nbspHtml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr">
+        <body>
+            <p>Tout au loin sur la chaussée, aussi loin qu’on pouvait voir</p>
+            <p>Lui, notre colonel, savait peut-être pourquoi ces deux gens-là tiraient <span>[...]</span> On buvait de la bière sucrée.</p>
+        </body>
+        </html>
+        """
+
+        let iter = iterator(nbspHtml, start: locator(selector: ":root > :nth-child(2) > :nth-child(2)"))
+
+        let expectedElement = TextContentElement(
+            locator: locator(
+                progression: 0.5,
+                selector: "html > body > p:nth-child(2)",
+                before: "oin sur la chaussée, aussi loin qu’on pouvait voir",
+                highlight: "Lui, notre colonel, savait peut-être pourquoi ces deux gens-là tiraient [...] On buvait de la bière sucrée."
+            ),
+            role: .body,
+            segments: [
+                TextContentElement.Segment(
+                    locator: locator(
+                        progression: 0.5,
+                        selector: "html > body > p:nth-child(2)",
+                        before: "oin sur la chaussée, aussi loin qu’on pouvait voir",
+                        highlight: "Lui, notre colonel, savait peut-être pourquoi ces deux gens-là tiraient [...] On buvait de la bière sucrée."
+                    ),
+                    text: "Lui, notre colonel, savait peut-être pourquoi ces deux gens-là tiraient [...] On buvait de la bière sucrée.",
+                    attributes: [ContentAttribute(key: .language, value: Language("fr"))]
+                ),
+            ]
+        )
+
+        XCTAssertEqual(expectedElement.equatable(), try iter.next()?.equatable())
+    }
+
+    func testStartingFromCSSSelectorUsingRootSelector() {
+        let nbspHtml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr">
+        <head></head>
+        <body>
+            <p>Tout au loin sur la chaussée, aussi loin qu’on pouvait voir</p>
+            <p>Lui, notre colonel, savait peut-être pourquoi ces deux gens-là tiraient <span>[...]</span> On buvait de la bière sucrée.</p>
+        </body>
+        </html>
+        """
+
+        let iter = iterator(nbspHtml, start: locator(selector: ":root > :nth-child(2) > :nth-child(2)"))
+
+        let expectedElement = TextContentElement(
+            locator: locator(
+                progression: 0.5,
+                selector: "html > body > p:nth-child(2)",
+                before: "oin sur la chaussée, aussi loin qu’on pouvait voir",
+                highlight: "Lui, notre colonel, savait peut-être pourquoi ces deux gens-là tiraient [...] On buvait de la bière sucrée."
+            ),
+            role: .body,
+            segments: [
+                TextContentElement.Segment(
+                    locator: locator(
+                        progression: 0.5,
+                        selector: "html > body > p:nth-child(2)",
+                        before: "oin sur la chaussée, aussi loin qu’on pouvait voir",
+                        highlight: "Lui, notre colonel, savait peut-être pourquoi ces deux gens-là tiraient [...] On buvait de la bière sucrée."
+                    ),
+                    text: "Lui, notre colonel, savait peut-être pourquoi ces deux gens-là tiraient [...] On buvait de la bière sucrée.",
+                    attributes: [ContentAttribute(key: .language, value: Language("fr"))]
+                ),
+            ]
+        )
+
+        XCTAssertEqual(expectedElement.equatable(), try iter.next()?.equatable())
+    }
+
+    func testIteratingOverImageElements() {
+        let html = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <html xmlns="http://www.w3.org/1999/xhtml">
+            <body>
+                <img src="image.png"/>
+                <img src="../cover.jpg" alt="Accessibility description" />
+            </body>
+            </html>
+        """
+
+        let expectedElements: [AnyEquatableContentElement] = [
+            ImageContentElement(
+                locator: locator(progression: 0.0, selector: "html > body > img:nth-child(1)"),
+                embeddedLink: Link(href: "/dir/image.png"),
+                caption: nil,
+                attributes: []
+            ).equatable(),
+            ImageContentElement(
+                locator: locator(progression: 0.5, selector: "html > body > img:nth-child(2)"),
+                embeddedLink: Link(href: "/cover.jpg"),
+                caption: nil,
+                attributes: [ContentAttribute(key: .accessibilityLabel, value: "Accessibility description")]
+            ).equatable(),
+        ]
+
+        XCTAssertEqual(expectedElements, iterator(html).elements())
+    }
+
+    func testIteratingOverAudioElements() {
+        let html = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        <body>
+            <audio src="audio.mp3" />
+            <audio>
+                <source src="audio.mp3" type="audio/mp3" />
+                <source src="audio.ogg" type="audio/ogg" />
+            </audio>
+        </body>
+        </html>
+        """
+
+        let expectedElements: [AnyEquatableContentElement] = [
+            AudioContentElement(
+                locator: locator(progression: 0.0, selector: "html > body > audio:nth-child(1)"),
+                embeddedLink: Link(href: "/dir/audio.mp3"),
+                attributes: []
+            ).equatable(),
+            AudioContentElement(
+                locator: locator(progression: 0.5, selector: "html > body > audio:nth-child(2)"),
+                embeddedLink: Link(
+                    href: "/dir/audio.mp3",
+                    type: "audio/mp3",
+                    alternates: [Link(href: "/dir/audio.ogg", type: "audio/ogg")]
+                ),
+                attributes: []
+            ).equatable(),
+        ]
+
+        XCTAssertEqual(expectedElements, iterator(html).elements())
+    }
+
+    func testIteratingOverVideoElements() {
+        let html = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        <body>
+            <video src="video.mp4" />
+            <video>
+                <source src="video.mp4" type="video/mp4" />
+                <source src="video.m4v" type="video/x-m4v" />
+            </video>
+        </body>
+        </html>
+        """
+
+        let expectedElements: [AnyEquatableContentElement] = [
+            VideoContentElement(
+                locator: locator(progression: 0.0, selector: "html > body > video:nth-child(1)"),
+                embeddedLink: Link(href: "/dir/video.mp4"),
+                attributes: []
+            ).equatable(),
+            VideoContentElement(
+                locator: locator(progression: 0.5, selector: "html > body > video:nth-child(2)"),
+                embeddedLink: Link(
+                    href: "/dir/video.mp4",
+                    type: "video/mp4",
+                    alternates: [Link(href: "/dir/video.m4v", type: "video/x-m4v")]
+                ),
+                attributes: []
+            ).equatable(),
+        ]
+
+        XCTAssertEqual(expectedElements, iterator(html).elements())
+    }
+
+    func testIteratingOverElementContainingTextAndChildElements() {
+        let html = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        <body>
+            <ol class="decimal" id="c06-list-0001">
+                <li id="c06-li-0001">Let&#39;s start at the top&#8212;the <i>source of ideas</i>.
+                    <aside><div class="top hr"><hr/></div>
+                    <section class="feature1">
+                        <p id="c06-para-0019"><i>While almost everyone today claims to be Agile, what I&#39;ve just described is very much a <i>waterfall</i> process.</i></p>
+                    </section>
+                    Trailing text
+                </li>
+            </ol>
+        </body>
+        </html>
+        """
+
+        let expectedElements: [AnyEquatableContentElement] = [
+            TextContentElement(
+                locator: locator(
+                    progression: 0.0,
+                    selector: "#c06-li-0001",
+                    highlight: "Let's start at the top—the source of ideas.",
+                    after: "\n            "
+                ),
+                role: .body,
+                segments: [
+                    TextContentElement.Segment(
+                        locator: locator(
+                            progression: 0.0,
+                            selector: "#c06-li-0001",
+                            highlight: "Let's start at the top—the source of ideas.",
+                            after: "\n            "
+                        ),
+                        text: "Let's start at the top—the source of ideas.",
+                        attributes: []
+                    ),
+                ],
+                attributes: []
+            ).equatable(),
+            TextContentElement(
+                locator: locator(
+                    progression: 1 / 3.0,
+                    selector: "#c06-para-0019",
+                    before: "start at the top—the source of ideas.\n            ",
+                    highlight: "While almost everyone today claims to be Agile, what I've just described is very much a waterfall process."
+                ),
+                role: .body,
+                segments: [
+                    TextContentElement.Segment(
+                        locator: locator(
+                            progression: 1 / 3.0,
+                            selector: "#c06-para-0019",
+                            before: "start at the top—the source of ideas.\n            ",
+                            highlight: "While almost everyone today claims to be Agile, what I've just described is very much a waterfall process."
+                        ),
+                        text: "While almost everyone today claims to be Agile, what I've just described is very much a waterfall process.",
+                        attributes: []
+                    ),
+                ],
+                attributes: []
+            ).equatable(),
+            TextContentElement(
+                locator: locator(
+                    progression: 2 / 3.0,
+                    selector: "#c06-para-0019",
+                    before: "e just described is very much a waterfall process.\n            \n            ",
+                    highlight: "Trailing text",
+                    after: "\n        "
+                ),
+                role: .body,
+                segments: [
+                    TextContentElement.Segment(
+                        locator: locator(
+                            progression: 2 / 3.0,
+                            selector: "#c06-para-0019",
+                            before: "e just described is very much a waterfall process.\n            ",
+                            highlight: "Trailing text",
+                            after: "\n        "
+                        ),
+                        text: "Trailing text",
+                        attributes: []
+                    ),
+                ],
+                attributes: []
+            ).equatable(),
+        ]
+
+        let iter = iterator(html)
+        XCTAssertEqual(expectedElements[0], try iter.next()?.equatable())
+        XCTAssertEqual(expectedElements[1], try iter.next()?.equatable())
+        XCTAssertEqual(expectedElements[2], try iter.next()?.equatable())
+        XCTAssertNil(try iter.next())
+    }
+}
+
+private extension ContentIterator {
+    func elements() -> [AnyEquatableContentElement] {
+        var elements: [AnyEquatableContentElement] = []
+        while let next = try? next() {
+            elements.append(AnyEquatableContentElement(next))
+        }
+        return elements
+    }
+}
+
+private extension ContentElement {
+    func equatable() -> AnyEquatableContentElement {
+        AnyEquatableContentElement(self)
+    }
+}


### PR DESCRIPTION
### Added

#### Streamer

* The EPUB content iterator now returns `audio` and `video` elements and fill in the `progression` and `totalProgression` locator properties.

### Changed

#### Navigator

* `EPUBNavigatorViewController.firstVisibleElementLocator()` now returns the first *block* element that is visible on the screen, even if it starts on previous pages.
    * This is used to make sure the user will not miss any context when restoring a TTS session in the middle of a resource.

### Fixed

#### Streamer

* Fix issue with the TTS starting from the beginning of the chapter instead of the current position.

---
* Compute a `progression` and `totalProgression` in the HTML content iterator locators.
* Optimize computation of a locator substring.
* Parse inline text nodes in an element containing more children elements.
* Locate starting location when in an empty element.
* Improve handling of whitespaces in `Locator.Text`.