### PR TITLE
Fix pausing the `PublicationSpeechSynthesizer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file. Take a look
 * Fixed the audio session kept opened while the app is in the background and paused.
 * Fixed the **Attribute dir redefined** error when the EPUB resource already has a `dir` attribute.
 * [#309](https://github.com/readium/swift-toolkit/issues/309) Fixed restoring the EPUB location when the application was killed in the background (contributed by [@triin-ko](https://github.com/readium/swift-toolkit/pull/311)).
+* Fixed pausing the `PublicationSpeechSynthesizer` right before starting the utterance.
 
 #### Streamer
 

--- a/Sources/Navigator/TTS/AVTTSEngine.swift
+++ b/Sources/Navigator/TTS/AVTTSEngine.swift
@@ -267,7 +267,10 @@ public class AVTTSEngine: NSObject, TTSEngine, AVSpeechSynthesizerDelegate, Logg
         case let (.playing(current), .didFinish(finished)) where current == finished:
             state = .stopped
             didChangePlaying(false)
-            current.completion(.success(()))
+
+            if !current.isCancelled {
+                current.completion(.success(()))
+            }
 
         case let (.playing(current), .play(next)):
             state = .stopping(current, queued: next)

--- a/Sources/Navigator/TTS/PublicationSpeechSynthesizer.swift
+++ b/Sources/Navigator/TTS/PublicationSpeechSynthesizer.swift
@@ -225,8 +225,6 @@ public class PublicationSpeechSynthesizer: Loggable {
 
     /// Plays the given `utterance` with the TTS `engine`.
     private func play(_ utterance: Utterance) {
-        state = .playing(utterance, range: nil)
-
         currentTask = engine.speak(
             TTSUtterance(
                 text: utterance.text,
@@ -267,6 +265,8 @@ public class PublicationSpeechSynthesizer: Loggable {
                 }
             }
         )
+
+        state = .playing(utterance, range: nil)
     }
 
     /// Returns the user selected voice if it's compatible with the utterance language. Otherwise, falls back on


### PR DESCRIPTION
### Fixed
#### Navigator

* Fixed pausing the `PublicationSpeechSynthesizer` right before starting the utterance.
