### PR TITLE
Added custom readingOrder to EPubNavigationViewController

### DIFF
--- a/Sources/Navigator/EPUB/EPUBSpread.swift
+++ b/Sources/Navigator/EPUB/EPUBSpread.swift
@@ -117,15 +117,15 @@ struct EPUBSpread: Loggable {
     ///   - publication: The Publication to build the spreads for.
     ///   - readingProgression: Reading progression direction used to layout the pages.
     ///   - spread: Indicates whether two pages are displayed side-by-side.
-    static func makeSpreads(for publication: Publication, readingProgression: ReadingProgression, spread: Bool) -> [EPUBSpread] {
+  static func makeSpreads(for publication: Publication, readingOrder: [Link], readingProgression: ReadingProgression, spread: Bool) -> [EPUBSpread] {
         spread
-            ? makeTwoPagesSpreads(for: publication, readingProgression: readingProgression)
-            : makeOnePageSpreads(for: publication, readingProgression: readingProgression)
+            ? makeTwoPagesSpreads(for: publication, readingOrder: readingOrder, readingProgression: readingProgression)
+            : makeOnePageSpreads(for: publication, readingOrder: readingOrder, readingProgression: readingProgression)
     }
 
     /// Builds a list of one-page spreads for the given Publication.
-    private static func makeOnePageSpreads(for publication: Publication, readingProgression: ReadingProgression) -> [EPUBSpread] {
-        publication.readingOrder.map {
+    private static func makeOnePageSpreads(for publication: Publication, readingOrder: [Link], readingProgression: ReadingProgression) -> [EPUBSpread] {
+        readingOrder.map {
             EPUBSpread(
                 spread: false,
                 links: [$0],
@@ -136,7 +136,7 @@ struct EPUBSpread: Loggable {
     }
 
     /// Builds a list of two-page spreads for the given Publication.
-    private static func makeTwoPagesSpreads(for publication: Publication, readingProgression: ReadingProgression) -> [EPUBSpread] {
+    private static func makeTwoPagesSpreads(for publication: Publication, readingOrder: [Link], readingProgression: ReadingProgression) -> [EPUBSpread] {
         /// Builds two-pages spreads from a list of links and a spread accumulator.
         func makeSpreads(for links: [Link], in spreads: [EPUBSpread] = []) -> [EPUBSpread] {
             var links = links
@@ -185,7 +185,7 @@ struct EPUBSpread: Loggable {
             }
         }
 
-        return makeSpreads(for: publication.readingOrder)
+        return makeSpreads(for: readingOrder)
     }
 }
 


### PR DESCRIPTION
To be able to show non-linear resources this commit adds an optional and extra parameter to the EPubNavigationViewController which is by default set to be the publication's readingOrder.

This lets us show non-linear resources or navigate to internal resources in separate views. This can be used to solve issues like Impossible to open resource with linear=no #330.