### PR TITLE
Support for background playback with `PublicationSpeechSynthesizer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,25 @@ All notable changes to this project will be documented in this file. Take a look
 
 ## [Unreleased]
 
+### Added
+
+#### Navigator
+
+* The `PublicationSpeechSynthesizer` (TTS) now supports background playback by default.
+    * You will need to enable the **Audio Background Mode** in your app's build info.
+
 ### Fixed
 
 #### Navigator
 
 * Improved performance when adding hundreds of HTML decorations at once.
+* Fixed broadcasting the `PublicationSpeechSynthesizer` with AirPlay when the screen is locked.
+
+### Changed
+
+#### Navigator
+
+* You need to provide the configuration of the Audio Session to the constructor of `PublicationSpeechSynthesizer`, instead of `AVTTSEngine`.
 
 
 ## [2.5.1]

--- a/Sources/Navigator/TTS/PublicationSpeechSynthesizer.swift
+++ b/Sources/Navigator/TTS/PublicationSpeechSynthesizer.swift
@@ -4,6 +4,7 @@
 //  available in the top-level LICENSE file of the project.
 //
 
+import AVFoundation
 import Foundation
 import R2Shared
 
@@ -35,10 +36,14 @@ public class PublicationSpeechSynthesizer: Loggable {
     public struct Configuration: Equatable {
         /// Language overriding the publication one.
         public var defaultLanguage: Language?
+
         /// Identifier for the voice used to speak the utterances.
         public var voiceIdentifier: String?
 
-        public init(defaultLanguage: Language? = nil, voiceIdentifier: String? = nil) {
+        public init(
+            defaultLanguage: Language? = nil,
+            voiceIdentifier: String? = nil
+        ) {
             self.defaultLanguage = defaultLanguage
             self.voiceIdentifier = voiceIdentifier
         }
@@ -46,7 +51,7 @@ public class PublicationSpeechSynthesizer: Loggable {
 
     /// An utterance is an arbitrary text (e.g. sentence) extracted from the publication, that can be synthesized by
     /// the TTS engine.
-    public struct Utterance {
+    public struct Utterance: Equatable {
         /// Text to be spoken.
         public let text: String
         /// Locator to the utterance in the publication.
@@ -56,7 +61,7 @@ public class PublicationSpeechSynthesizer: Loggable {
     }
 
     /// Represents a state of the `PublicationSpeechSynthesizer`.
-    public enum State {
+    public enum State: Equatable {
         /// The synthesizer is completely stopped and must be (re)started from a given locator.
         case stopped
 
@@ -66,11 +71,24 @@ public class PublicationSpeechSynthesizer: Loggable {
         /// The TTS engine is synthesizing the associated utterance.
         /// `range` will be regularly updated while the utterance is being played.
         case playing(Utterance, range: Locator?)
+
+        var isPlaying: Bool {
+            switch self {
+            case .stopped, .paused:
+                return false
+            case .playing:
+                return true
+            }
+        }
     }
 
     /// Current state of the `PublicationSpeechSynthesizer`.
     public private(set) var state: State = .stopped {
         didSet {
+            if oldValue.isPlaying != state.isPlaying {
+                _AudioSession.shared.user(audioSessionUser, didChangePlaying: state.isPlaying)
+            }
+
             delegate?.publicationSpeechSynthesizer(self, stateDidChange: state)
         }
     }
@@ -93,6 +111,8 @@ public class PublicationSpeechSynthesizer: Loggable {
     /// - Parameters:
     ///   - publication: Publication which will be iterated through and synthesized.
     ///   - config: Initial TTS configuration.
+    ///   - audioSessionConfig: Configuration of the audio session used to play
+    ///     the utterances.
     ///   - engineFactory: Factory to create an instance of `TtsEngine`. Defaults to `AVTTSEngine`.
     ///   - tokenizerFactory: Factory to create a `ContentTokenizer` which will be used to
     ///     split each `ContentElement` item into smaller chunks. Splits by sentences by default.
@@ -100,6 +120,10 @@ public class PublicationSpeechSynthesizer: Loggable {
     public init?(
         publication: Publication,
         config: Configuration = Configuration(),
+        audioSessionConfig: _AudioSession.Configuration = .init(
+            category: .playback,
+            mode: .spokenAudio
+        ),
         engineFactory: @escaping EngineFactory = { AVTTSEngine() },
         tokenizerFactory: @escaping TokenizerFactory = defaultTokenizerFactory,
         delegate: PublicationSpeechSynthesizerDelegate? = nil
@@ -110,6 +134,7 @@ public class PublicationSpeechSynthesizer: Loggable {
 
         self.publication = publication
         self.config = config
+        audioSessionUser = AudioSessionUser(config: audioSessionConfig)
         self.engineFactory = engineFactory
         self.tokenizerFactory = tokenizerFactory
         self.delegate = delegate
@@ -151,6 +176,8 @@ public class PublicationSpeechSynthesizer: Loggable {
 
     /// (Re)starts the synthesizer from the given locator or the beginning of the publication.
     public func start(from startLocator: Locator? = nil) {
+        _AudioSession.shared.start(with: audioSessionUser, isPlaying: false)
+
         currentTask?.cancel()
         publicationIterator = publication.content(from: startLocator)?.iterator()
         playNextUtterance(.forward)
@@ -371,6 +398,24 @@ public class PublicationSpeechSynthesizer: Loggable {
         default:
             return []
         }
+    }
+
+    // MARK: - Audio session
+
+    private let audioSessionUser: AudioSessionUser
+
+    private final class AudioSessionUser: R2Shared._AudioSessionUser {
+        let audioConfiguration: _AudioSession.Configuration
+
+        init(config: _AudioSession.Configuration) {
+            audioConfiguration = config
+        }
+
+        deinit {
+            _AudioSession.shared.end(for: self)
+        }
+
+        func play() {}
     }
 }
 

--- a/Sources/Shared/Toolkit/Media/AudioSession.swift
+++ b/Sources/Shared/Toolkit/Media/AudioSession.swift
@@ -27,7 +27,7 @@ public extension _AudioSessionUser {
 /// **WARNING:** This API is experimental and may change or be removed in a future release without
 /// notice. Use with caution.
 public final class _AudioSession: Loggable {
-    public struct Configuration {
+    public struct Configuration: Equatable {
         let category: AVAudioSession.Category
         let mode: AVAudioSession.Mode
         let routeSharingPolicy: AVAudioSession.RouteSharingPolicy

--- a/TestApp/Sources/App/AppModule.swift
+++ b/TestApp/Sources/App/AppModule.swift
@@ -38,7 +38,7 @@ final class AppModule {
         opds = OPDSModule(delegate: self)
 
         // Set Readium 2's logging minimum level.
-        R2EnableLog(withMinimumSeverityLevel: .warning)
+        R2EnableLog(withMinimumSeverityLevel: .debug)
     }
 
     private(set) lazy var aboutViewController: UIViewController = {

--- a/TestApp/Sources/App/AppModule.swift
+++ b/TestApp/Sources/App/AppModule.swift
@@ -38,7 +38,7 @@ final class AppModule {
         opds = OPDSModule(delegate: self)
 
         // Set Readium 2's logging minimum level.
-        R2EnableLog(withMinimumSeverityLevel: .debug)
+        R2EnableLog(withMinimumSeverityLevel: .warning)
     }
 
     private(set) lazy var aboutViewController: UIViewController = {

--- a/TestApp/Sources/Info.plist
+++ b/TestApp/Sources/Info.plist
@@ -204,6 +204,11 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>processing</string>
+	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/TestApp/Sources/Reader/Common/TTS/TTSViewModel.swift
+++ b/TestApp/Sources/Reader/Common/TTS/TTSViewModel.swift
@@ -6,9 +6,9 @@
 
 import Combine
 import Foundation
+import MediaPlayer
 import R2Navigator
 import R2Shared
-import MediaPlayer
 
 final class TTSViewModel: ObservableObject, Loggable {
     struct State: Equatable {
@@ -145,7 +145,7 @@ final class TTSViewModel: ObservableObject, Loggable {
     private func setupNowPlaying() {
         _NowPlayingInfo.shared.media = .init(
             title: publication.metadata.title,
-            artist: publication.metadata.authors.map { $0.name }.joined(separator: ", "),
+            artist: publication.metadata.authors.map(\.name).joined(separator: ", "),
             artwork: publication.cover
         )
 


### PR DESCRIPTION
### Added

#### Navigator

* The `PublicationSpeechSynthesizer` (TTS) now supports background playback by default.
    * You will need to enable the **Audio Background Mode** in your app's build info.

### Fixed

#### Navigator

* Fixed broadcasting the `PublicationSpeechSynthesizer` with AirPlay when the screen is locked.

### Changed

#### Navigator

* You need to provide the configuration of the Audio Session to the constructor of `PublicationSpeechSynthesizer`, instead of `AVTTSEngine`.