### PR TITLE
Adjust the audio session strategy for the `AudioNavigator`

### DIFF
--- a/Sources/Navigator/Audiobook/AudioNavigator.swift
+++ b/Sources/Navigator/Audiobook/AudioNavigator.swift
@@ -31,9 +31,8 @@ open class _AudioNavigator: _MediaNavigator, AudioSessionUser, Loggable {
             playbackRefreshInterval: TimeInterval = 0.5,
             audioSession: AudioSession.Configuration = .init(
                 category: .playback,
-                mode: .default,
-                routeSharingPolicy: .longForm,
-                options: []
+                mode: .spokenAudio,
+                routeSharingPolicy: .longFormAudio
             )
         ) {
             self.playbackRefreshInterval = playbackRefreshInterval

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed.js
@@ -8732,17 +8732,22 @@ const attributeBlacklistMatch = (0,_utilities_data_js__WEBPACK_IMPORTED_MODULE_1
     "ng-*",
 ]);
 /**
+ * Prevents errors when attribute name contains a colon (e.g. "xlink:href").
+ */
+function sanitizeAttributeName(name) {
+    return name.replace(/:/g, "\\:");
+}
+/**
  * Get simplified attribute selector for an element.
  */
-function attributeNodeToSimplifiedSelector({ nodeName, }) {
-    return `[${nodeName}]`;
+function attributeNodeToSimplifiedSelector({ name, }) {
+    return `[${name}]`;
 }
 /**
  * Get attribute selector for an element.
  */
-function attributeNodeToSelector({ nodeName, nodeValue, }) {
-    const selector = `[${nodeName}='${(0,_utilities_selectors_js__WEBPACK_IMPORTED_MODULE_0__.sanitizeSelectorItem)(nodeValue)}']`;
-    return selector;
+function attributeNodeToSelector({ name, value, }) {
+    return `[${name}='${value}']`;
 }
 /**
  * Checks whether attribute should be used as a selector.
@@ -8756,10 +8761,19 @@ function isValidAttributeNode({ nodeName }, element) {
     return !attributeBlacklistMatch(nodeName);
 }
 /**
+ * Sanitize all attribute data. We want to do it once, before we start to generate simplified/full selectors from the same data.
+ */
+function sanitizeAttributeData({ nodeName, nodeValue }) {
+    return {
+        name: sanitizeAttributeName(nodeName),
+        value: (0,_utilities_selectors_js__WEBPACK_IMPORTED_MODULE_0__.sanitizeSelectorItem)(nodeValue),
+    };
+}
+/**
  * Get attribute selectors for an element.
  */
 function getElementAttributeSelectors(element) {
-    const validAttributes = Array.from(element.attributes).filter((attributeNode) => isValidAttributeNode(attributeNode, element));
+    const validAttributes = Array.from(element.attributes).filter((attributeNode) => isValidAttributeNode(attributeNode, element)).map(sanitizeAttributeData);
     return [
         ...validAttributes.map(attributeNodeToSimplifiedSelector),
         ...validAttributes.map(attributeNodeToSelector),

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
@@ -8732,17 +8732,22 @@ const attributeBlacklistMatch = (0,_utilities_data_js__WEBPACK_IMPORTED_MODULE_1
     "ng-*",
 ]);
 /**
+ * Prevents errors when attribute name contains a colon (e.g. "xlink:href").
+ */
+function sanitizeAttributeName(name) {
+    return name.replace(/:/g, "\\:");
+}
+/**
  * Get simplified attribute selector for an element.
  */
-function attributeNodeToSimplifiedSelector({ nodeName, }) {
-    return `[${nodeName}]`;
+function attributeNodeToSimplifiedSelector({ name, }) {
+    return `[${name}]`;
 }
 /**
  * Get attribute selector for an element.
  */
-function attributeNodeToSelector({ nodeName, nodeValue, }) {
-    const selector = `[${nodeName}='${(0,_utilities_selectors_js__WEBPACK_IMPORTED_MODULE_0__.sanitizeSelectorItem)(nodeValue)}']`;
-    return selector;
+function attributeNodeToSelector({ name, value, }) {
+    return `[${name}='${value}']`;
 }
 /**
  * Checks whether attribute should be used as a selector.
@@ -8756,10 +8761,19 @@ function isValidAttributeNode({ nodeName }, element) {
     return !attributeBlacklistMatch(nodeName);
 }
 /**
+ * Sanitize all attribute data. We want to do it once, before we start to generate simplified/full selectors from the same data.
+ */
+function sanitizeAttributeData({ nodeName, nodeValue }) {
+    return {
+        name: sanitizeAttributeName(nodeName),
+        value: (0,_utilities_selectors_js__WEBPACK_IMPORTED_MODULE_0__.sanitizeSelectorItem)(nodeValue),
+    };
+}
+/**
  * Get attribute selectors for an element.
  */
 function getElementAttributeSelectors(element) {
-    const validAttributes = Array.from(element.attributes).filter((attributeNode) => isValidAttributeNode(attributeNode, element));
+    const validAttributes = Array.from(element.attributes).filter((attributeNode) => isValidAttributeNode(attributeNode, element)).map(sanitizeAttributeData);
     return [
         ...validAttributes.map(attributeNodeToSimplifiedSelector),
         ...validAttributes.map(attributeNodeToSelector),

--- a/Sources/Navigator/TTS/PublicationSpeechSynthesizer.swift
+++ b/Sources/Navigator/TTS/PublicationSpeechSynthesizer.swift
@@ -122,7 +122,8 @@ public class PublicationSpeechSynthesizer: Loggable {
         config: Configuration = Configuration(),
         audioSessionConfig: AudioSession.Configuration = .init(
             category: .playback,
-            mode: .spokenAudio
+            mode: .spokenAudio,
+            routeSharingPolicy: .longFormAudio
         ),
         engineFactory: @escaping EngineFactory = { AVTTSEngine() },
         tokenizerFactory: @escaping TokenizerFactory = defaultTokenizerFactory,


### PR DESCRIPTION
`spokenAudio` is better suited for the `AudioSession` mode, as it will interrupt the audiobook playback when a spoken notification is triggered.


> Appropriate for applications which play spoken audio and wish to be paused (via audio session interruption) rather than ducked if another app (such as a navigation app) plays a spoken audio prompt.  Examples of apps that would use this are podcast players and audio books.  For more information, see the related category option `AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers`.