### PR TITLE
Fix Copy and Share editing actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+#### Navigator
+
+* From iOS 13 to 15, PDF text selection is disabled on protected publications disabling the **Copy** editing action.
+* The **Share** editing action is disabled for any protected publication.
+
 
 ## [2.6.1]
 

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed.js
@@ -2848,8 +2848,7 @@ function nodeTextLength(node) {
       // nb. `textContent` excludes text in comments and processing instructions
       // when called on a parent element, so we don't need to subtract that here.
 
-      return (/** @type {string} */node.textContent.length
-      );
+      return /** @type {string} */node.textContent.length;
     default:
       return 0;
   }

--- a/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
+++ b/Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
@@ -2848,8 +2848,7 @@ function nodeTextLength(node) {
       // nb. `textContent` excludes text in comments and processing instructions
       // when called on a parent element, so we don't need to subtract that here.
 
-      return (/** @type {string} */node.textContent.length
-      );
+      return /** @type {string} */node.textContent.length;
     default:
       return 0;
   }

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -352,8 +352,6 @@ open class EPUBNavigatorViewController: UIViewController,
 
         view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapBackground)))
 
-        viewModel.editingActions.updateSharedMenuController()
-
         reloadSpreads(at: initialLocation, force: false)
 
         applySettings()

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -159,7 +159,7 @@ final class EPUBNavigatorViewModel: Loggable {
         self.config = config
         editingActions = EditingActionsController(
             actions: config.editingActions,
-            rights: publication.rights
+            publication: publication
         )
         self.httpServer = httpServer
         self.publicationEndpoint = publicationEndpoint

--- a/Sources/Navigator/EPUB/EPUBSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBSpreadView.swift
@@ -265,14 +265,6 @@ class EPUBSpreadView: UIView, Loggable, PageView {
         delegate?.spreadView(self, selectionDidChange: text, frame: frame)
     }
 
-    /// Called when the user hit the Share item in the selection context menu.
-    @objc func shareSelection(_ sender: Any?) {
-        guard let shareViewController = viewModel.editingActions.makeShareViewController(from: webView) else {
-            return
-        }
-        delegate?.spreadView(self, present: shareViewController)
-    }
-
     /// Update webview style to userSettings.
     /// To override in subclasses.
     func applySettings() {

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -102,8 +102,8 @@ final class EditingActionsController {
         publication: Publication
     ) {
         self.actions = actions
-        self.rights = publication.rights
-        self.canShare = !publication.isProtected
+        rights = publication.rights
+        canShare = !publication.isProtected
     }
 
     /// Current user selection contents and frame in the publication view.
@@ -134,7 +134,7 @@ final class EditingActionsController {
 
         return delegate?.editingActions(self, canPerformAction: action, for: selection) ?? true
     }
-    
+
     /// Verifies that the user has the rights to use the given `action`.
     private func isActionAllowed(_ action: EditingAction) -> Bool {
         switch action {
@@ -179,7 +179,7 @@ final class EditingActionsController {
     }
 
     // MARK: - Copy
-    
+
     /// Returns whether the copy interaction is at all allowed. It doesn't
     /// guarantee that the next copy action will be valid, if the license
     /// cancels it.

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -10,9 +10,12 @@ import UIKit
 
 /// An `EditingAction` is an item in the text selection menu.
 ///
-/// iOS provides default actions for copy, share, etc. (see `UIMenuController`), but you can provide custom actions
-/// with `EditingAction(title: "Highlight", action: #selector(highlight:))`. Then, implement the selector in one of your
-/// classes in the responder chain. Typically, in the `UIViewController` wrapping the navigator view controller.
+/// iOS provides default actions for copy, share, etc. (see `UIMenuController`),
+/// but you can provide custom actions with
+/// `EditingAction(title: "Highlight", action: #selector(highlight:))`.
+/// Then, implement the selector in one of your classes in the responder chain.
+/// Typically, in the `UIViewController` wrapping the navigator view
+/// controller.
 public struct EditingAction: Hashable {
     /// Default editing actions enabled in the navigator.
     public static var defaultActions: [EditingAction] {
@@ -27,24 +30,24 @@ public struct EditingAction: Hashable {
     /// Not available on iOS 16+
     public static let lookup = EditingAction(kind: .native("_lookup:"))
 
-    /// Look up the text selection in the dictionary (and other sources on iOS 16+).
+    /// Look up the text selection in the dictionary (and other sources on
+    /// iOS 16+).
     ///
-    /// On iOS 16+, enabling this action will show two items: Look Up and Search Web.
+    /// On iOS 16+, enabling this action will show two items: Look Up and
+    /// Search Web.
     public static let define = EditingAction(kind: .native("_define:"))
 
     /// Translate the text selection.
     public static let translate = EditingAction(kind: .native("_translate:"))
 
     /// Share the text selection.
-    ///
-    /// Implementation detail: We use a custom share action to make sure the user is allowed to share the content. We
-    /// can't override the native _share: action since it is private.
-    public static let share = EditingAction(title: R2NavigatorLocalizedString("EditingAction.share"), action: #selector(EPUBSpreadView.shareSelection))
+    public static let share = EditingAction(kind: .native("_share:"))
 
     /// Create a custom editing action.
     ///
-    /// You need to implement the selector in one of your classes in the responder chain. Typically, in the
-    /// `UIViewController` wrapping the navigator view controller.
+    /// You need to implement the selector in one of your classes in the
+    /// responder chain. Typically, in the `UIViewController` wrapping the
+    /// navigator view controller.
     public init(title: String, action: Selector) {
         self.init(kind: .custom(UIMenuItem(title: title, action: action)))
     }
@@ -91,11 +94,16 @@ final class EditingActionsController {
 
     private let actions: [EditingAction]
     private let rights: UserRights
+    private let canShare: Bool
     private var isEnabled = true
 
-    init(actions: [EditingAction], rights: UserRights) {
+    init(
+        actions: [EditingAction],
+        publication: Publication
+    ) {
         self.actions = actions
-        self.rights = rights
+        self.rights = publication.rights
+        self.canShare = !publication.isProtected
     }
 
     /// Current user selection contents and frame in the publication view.
@@ -110,29 +118,53 @@ final class EditingActionsController {
         }
     }
 
+    func canPerformAction(_ action: EditingAction) -> Bool {
+        canPerformAction(action.action)
+    }
+
     func canPerformAction(_ selector: Selector) -> Bool {
         guard
             isEnabled,
             let selection = selection,
-            let action = actions.first(where: { $0.action == selector })
+            let action = actions.first(where: { $0.action == selector }),
+            isActionAllowed(action)
         else {
             return false
         }
 
         return delegate?.editingActions(self, canPerformAction: action, for: selection) ?? true
     }
-
-    func canPerformAction(_ action: EditingAction) -> Bool {
-        canPerformAction(action.action)
+    
+    /// Verifies that the user has the rights to use the given `action`.
+    private func isActionAllowed(_ action: EditingAction) -> Bool {
+        switch action {
+        case .copy:
+            return rights.canCopy
+        case .share:
+            return canShare
+        default:
+            return true
+        }
     }
 
     @available(iOS 13.0, *)
     func buildMenu(with builder: UIMenuBuilder) {
         // On iOS 16, there's a new "Search Web" menu item which is required
         // to enable the define action.
-        if #available(iOS 16.0, *), !actions.contains(.define) {
+        if #available(iOS 16.0, *), !canPerformAction(.define) {
             builder.remove(menu: .lookup)
         }
+        if !canPerformAction(.lookup) {
+            builder.remove(menu: .lookup)
+        }
+        if !canPerformAction(.share) {
+            builder.remove(menu: .share)
+        }
+
+        // Learn is removed as it seems bugged on iOS 17: it opens a Text
+        // Expansion setting which allows to copy the selection.
+        // To reproduce, comment out and select Japanese text on a PDF.
+        builder.remove(menu: .learn)
     }
 
     func updateSharedMenuController() {
@@ -147,10 +179,12 @@ final class EditingActionsController {
     }
 
     // MARK: - Copy
-
-    /// Returns whether the copy interaction is at all allowed. It doesn't guarantee that the next copy action will be valid, if the license cancels it.
+    
+    /// Returns whether the copy interaction is at all allowed. It doesn't
+    /// guarantee that the next copy action will be valid, if the license
+    /// cancels it.
     var canCopy: Bool {
-        canPerformAction(.copy) && rights.canCopy
+        canPerformAction(.copy)
     }
 
     /// Copies the authorized portion of the selection text into the pasteboard.
@@ -164,32 +198,5 @@ final class EditingActionsController {
         }
 
         UIPasteboard.general.string = text
-    }
-
-    // MARK: - Share
-
-    /// Builds a UIActivityViewController to share the authorized contents of the user selection.
-    func makeShareViewController(from contentsView: UIView) -> UIActivityViewController? {
-        // Peeks into the available selection contents authorized for copy.
-        guard
-            let selection = selection,
-            let text = selection.locator.text.highlight
-        else {
-            return nil
-        }
-        guard canCopy, rights.canCopy(text: text) else {
-            delegate?.editingActionsDidPreventCopy(self)
-            return nil
-        }
-
-        let viewController = UIActivityViewController(activityItems: [text], applicationActivities: nil)
-        viewController.completionWithItemsHandler = { _, completed, _, _ in
-            if completed {
-                self.copy()
-            }
-        }
-        viewController.popoverPresentationController?.sourceView = contentsView
-        viewController.popoverPresentationController?.sourceRect = selection.frame ?? .zero
-        return viewController
     }
 }

--- a/Sources/Navigator/PDF/PDFDocumentView.swift
+++ b/Sources/Navigator/PDF/PDFDocumentView.swift
@@ -23,7 +23,7 @@ public final class PDFDocumentView: PDFView {
         // account.
         firstScrollView?.contentInsetAdjustmentBehavior = .never
     }
-    
+
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -44,7 +44,7 @@ public final class PDFDocumentView: PDFView {
         firstScrollView?.contentInset.top = notchAreaInsets.top
         firstScrollView?.contentInset.bottom = notchAreaInsets.bottom
     }
-    
+
     override public func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         super.canPerformAction(action, withSender: sender) && editingActions.canPerformAction(action)
     }
@@ -52,9 +52,9 @@ public final class PDFDocumentView: PDFView {
     override public func copy(_ sender: Any?) {
         editingActions.copy()
     }
-    
+
     @available(iOS 13.0, *)
-    public override func buildMenu(with builder: UIMenuBuilder) {
+    override public func buildMenu(with builder: UIMenuBuilder) {
         editingActions.buildMenu(with: builder)
         super.buildMenu(with: builder)
     }

--- a/Sources/Navigator/PDF/PDFDocumentView.swift
+++ b/Sources/Navigator/PDF/PDFDocumentView.swift
@@ -23,7 +23,7 @@ public final class PDFDocumentView: PDFView {
         // account.
         firstScrollView?.contentInsetAdjustmentBehavior = .never
     }
-
+    
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -44,12 +44,18 @@ public final class PDFDocumentView: PDFView {
         firstScrollView?.contentInset.top = notchAreaInsets.top
         firstScrollView?.contentInset.bottom = notchAreaInsets.bottom
     }
-
+    
     override public func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         super.canPerformAction(action, withSender: sender) && editingActions.canPerformAction(action)
     }
 
     override public func copy(_ sender: Any?) {
         editingActions.copy()
+    }
+    
+    @available(iOS 13.0, *)
+    public override func buildMenu(with builder: UIMenuBuilder) {
+        editingActions.buildMenu(with: builder)
+        super.buildMenu(with: builder)
     }
 }

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -105,7 +105,10 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
         self.publicationEndpoint = publicationEndpoint
         publicationBaseURL = URL(string: baseURL.absoluteString.addingSuffix("/"))!
         self.config = config
-        editingActions = EditingActionsController(actions: config.editingActions, rights: publication.rights)
+        editingActions = EditingActionsController(
+            actions: config.editingActions,
+            publication: publication
+        )
 
         settings = PDFSettings(
             preferences: config.preferences,
@@ -135,7 +138,7 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
         publicationEndpoint = nil
         publicationBaseURL = URL(string: baseURL.absoluteString.addingSuffix("/"))!
         config = Configuration(editingActions: editingActions)
-        self.editingActions = EditingActionsController(actions: editingActions, rights: publication.rights)
+        self.editingActions = EditingActionsController(actions: editingActions, publication: publication)
 
         settings = PDFSettings(
             preferences: config.preferences,
@@ -175,7 +178,7 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
         self.publicationEndpoint = publicationEndpoint
         self.publicationBaseURL = URL(string: publicationBaseURL.absoluteString.addingSuffix("/"))!
         self.config = config
-        editingActions = EditingActionsController(actions: config.editingActions, rights: publication.rights)
+        editingActions = EditingActionsController(actions: config.editingActions, publication: publication)
 
         settings = PDFSettings(
             preferences: config.preferences,
@@ -205,8 +208,6 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
         super.viewDidLoad()
 
         resetPDFView(at: initialLocation)
-
-        editingActions.updateSharedMenuController()
     }
 
     override open func viewWillAppear(_ animated: Bool) {
@@ -541,9 +542,10 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
 
     @objc func selectionDidChange(_ note: Notification) {
         guard
+            ensureSelectionIsAllowed(),
             let pdfView = pdfView,
-            let locator = currentLocation,
             let selection = pdfView.currentSelection,
+            let locator = currentLocation,
             let text = selection.string,
             let page = selection.pages.first
         else {
@@ -558,15 +560,29 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
                 .insetBy(dx: -8, dy: -8)
         )
     }
-
-    @objc private func shareSelection(_ sender: Any?) {
-        guard
-            let pdfView = pdfView,
-            let shareViewController = editingActions.makeShareViewController(from: pdfView)
-        else {
-            return
+    
+    /// From iOS 13 to 15, the Share menu action is impossible to remove without
+    /// resorting to complex method swizzling in the subviews of ``PDFView``.
+    /// (https://stackoverflow.com/a/61361294)
+    ///
+    /// To prevent users from copying the text, we simply disable all text
+    /// selection in this case.
+    private func ensureSelectionIsAllowed() -> Bool {
+        guard !editingActions.canCopy else {
+            return true
         }
-        present(shareViewController, animated: true)
+
+        if #available(iOS 13, *) {
+            if #available(iOS 16, *) {
+                // Do nothing, as the issue is solved since iOS 16.
+            } else {
+                if let pdfView = pdfView, pdfView.currentSelection != nil {
+                    pdfView.clearSelection()
+                }
+                return false
+            }
+        }
+        return true
     }
 
     // MARK: - Navigator

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -560,7 +560,7 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
                 .insetBy(dx: -8, dy: -8)
         )
     }
-    
+
     /// From iOS 13 to 15, the Share menu action is impossible to remove without
     /// resorting to complex method swizzling in the subviews of ``PDFView``.
     /// (https://stackoverflow.com/a/61361294)


### PR DESCRIPTION
### Fixed

#### Navigator

* From iOS 13 to 15, PDF text selection is disabled on protected publications disabling the **Copy** editing action.
* The **Share** editing action is disabled for any protected publication.

---

From iOS 13 to 15, the Share menu action is impossible to remove without resorting to complex [method swizzling in the subviews of `PDFView`](https://stackoverflow.com/a/61361294). To prevent users from copying the text, we simply disable all text selection in this case.