### PR TITLE
Fix 367: Fix initial location when in landscape landscape

### DIFF
--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -166,9 +166,12 @@ open class EPUBNavigatorViewController: UIViewController,
 
         mutating func transition(_ event: Event) -> Bool {
             switch (self, event) {
+            // Loading the spreads is always possible, because it can be triggered by rotating the
+            // screen. In which case it cancels any on-going state.
+            case let (_, .load(locator)):
+                self = .loading(pendingLocator: locator)
+
             // All events are ignored when loading spreads, except for `loaded` and `load`.
-            case (.loading, .load):
-                return true
             case (.loading, .loaded):
                 self = .idle
             case (.loading, _):
@@ -192,11 +195,6 @@ open class EPUBNavigatorViewController: UIViewController,
             case (.moving, .jump),
                  (.moving, .move):
                 return false
-
-            // Loading the spreads is always possible, because it can be triggered by rotating the
-            // screen. In which case it cancels any on-going state.
-            case let (_, .load(locator)):
-                self = .loading(pendingLocator: locator)
 
             default:
                 log(.error, "Invalid event \(event) for state \(self)")


### PR DESCRIPTION
To be able to handle rotation and screen changes which causes a full spread reload we need to cancel any ongoing state when this happens.

Fixes #367