### PR TITLE
Validate `Link`'s `href` when creating a `URL`

### DIFF
--- a/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
+++ b/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
@@ -35,8 +35,10 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate {
 
     /// Creates a new `AVURLAsset` to serve the given `link`.
     func makeAsset(for link: Link) throws -> AVURLAsset {
-        let originalURL = link.url(relativeTo: publication.baseURL)
-        guard var components = URLComponents(url: originalURL.url, resolvingAgainstBaseURL: true) else {
+        guard
+            let originalURL = try? link.url(relativeTo: publication.baseURL),
+            var components = URLComponents(url: originalURL.url, resolvingAgainstBaseURL: true)
+        else {
             throw AssetError.invalidHREF(link.href)
         }
 

--- a/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
+++ b/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
@@ -169,11 +169,13 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
     }
 
     private func imageViewController(at index: Int) -> ImageViewController? {
-        guard publication.readingOrder.indices.contains(index) else {
+        guard
+            publication.readingOrder.indices.contains(index),
+            let url = try? publication.readingOrder[index].url(relativeTo: publicationBaseURL)
+        else {
             return nil
         }
 
-        let url = publication.readingOrder[index].url(relativeTo: publicationBaseURL)
         return ImageViewController(index: index, url: url.url)
     }
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -176,7 +176,7 @@ final class EPUBNavigatorViewModel: Loggable {
     }
 
     func url(to link: Link) -> AnyURL? {
-        link.url(relativeTo: publicationBaseURL)
+        try? link.url(relativeTo: publicationBaseURL)
     }
 
     private func serveFile(at file: FileURL, baseEndpoint: HTTPServerEndpoint) throws -> HTTPURL {

--- a/Sources/Navigator/EPUB/EPUBSpread.swift
+++ b/Sources/Navigator/EPUB/EPUBSpread.swift
@@ -83,7 +83,10 @@ struct EPUBSpread: Loggable {
     ///   - page [left|center|right]: (optional) Page position of the linked resource in the spread.
     func json(forBaseURL baseURL: HTTPURL) -> [[String: Any]] {
         func makeLinkJSON(_ link: Link, page: Presentation.Page? = nil) -> [String: Any]? {
-            let url = link.url(relativeTo: baseURL)
+            guard let url = try? link.url(relativeTo: baseURL) else {
+                return nil
+            }
+            
             let page = page ?? link.properties.page ?? readingProgression.leadingPage
             return [
                 "link": link.json,

--- a/Sources/Navigator/EPUB/EPUBSpread.swift
+++ b/Sources/Navigator/EPUB/EPUBSpread.swift
@@ -86,7 +86,7 @@ struct EPUBSpread: Loggable {
             guard let url = try? link.url(relativeTo: baseURL) else {
                 return nil
             }
-            
+
             let page = page ?? link.properties.page ?? readingProgression.leadingPage
             return [
                 "link": link.json,

--- a/Sources/OPDS/OPDS2Parser.swift
+++ b/Sources/OPDS/OPDS2Parser.swift
@@ -180,7 +180,7 @@ public class OPDS2Parser: Loggable {
                     }
                     for linkDict in links {
                         var link = try Link(json: linkDict)
-                        link.normalizeHREFs(to: feedURL)
+                        try link.normalizeHREFs(to: feedURL)
                         facet.links.append(link)
                     }
                 }
@@ -192,7 +192,7 @@ public class OPDS2Parser: Loggable {
     static func parseLinks(feed: Feed, feedURL: URL, links: [[String: Any]]) throws {
         for linkDict in links {
             var link = try Link(json: linkDict)
-            link.normalizeHREFs(to: feedURL)
+            try link.normalizeHREFs(to: feedURL)
             feed.links.append(link)
         }
     }
@@ -207,7 +207,7 @@ public class OPDS2Parser: Loggable {
     static func parseNavigation(feed: Feed, feedURL: URL, navLinks: [[String: Any]]) throws {
         for navDict in navLinks {
             var link = try Link(json: navDict)
-            link.normalizeHREFs(to: feedURL)
+            try link.normalizeHREFs(to: feedURL)
             feed.navigation.append(link)
         }
     }
@@ -233,7 +233,7 @@ public class OPDS2Parser: Loggable {
                     }
                     for linkDict in links {
                         var link = try Link(json: linkDict)
-                        link.normalizeHREFs(to: feedURL)
+                        try link.normalizeHREFs(to: feedURL)
                         group.links.append(link)
                     }
                 case "navigation":
@@ -242,7 +242,7 @@ public class OPDS2Parser: Loggable {
                     }
                     for linkDict in links {
                         var link = try Link(json: linkDict)
-                        link.normalizeHREFs(to: feedURL)
+                        try link.normalizeHREFs(to: feedURL)
                         group.navigation.append(link)
                     }
                 case "publications":

--- a/Sources/Shared/Fetcher/ArchiveFetcher.swift
+++ b/Sources/Shared/Fetcher/ArchiveFetcher.swift
@@ -28,7 +28,7 @@ public final class ArchiveFetcher: Fetcher, Loggable {
 
     public func get(_ link: Link) -> Resource {
         guard
-            let path = link.url().relativeURL?.path,
+            let path = try? link.url().relativeURL?.path,
             let entry = findEntry(at: path),
             let reader = archive.readEntry(at: entry.path)
         else {

--- a/Sources/Shared/Fetcher/FileFetcher.swift
+++ b/Sources/Shared/Fetcher/FileFetcher.swift
@@ -23,7 +23,7 @@ public final class FileFetcher: Fetcher, Loggable {
     }
 
     public func get(_ link: Link) -> Resource {
-        if let linkHREF = link.url().relativeURL {
+        if let linkHREF = try? link.url().relativeURL {
             for (href, url) in paths {
                 if linkHREF == href {
                     return FileResource(link: link, file: url)

--- a/Sources/Shared/Fetcher/HTTPFetcher.swift
+++ b/Sources/Shared/Fetcher/HTTPFetcher.swift
@@ -21,7 +21,7 @@ public final class HTTPFetcher: Fetcher, Loggable {
     public let links: [Link] = []
 
     public func get(_ link: Link) -> Resource {
-        guard let url = link.url(relativeTo: baseURL).httpURL else {
+        guard let url = try? link.url(relativeTo: baseURL).httpURL else {
             log(.error, "Not a valid HTTP URL: \(link.href)")
             return FailureResource(link: link, error: .badRequest(HTTPError(kind: .malformedRequest(url: link.href))))
         }

--- a/Sources/Shared/Publication/HREFNormalizer.swift
+++ b/Sources/Shared/Publication/HREFNormalizer.swift
@@ -8,27 +8,27 @@ import Foundation
 
 public extension Manifest {
     /// Resolves the HREFs in the ``Manifest`` to the link with `rel="self"`.
-    mutating func normalizeHREFsToSelf() {
-        guard let base = link(withRel: .self)?.url() else {
+    mutating func normalizeHREFsToSelf() throws {
+        guard let base = try link(withRel: .self)?.url() else {
             return
         }
 
-        normalizeHREFs(to: base)
+        try normalizeHREFs(to: base)
     }
 
     /// Resolves the HREFs in the ``Manifest`` to the given `baseURL`.
-    mutating func normalizeHREFs<T: URLConvertible>(to baseURL: T) {
-        transform(HREFNormalizer(baseURL: baseURL))
+    mutating func normalizeHREFs<T: URLConvertible>(to baseURL: T) throws {
+        try transform(HREFNormalizer(baseURL: baseURL))
     }
 }
 
 public extension Link {
     /// Resolves the HREFs in the ``Link`` to the given `baseURL`.
-    mutating func normalizeHREFs<T: URLConvertible>(to baseURL: T?) {
+    mutating func normalizeHREFs<T: URLConvertible>(to baseURL: T?) throws {
         guard let baseURL = baseURL else {
             return
         }
-        transform(HREFNormalizer(baseURL: baseURL))
+        try transform(HREFNormalizer(baseURL: baseURL))
     }
 }
 
@@ -39,12 +39,12 @@ private struct HREFNormalizer: ManifestTransformer, Loggable {
         self.baseURL = baseURL.anyURL
     }
 
-    func transform(link: inout Link) {
+    func transform(link: inout Link) throws {
         guard !link.templated else {
             log(.warning, "Cannot safely resolve a URI template to a base URL before expanding it: \(link.href)")
             return
         }
 
-        link.href = link.url(relativeTo: baseURL).string
+        link.href = try link.url(relativeTo: baseURL).string
     }
 }

--- a/Sources/Shared/Publication/Link.swift
+++ b/Sources/Shared/Publication/Link.swift
@@ -101,9 +101,9 @@ public struct Link: JSONEquatable, Hashable {
             warnings?.log("`href` is required", model: Self.self, source: json)
             throw JSONError.parsing(Self.self)
         }
-        
+
         let templated = (jsonObject["templated"] as? Bool) ?? false
-        
+
         // We support existing publications with incorrect HREFs (not valid percent-encoded
         // URIs). We try to parse them first as valid, but fall back on a percent-decoded
         // path if it fails.
@@ -114,7 +114,7 @@ public struct Link: JSONEquatable, Hashable {
             }
             href = url.string
         }
-        
+
         self.init(
             href: href,
             type: jsonObject["type"] as? String,
@@ -172,7 +172,7 @@ public struct Link: JSONEquatable, Hashable {
         if href.isEmpty {
             href = "#"
         }
-        
+
         guard let url = AnyURL(string: href) else {
             throw LinkError.invalidHREF(href)
         }

--- a/Sources/Shared/Publication/ManifestTransformer.swift
+++ b/Sources/Shared/Publication/ManifestTransformer.swift
@@ -8,101 +8,101 @@ import Foundation
 
 /// Transforms a ``Manifest``'s components.
 public protocol ManifestTransformer {
-    func transform(manifest: inout Manifest)
-    func transform(metadata: inout Metadata)
-    func transform(link: inout Link)
+    func transform(manifest: inout Manifest) throws
+    func transform(metadata: inout Metadata) throws
+    func transform(link: inout Link) throws
 }
 
 public protocol ManifestTransformable {
-    mutating func transform(_ transformer: ManifestTransformer)
+    mutating func transform(_ transformer: ManifestTransformer) throws
 }
 
 public extension ManifestTransformer {
-    func transform(manifest: inout Manifest) {}
-    func transform(metadata: inout Metadata) {}
-    func transform(link: inout Link) {}
+    func transform(manifest: inout Manifest) throws {}
+    func transform(metadata: inout Metadata) throws {}
+    func transform(link: inout Link) throws {}
 }
 
 extension Manifest: ManifestTransformable {
     /// Transforms the receiver ``Manifest``, applying the given `transformer`
     /// to each component.
-    public mutating func transform(_ transformer: ManifestTransformer) {
-        metadata.transform(transformer)
-        links.transform(transformer)
-        readingOrder.transform(transformer)
-        resources.transform(transformer)
-        tableOfContents.transform(transformer)
-        subcollections.transform(transformer)
+    public mutating func transform(_ transformer: ManifestTransformer) throws {
+        try metadata.transform(transformer)
+        try links.transform(transformer)
+        try readingOrder.transform(transformer)
+        try resources.transform(transformer)
+        try tableOfContents.transform(transformer)
+        try subcollections.transform(transformer)
 
-        transformer.transform(manifest: &self)
+        try transformer.transform(manifest: &self)
     }
 }
 
 extension Metadata: ManifestTransformable {
-    public mutating func transform(_ transformer: ManifestTransformer) {
-        subjects.transform(transformer)
-        authors.transform(transformer)
-        translators.transform(transformer)
-        editors.transform(transformer)
-        artists.transform(transformer)
-        illustrators.transform(transformer)
-        letterers.transform(transformer)
-        pencilers.transform(transformer)
-        colorists.transform(transformer)
-        inkers.transform(transformer)
-        narrators.transform(transformer)
-        contributors.transform(transformer)
-        publishers.transform(transformer)
-        imprints.transform(transformer)
-        belongsTo.transform(transformer)
+    public mutating func transform(_ transformer: ManifestTransformer) throws {
+        try subjects.transform(transformer)
+        try authors.transform(transformer)
+        try translators.transform(transformer)
+        try editors.transform(transformer)
+        try artists.transform(transformer)
+        try illustrators.transform(transformer)
+        try letterers.transform(transformer)
+        try pencilers.transform(transformer)
+        try colorists.transform(transformer)
+        try inkers.transform(transformer)
+        try narrators.transform(transformer)
+        try contributors.transform(transformer)
+        try publishers.transform(transformer)
+        try imprints.transform(transformer)
+        try belongsTo.transform(transformer)
 
-        transformer.transform(metadata: &self)
+        try transformer.transform(metadata: &self)
     }
 }
 
 extension PublicationCollection: ManifestTransformable {
-    public mutating func transform(_ transformer: ManifestTransformer) {
-        links.transform(transformer)
-        subcollections.transform(transformer)
+    public mutating func transform(_ transformer: ManifestTransformer) throws {
+        try links.transform(transformer)
+        try subcollections.transform(transformer)
     }
 }
 
 extension Contributor: ManifestTransformable {
-    public mutating func transform(_ transformer: ManifestTransformer) {
-        links.transform(transformer)
+    public mutating func transform(_ transformer: ManifestTransformer) throws {
+        try links.transform(transformer)
     }
 }
 
 extension Subject: ManifestTransformable {
-    public mutating func transform(_ transformer: ManifestTransformer) {
-        links.transform(transformer)
+    public mutating func transform(_ transformer: ManifestTransformer) throws {
+        try links.transform(transformer)
     }
 }
 
 extension Link: ManifestTransformable {
-    public mutating func transform(_ transformer: ManifestTransformer) {
-        alternates.transform(transformer)
-        children.transform(transformer)
+    public mutating func transform(_ transformer: ManifestTransformer) throws {
+        try alternates.transform(transformer)
+        try children.transform(transformer)
 
-        transformer.transform(link: &self)
+        try transformer.transform(link: &self)
     }
 }
 
 extension Array: ManifestTransformable where Element: ManifestTransformable {
-    public mutating func transform(_ transformer: ManifestTransformer) {
-        self = map {
+    public mutating func transform(_ transformer: ManifestTransformer) throws {
+        self = try map {
             var copy = $0
-            copy.transform(transformer)
+            try copy.transform(transformer)
             return copy
         }
     }
 }
 
 extension Dictionary: ManifestTransformable where Value: ManifestTransformable {
-    public mutating func transform(_ transformer: ManifestTransformer) {
-        self = mapValues {
+    public mutating func transform(_ transformer: ManifestTransformer) throws {
+        self = try mapValues {
             var copy = $0
-            copy.transform(transformer)
+            try copy.transform(transformer)
             return copy
         }
     }

--- a/Sources/Shared/Toolkit/HTTP/HTTPRequest.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPRequest.swift
@@ -180,7 +180,7 @@ extension String: HTTPRequestConvertible {
 
 extension Link: HTTPRequestConvertible {
     public func httpRequest() -> HTTPResult<HTTPRequest> {
-        guard let url = url().httpURL else {
+        guard let url = try? url().httpURL else {
             return .failure(HTTPError(kind: .malformedRequest(url: href)))
         }
         return url.httpRequest()

--- a/Sources/Streamer/Parser/Readium/ReadiumWebPubParser.swift
+++ b/Sources/Streamer/Parser/Readium/ReadiumWebPubParser.swift
@@ -59,7 +59,7 @@ public class ReadiumWebPubParser: PublicationParser, Loggable {
         // used to read the manifest file. We use an `HTTPFetcher` instead to serve the remote
         // resources.
         if !isPackage,
-           let baseURL = manifest.link(withRel: .`self`)?.url().httpURL
+           let baseURL = try manifest.link(withRel: .`self`)?.url().httpURL
         {
             fetcher = HTTPFetcher(client: httpClient, baseURL: baseURL)
         }

--- a/Sources/Streamer/Toolkit/Extensions/Fetcher.swift
+++ b/Sources/Streamer/Toolkit/Extensions/Fetcher.swift
@@ -36,8 +36,8 @@ extension Fetcher {
             guard !ignoring(link) else {
                 continue
             }
-            let components = link.url().pathSegments
             guard
+                let components = try? link.url().pathSegments,
                 components.count > 1,
                 title == nil || title == components.first
             else {

--- a/TestApp/Sources/App/AppModule.swift
+++ b/TestApp/Sources/App/AppModule.swift
@@ -86,7 +86,7 @@ extension AppModule: ReaderModuleDelegate {}
 
 extension AppModule: OPDSModuleDelegate {
     func opdsDownloadPublication(_ publication: Publication?, at link: Link, sender: UIViewController) async throws -> Book {
-        let url = link.url(relativeTo: publication?.baseURL)
+        let url = try link.url(relativeTo: publication?.baseURL)
         return try await library.importPublication(from: url.url, sender: sender)
     }
 }

--- a/TestApp/Sources/Common/Publication.swift
+++ b/TestApp/Sources/Common/Publication.swift
@@ -13,7 +13,7 @@ extension Publication {
     var downloadLinks: [Link] {
         links.filter {
             DocumentTypes.main.supportsMediaType($0.type)
-                || DocumentTypes.main.supportsFileExtension($0.url().url.pathExtension)
+                || DocumentTypes.main.supportsFileExtension(try? $0.url().url.pathExtension)
         }
     }
 }

--- a/TestApp/Sources/OPDS/OPDSGroupTableViewCell.swift
+++ b/TestApp/Sources/OPDS/OPDSGroupTableViewCell.swift
@@ -89,7 +89,7 @@ extension OPDSGroupTableViewCell: UICollectionViewDataSource {
                         .joined(separator: ", ")
                 )
 
-                let coverURL: URL? = publication.link(withRel: .cover)?.url(relativeTo: publication.baseURL).url
+                let coverURL: URL? = try? publication.link(withRel: .cover)?.url(relativeTo: publication.baseURL).url
                     ?? publication.images.first.flatMap { URL(string: $0.href) }
 
                 if let coverURL = coverURL {

--- a/TestApp/Sources/OPDS/OPDSPublicationTableViewCell.swift
+++ b/TestApp/Sources/OPDS/OPDSPublicationTableViewCell.swift
@@ -64,7 +64,7 @@ extension OPDSPublicationTableViewCell: UICollectionViewDataSource {
                     .joined(separator: ", ")
             )
 
-            let coverURL: URL? = publication.link(withRel: .cover)?.url(relativeTo: publication.baseURL).url
+            let coverURL: URL? = try? publication.link(withRel: .cover)?.url(relativeTo: publication.baseURL).url
                 ?? publication.images.first.flatMap { URL(string: $0.href) }
 
             if let coverURL = coverURL {

--- a/Tests/SharedTests/Publication/HREFNormalizerTests.swift
+++ b/Tests/SharedTests/Publication/HREFNormalizerTests.swift
@@ -42,9 +42,9 @@ class HREFNormalizerTests: XCTestCase {
         ]
     )
 
-    func testNormalizeManifestHREFsToSelf() {
+    func testNormalizeManifestHREFsToSelf() throws {
         var sut = manifest
-        sut.normalizeHREFsToSelf()
+        try sut.normalizeHREFsToSelf()
         XCTAssertEqual(
             sut,
             Manifest(
@@ -83,9 +83,9 @@ class HREFNormalizerTests: XCTestCase {
         )
     }
 
-    func testNormalizeManifestHREFsToBaseURL() {
+    func testNormalizeManifestHREFsToBaseURL() throws {
         var sut = manifest
-        sut.normalizeHREFs(to: AnyURL(string: "https://other/dir/")!)
+        try sut.normalizeHREFs(to: AnyURL(string: "https://other/dir/")!)
 
         XCTAssertEqual(
             sut,
@@ -125,7 +125,7 @@ class HREFNormalizerTests: XCTestCase {
         )
     }
 
-    func testNormalizeLinkHREFsToBaseURL() {
+    func testNormalizeLinkHREFsToBaseURL() throws {
         var sut = Link(
             href: "href1",
             alternates: [
@@ -149,7 +149,7 @@ class HREFNormalizerTests: XCTestCase {
                 ),
             ]
         )
-        sut.normalizeHREFs(to: AnyURL(string: "https://other/dir/")!)
+        try sut.normalizeHREFs(to: AnyURL(string: "https://other/dir/")!)
 
         XCTAssertEqual(
             sut,

--- a/Tests/SharedTests/Publication/LinkTests.swift
+++ b/Tests/SharedTests/Publication/LinkTests.swift
@@ -260,7 +260,7 @@ class LinkTests: XCTestCase {
             AnyURL(string: "http://test.com/folder/file.html")!
         )
     }
-    
+
     func testURLWithInvalidHREF() {
         XCTAssertThrowsError(try Link(href: "01_Note de l editeur audio.mp3").url()) { error in
             XCTAssertEqual(LinkError.invalidHREF("01_Note de l editeur audio.mp3"), error as? LinkError)

--- a/Tests/SharedTests/Publication/LinkTests.swift
+++ b/Tests/SharedTests/Publication/LinkTests.swift
@@ -70,6 +70,12 @@ class LinkTests: XCTestCase {
         XCTAssertThrowsError(try Link(json: ""))
     }
 
+    func testParseInvalidHREFWithDecodedPathInJSON() throws {
+        let link = try Link(json: ["href": "01_Note de l editeur audio.mp3"])
+        XCTAssertEqual(link, Link(href: "01_Note%20de%20l%20editeur%20audio.mp3"))
+        XCTAssertEqual(try link.url(), AnyURL(string: "01_Note%20de%20l%20editeur%20audio.mp3"))
+    }
+
     func testParseJSONRelAsSingleString() {
         XCTAssertEqual(
             try? Link(json: ["href": "a", "rel": "publication"]),
@@ -223,36 +229,42 @@ class LinkTests: XCTestCase {
         XCTAssertEqual(Link(href: "file.pdf").mediaType, .pdf)
     }
 
-    func testURLRelativeToBaseURL() {
+    func testURLRelativeToBaseURL() throws {
         XCTAssertEqual(
-            Link(href: "folder/file.html").url(relativeTo: AnyURL(string: "http://host/")!),
+            try Link(href: "folder/file.html").url(relativeTo: AnyURL(string: "http://host/")!),
             AnyURL(string: "http://host/folder/file.html")!
         )
     }
 
-    func testURLRelativeToBaseURLWithRootPrefix() {
+    func testURLRelativeToBaseURLWithRootPrefix() throws {
         XCTAssertEqual(
-            Link(href: "file.html").url(relativeTo: AnyURL(string: "http://host/folder/")!),
+            try Link(href: "file.html").url(relativeTo: AnyURL(string: "http://host/folder/")!),
             AnyURL(string: "http://host/folder/file.html")!
         )
     }
 
-    func testURLRelativeToNil() {
+    func testURLRelativeToNil() throws {
         XCTAssertEqual(
-            Link(href: "http://example.com/folder/file.html").url(),
+            try Link(href: "http://example.com/folder/file.html").url(),
             AnyURL(string: "http://example.com/folder/file.html")!
         )
         XCTAssertEqual(
-            Link(href: "folder/file.html").url(),
+            try Link(href: "folder/file.html").url(),
             AnyURL(string: "folder/file.html")!
         )
     }
 
-    func testURLWithAbsoluteHREF() {
+    func testURLWithAbsoluteHREF() throws {
         XCTAssertEqual(
-            Link(href: "http://test.com/folder/file.html").url(relativeTo: AnyURL(string: "http://host/")!),
+            try Link(href: "http://test.com/folder/file.html").url(relativeTo: AnyURL(string: "http://host/")!),
             AnyURL(string: "http://test.com/folder/file.html")!
         )
+    }
+    
+    func testURLWithInvalidHREF() {
+        XCTAssertThrowsError(try Link(href: "01_Note de l editeur audio.mp3").url()) { error in
+            XCTAssertEqual(LinkError.invalidHREF("01_Note de l editeur audio.mp3"), error as? LinkError)
+        }
     }
 
     func testTemplateParameters() {


### PR DESCRIPTION
Some RWPMs contain invalid HREFs (not percent-encoded). This PR adds a conversion step when parsing a JSON in `Link`.