### PR TITLE
Bubble up errors while loading Resources

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,10 +33,12 @@ jobs:
           git diff --exit-code Support/Carthage/Readium.xcodeproj
       - name: Build
         run: |
-          xcodebuild build-for-testing -scheme "$scheme" -destination "platform=$platform,name=$device"
+          set -eo pipefail
+          xcodebuild build-for-testing -scheme "$scheme" -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
       - name: Test
         run: |
-          xcodebuild test-without-building -scheme "$scheme" -destination "platform=$platform,name=$device"
+          set -eo pipefail
+          xcodebuild test-without-building -scheme "$scheme" -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
 
   lint:
     name: Lint
@@ -91,7 +93,8 @@ jobs:
         run: make dev lcp=${{ secrets.LCP_URL_SPM }}
       - name: Build
         run: |
-          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device"
+          set -eo pipefail
+          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
 
   int-spm:
     name: Integration (Swift Package Manager)
@@ -118,7 +121,8 @@ jobs:
         run: make spm lcp=${{ secrets.LCP_URL_SPM }} commit=$commit_sha
       - name: Build
         run: |
-          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device"
+          set -eo pipefail
+          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
 
   int-carthage:
     name: Integration (Carthage)
@@ -145,7 +149,8 @@ jobs:
         run: make carthage lcp=${{ secrets.LCP_URL_CARTHAGE }} commit=$commit_sha
       - name: Build
         run: |
-          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device"
+          set -eo pipefail
+          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
 
   # Warning: This job cannot actually test the state of the current commit,
   # but will check that the latest branch/tag set in the Podspecs are valid.
@@ -168,4 +173,5 @@ jobs:
         run: make cocoapods lcp=${{ secrets.LCP_URL_COCOAPODS }} commit=$commit_sha
       - name: Build
         run: |
-          xcodebuild build -workspace TestApp.xcworkspace -scheme TestApp -destination "platform=$platform,name=$device"
+          set -eo pipefail
+          xcodebuild build -workspace TestApp.xcworkspace -scheme TestApp -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * The `AudioNavigator` API has been promoted to stable and ships with a new Preferences API.
+* The new `NavigatorDelegate.didFailToLoadResourceAt(_:didFailToLoadResourceAt:withError:)` delegate API notifies when an error occurs while loading a publication resource (contributed by [@ettore](https://github.com/readium/swift-toolkit/pull/400)).
 
 ### Fixed
 

--- a/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
+++ b/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
@@ -163,19 +163,20 @@ public class GCDHTTPServer: HTTPServer, Loggable {
             }
 
             log(.warning, "Resource not found for request \(request)")
-            completion(
-                HTTPServerRequest(url: request.url, href: nil),
-                FailureResource(link: Link(href: request.url.absoluteString),
-                                error: .notFound(nil)),
-                nil)
+            completion(HTTPServerRequest(url: request.url, href: nil),
+                       FailureResource(link: Link(href: request.url.absoluteString),
+                                       error: .notFound(nil)),
+                       nil)
         }
     }
 
     // MARK: HTTPServer
 
-    public func serve(at endpoint: HTTPServerEndpoint, 
-                      handler: @escaping (HTTPServerRequest) -> Resource,
-                      failureHandler: FailureHandler?) throws -> URL {
+    public func serve(
+        at endpoint: HTTPServerEndpoint,
+        handler: @escaping (HTTPServerRequest) -> Resource,
+        failureHandler: FailureHandler?
+    ) throws -> URL {
         try queue.sync(flags: .barrier) {
             if case .stopped = state {
                 try start()

--- a/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
+++ b/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
@@ -172,7 +172,7 @@ public class GCDHTTPServer: HTTPServer, Loggable {
 
     // MARK: HTTPServer
 
-    public func serve(at endpoint: HTTPServerEndpoint, handler: @escaping (HTTPServerRequest) -> any Resource) throws -> URL {
+    public func serve(at endpoint: HTTPServerEndpoint, handler: @escaping (HTTPServerRequest) -> Resource) throws -> URL {
         try serve(at: endpoint, handler: handler, failureHandler: nil)
     }
 

--- a/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
+++ b/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
@@ -172,6 +172,10 @@ public class GCDHTTPServer: HTTPServer, Loggable {
 
     // MARK: HTTPServer
 
+    public func serve(at endpoint: HTTPServerEndpoint, handler: @escaping (HTTPServerRequest) -> any Resource) throws -> URL {
+        try serve(at: endpoint, handler: handler, failureHandler: nil)
+    }
+
     public func serve(
         at endpoint: HTTPServerEndpoint,
         handler: @escaping (HTTPServerRequest) -> Resource,

--- a/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
+++ b/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
@@ -101,10 +101,12 @@ public class GCDHTTPServer: HTTPServer, Loggable {
             case let .failure(error):
                 self.log(.error, error)
                 failureHandler?(resource.link.href, request.url, error)
-                response = ReadiumGCDWebServerErrorResponse(statusCode: error.httpStatusCode)
+                response = ReadiumGCDWebServerErrorResponse(
+                    statusCode: error.httpStatusCode,
+                    error: error)
             }
 
-            completion(response)
+            completion(response) // goes back to ReadiumGCDWebServerConnection.m
         }
     }
 

--- a/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
+++ b/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
@@ -61,13 +61,10 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
                 publication: publication,
                 failureHandler: { [weak self] request, error in
                     DispatchQueue.main.async { [weak self] in
-                        guard let self = self else {
+                        guard let self = self, let href = request.href else {
                             return
                         }
-                        self.delegate?.navigator(self,
-                                                 didFailToLoadResourceAt: request.href,
-                                                 url: request.url,
-                                                 withError: error)
+                        self.delegate?.navigator(self, didFailToLoadResourceAt: href, withError: error)
                     }
                 }
             )

--- a/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
+++ b/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
@@ -59,15 +59,15 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
             publicationBaseURL = try httpServer.serve(
                 at: uuidEndpoint,
                 publication: publication,
-                failureHandler: { [weak self] href, url, error in
+                failureHandler: { [weak self] request, error in
                     DispatchQueue.main.async { [weak self] in
                         guard let self = self else {
                             return
                         }
                         self.delegate?.navigator(
                             self,
-                            didFailToLoadResourceAt: href,
-                            url: url,
+                            didFailToLoadResourceAt: request.href,
+                            url: request.url,
                             withError: error)
                     }
                 }

--- a/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
+++ b/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
@@ -64,17 +64,16 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
                         guard let self = self else {
                             return
                         }
-                        self.delegate?.navigator(
-                            self,
-                            didFailToLoadResourceAt: request.href,
-                            url: request.url,
-                            withError: error)
+                        self.delegate?.navigator(self,
+                                                 didFailToLoadResourceAt: request.href,
+                                                 url: request.url,
+                                                 withError: error)
                     }
                 }
             )
         }
 
-        self.publicationBaseURL = URL(string: publicationBaseURL.absoluteString.addingSuffix("/"))!
+        publicationBaseURL = URL(string: publicationBaseURL.absoluteString.addingSuffix("/"))!
     }
 
     @available(*, deprecated, message: "See the 2.5.0 migration guide to migrate the HTTP server")
@@ -91,7 +90,7 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
             publicationEndpoint: nil
         )
 
-        self.publicationBaseURL = URL(string: publicationBaseURL.absoluteString.addingSuffix("/"))!
+        publicationBaseURL = URL(string: publicationBaseURL.absoluteString.addingSuffix("/"))!
     }
 
     private init(

--- a/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
+++ b/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
@@ -40,7 +40,7 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
 
         let publicationEndpoint: HTTPServerEndpoint?
         let uuidEndpoint = UUID().uuidString
-        if let url = publication.baseURL {
+        if publication.baseURL != nil {
             publicationEndpoint = nil
         } else {
             publicationEndpoint = uuidEndpoint
@@ -79,7 +79,7 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
     @available(*, deprecated, message: "See the 2.5.0 migration guide to migrate the HTTP server")
     public convenience init(publication: Publication, initialLocation: Locator? = nil) {
         precondition(!publication.isRestricted, "The provided publication is restricted. Check that any DRM was properly unlocked using a Content Protection.")
-        guard let baseURL = publication.baseURL else {
+        guard publication.baseURL != nil else {
             preconditionFailure("No base URL provided for the publication. Add it to the HTTP server.")
         }
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -947,15 +947,11 @@ extension EPUBNavigatorViewController: EPUBNavigatorViewModelDelegate {
 
     func epubNavigatorViewModel(
         _ viewModel: EPUBNavigatorViewModel,
-        didFailToLoadResourceAt href: String?,
-        url: URL,
+        didFailToLoadResourceAt href: String,
         withError error: ResourceError
     ) {
         DispatchQueue.main.async {
-            self.delegate?.navigator(self,
-                                     didFailToLoadResourceAt: href,
-                                     url: url,
-                                     withError: error)
+            self.delegate?.navigator(self, didFailToLoadResourceAt: href, withError: error)
         }
     }
 }

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -944,6 +944,18 @@ extension EPUBNavigatorViewController: EPUBNavigatorViewModelDelegate {
             }
         }
     }
+
+    func epubNavigatorViewModel(_ viewModel: EPUBNavigatorViewModel,
+                                didFailToLoadResourceAt href: String?,
+                                url: URL?,
+                                withError error: ResourceError) {
+        DispatchQueue.main.async {
+            self.delegate?.navigator(self,
+                                     didFailToLoadResourceAt: href,
+                                     url: url,
+                                     withError: error)
+        }
+    }
 }
 
 extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -947,7 +947,7 @@ extension EPUBNavigatorViewController: EPUBNavigatorViewModelDelegate {
 
     func epubNavigatorViewModel(_ viewModel: EPUBNavigatorViewModel,
                                 didFailToLoadResourceAt href: String?,
-                                url: URL?,
+                                url: URL,
                                 withError error: ResourceError) {
         DispatchQueue.main.async {
             self.delegate?.navigator(self,

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -945,10 +945,12 @@ extension EPUBNavigatorViewController: EPUBNavigatorViewModelDelegate {
         }
     }
 
-    func epubNavigatorViewModel(_ viewModel: EPUBNavigatorViewModel,
-                                didFailToLoadResourceAt href: String?,
-                                url: URL,
-                                withError error: ResourceError) {
+    func epubNavigatorViewModel(
+        _ viewModel: EPUBNavigatorViewModel,
+        didFailToLoadResourceAt href: String?,
+        url: URL,
+        withError error: ResourceError
+    ) {
         DispatchQueue.main.async {
             self.delegate?.navigator(self,
                                      didFailToLoadResourceAt: href,

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -11,10 +11,7 @@ import UIKit
 protocol EPUBNavigatorViewModelDelegate: AnyObject {
     func epubNavigatorViewModel(_ viewModel: EPUBNavigatorViewModel, runScript script: String, in scope: EPUBScriptScope)
     func epubNavigatorViewModelInvalidatePaginationView(_ viewModel: EPUBNavigatorViewModel)
-    func epubNavigatorViewModel(_ viewModel: EPUBNavigatorViewModel,
-                                didFailToLoadResourceAt href: String?,
-                                url: URL,
-                                withError error: ResourceError)
+    func epubNavigatorViewModel(_ viewModel: EPUBNavigatorViewModel, didFailToLoadResourceAt href: String, withError error: ResourceError)
 }
 
 enum EPUBScriptScope {
@@ -83,13 +80,10 @@ final class EPUBNavigatorViewModel: Loggable {
                 at: uuidEndpoint, // serving the chapters endpoint
                 publication: publication,
                 failureHandler: { [weak self] request, error in
-                    guard let self = self else {
+                    guard let self = self, let href = request.href else {
                         return
                     }
-                    self.delegate?.epubNavigatorViewModel(self,
-                                                          didFailToLoadResourceAt: request.href,
-                                                          url: request.url,
-                                                          withError: error)
+                    self.delegate?.epubNavigatorViewModel(self, didFailToLoadResourceAt: href, withError: error)
                 }
             )
         }

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -80,17 +80,16 @@ final class EPUBNavigatorViewModel: Loggable {
             publicationBaseURL = url
         } else {
             publicationBaseURL = try httpServer.serve(
-                at: uuidEndpoint,               //serving the chapters endpoint
+                at: uuidEndpoint, // serving the chapters endpoint
                 publication: publication,
                 failureHandler: { [weak self] request, error in
                     guard let self = self else {
                         return
                     }
-                    self.delegate?.epubNavigatorViewModel(
-                        self,
-                        didFailToLoadResourceAt: request.href,
-                        url: request.url,
-                        withError: error)
+                    self.delegate?.epubNavigatorViewModel(self,
+                                                          didFailToLoadResourceAt: request.href,
+                                                          url: request.url,
+                                                          withError: error)
                 }
             )
         }
@@ -134,7 +133,7 @@ final class EPUBNavigatorViewModel: Loggable {
             useLegacySettings: true
         )
 
-        self.publicationBaseURL = baseURL
+        publicationBaseURL = baseURL
     }
 
     private init(

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -13,7 +13,7 @@ protocol EPUBNavigatorViewModelDelegate: AnyObject {
     func epubNavigatorViewModelInvalidatePaginationView(_ viewModel: EPUBNavigatorViewModel)
     func epubNavigatorViewModel(_ viewModel: EPUBNavigatorViewModel,
                                 didFailToLoadResourceAt href: String?,
-                                url: URL?,
+                                url: URL,
                                 withError error: ResourceError)
 }
 
@@ -82,14 +82,14 @@ final class EPUBNavigatorViewModel: Loggable {
             publicationBaseURL = try httpServer.serve(
                 at: uuidEndpoint,               //serving the chapters endpoint
                 publication: publication,
-                failureHandler: { [weak self] href, url, error in
+                failureHandler: { [weak self] request, error in
                     guard let self = self else {
                         return
                     }
                     self.delegate?.epubNavigatorViewModel(
                         self,
-                        didFailToLoadResourceAt: href,
-                        url: url,
+                        didFailToLoadResourceAt: request.href,
+                        url: request.url,
                         withError: error)
                 }
             )

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -50,7 +50,7 @@ final class EPUBNavigatorViewModel: Loggable {
     ) throws {
         let uuidEndpoint: HTTPServerEndpoint = UUID().uuidString
         let publicationEndpoint: HTTPServerEndpoint?
-        if let url = publication.baseURL {
+        if publication.baseURL != nil {
             publicationEndpoint = nil
         } else {
             publicationEndpoint = uuidEndpoint

--- a/Sources/Navigator/EPUB/EPUBSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBSpreadView.swift
@@ -461,9 +461,8 @@ extension EPUBSpreadView: WKNavigationDelegate {
 
         if navigationAction.navigationType == .linkActivated {
             if let url = navigationAction.request.url {
-                let baseURL = viewModel.publicationBaseURL
                 // Check if url is internal or external
-                if url.host == baseURL.host {
+                if let baseURL = viewModel.publicationBaseURL, url.host == baseURL.host {
                     let href = url.absoluteString.replacingOccurrences(of: baseURL.absoluteString, with: "/")
                     delegate?.spreadView(self, didTapOnInternalLink: href, clickEvent: lastClick)
                 } else {

--- a/Sources/Navigator/Navigator.swift
+++ b/Sources/Navigator/Navigator.swift
@@ -105,7 +105,7 @@ public protocol NavigatorDelegate: AnyObject {
     func navigator(_ navigator: Navigator, shouldNavigateToNoteAt link: Link, content: String, referrer: String?) -> Bool
 
     /// Called when an error occurs while attempting to load a resource.
-    func navigator(_ navigator: Navigator, didFailToLoadResourceAt href: String?, url: URL, withError error: ResourceError)
+    func navigator(_ navigator: Navigator, didFailToLoadResourceAt href: String, withError error: ResourceError)
 }
 
 public extension NavigatorDelegate {
@@ -121,7 +121,7 @@ public extension NavigatorDelegate {
         true
     }
 
-    func navigator(_ navigator: Navigator, didFailToLoadResourceAt href: String?, url: URL, withError error: ResourceError) {}
+    func navigator(_ navigator: Navigator, didFailToLoadResourceAt href: String, withError error: ResourceError) {}
 }
 
 public enum NavigatorError: LocalizedError {

--- a/Sources/Navigator/Navigator.swift
+++ b/Sources/Navigator/Navigator.swift
@@ -120,6 +120,8 @@ public extension NavigatorDelegate {
     func navigator(_ navigator: Navigator, shouldNavigateToNoteAt link: Link, content: String, referrer: String?) -> Bool {
         true
     }
+
+    func navigator(_ navigator: Navigator, didFailToLoadResourceAt href: String?, url: URL, withError error: ResourceError) {}
 }
 
 public enum NavigatorError: LocalizedError {

--- a/Sources/Navigator/Navigator.swift
+++ b/Sources/Navigator/Navigator.swift
@@ -105,7 +105,7 @@ public protocol NavigatorDelegate: AnyObject {
     func navigator(_ navigator: Navigator, shouldNavigateToNoteAt link: Link, content: String, referrer: String?) -> Bool
 
     /// Called when an error occurs while attempting to load a resource.
-    func navigator(_ navigator: Navigator, didFailToLoadResourceAt href: String?, url: URL?, withError error: ResourceError)
+    func navigator(_ navigator: Navigator, didFailToLoadResourceAt href: String?, url: URL, withError error: ResourceError)
 }
 
 public extension NavigatorDelegate {

--- a/Sources/Navigator/Navigator.swift
+++ b/Sources/Navigator/Navigator.swift
@@ -103,6 +103,9 @@ public protocol NavigatorDelegate: AnyObject {
     /// note yourself, using its `content`. `link.type` contains information about the
     /// format of `content` and `referrer`, such as `text/html`.
     func navigator(_ navigator: Navigator, shouldNavigateToNoteAt link: Link, content: String, referrer: String?) -> Bool
+
+    /// Called when an error occurs while attempting to load a resource.
+    func navigator(_ navigator: Navigator, didFailToLoadResourceAt href: String?, url: URL?, withError error: ResourceError)
 }
 
 public extension NavigatorDelegate {

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -179,6 +179,33 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
         }
     }
 
+    private init(
+        publication: Publication,
+        initialLocation: Locator?,
+        httpServer: HTTPServer?,
+        publicationEndpoint: HTTPServerEndpoint?,
+        publicationBaseURL: URL,
+        config: Configuration
+    ) {
+        self.publication = publication
+        self.initialLocation = initialLocation
+        server = httpServer
+        self.publicationEndpoint = publicationEndpoint
+        self.publicationBaseURL = URL(string: publicationBaseURL.absoluteString.addingSuffix("/"))!
+        self.config = config
+        editingActions = EditingActionsController(actions: config.editingActions, publication: publication)
+
+        settings = PDFSettings(
+            preferences: config.preferences,
+            defaults: config.defaults,
+            metadata: publication.metadata
+        )
+
+        super.init(nibName: nil, bundle: nil)
+
+        postInit()
+    }
+
     @available(*, unavailable)
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -90,7 +90,7 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
 
         let uuidEndpoint: HTTPServerEndpoint = UUID().uuidString
         let publicationEndpoint: HTTPServerEndpoint?
-        if let url = publication.baseURL {
+        if publication.baseURL != nil {
             publicationEndpoint = nil
         } else {
             publicationEndpoint = uuidEndpoint

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -75,7 +75,7 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
 
     private let server: HTTPServer?
     private let publicationEndpoint: HTTPServerEndpoint?
-    private let publicationBaseURL: URL
+    private var publicationBaseURL: URL!
 
     public init(
         publication: Publication,
@@ -88,22 +88,18 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
             throw Error.publicationRestricted
         }
 
+        let uuidEndpoint: HTTPServerEndpoint = UUID().uuidString
         let publicationEndpoint: HTTPServerEndpoint?
-        let baseURL: URL
         if let url = publication.baseURL {
             publicationEndpoint = nil
-            baseURL = url
         } else {
-            let endpoint = UUID().uuidString
-            publicationEndpoint = endpoint
-            baseURL = try httpServer.serve(at: endpoint, publication: publication)
+            publicationEndpoint = uuidEndpoint
         }
 
         self.publication = publication
         self.initialLocation = initialLocation
         server = httpServer
         self.publicationEndpoint = publicationEndpoint
-        publicationBaseURL = URL(string: baseURL.absoluteString.addingSuffix("/"))!
         self.config = config
         editingActions = EditingActionsController(
             actions: config.editingActions,
@@ -117,6 +113,23 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
         )
 
         super.init(nibName: nil, bundle: nil)
+
+        if let url = publication.baseURL {
+            publicationBaseURL = url
+        } else {
+            publicationBaseURL = try httpServer.serve(
+                at: uuidEndpoint,
+                publication: publication,
+                failureHandler: { href, url, error in
+                    DispatchQueue.main.async { [weak self] in
+                        guard let self = self else {
+                            return
+                        }
+                        self.delegate?.navigator(self, didFailToLoadResourceAt: href, url: url, withError: error)
+                    }
+                }
+            )
+        }
 
         postInit()
     }
@@ -152,6 +165,8 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
     }
 
     private func postInit() {
+        publicationBaseURL = URL(string: publicationBaseURL.absoluteString.addingSuffix("/"))!
+
         editingActions.delegate = self
 
         // Wraps the PDF factories of publication services to return the currently opened document
@@ -162,33 +177,6 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
                 documentHolder, service.pdfFactory,
             ])
         }
-    }
-
-    private init(
-        publication: Publication,
-        initialLocation: Locator?,
-        httpServer: HTTPServer?,
-        publicationEndpoint: HTTPServerEndpoint?,
-        publicationBaseURL: URL,
-        config: Configuration
-    ) {
-        self.publication = publication
-        self.initialLocation = initialLocation
-        server = httpServer
-        self.publicationEndpoint = publicationEndpoint
-        self.publicationBaseURL = URL(string: publicationBaseURL.absoluteString.addingSuffix("/"))!
-        self.config = config
-        editingActions = EditingActionsController(actions: config.editingActions, publication: publication)
-
-        settings = PDFSettings(
-            preferences: config.preferences,
-            defaults: config.defaults,
-            metadata: publication.metadata
-        )
-
-        super.init(nibName: nil, bundle: nil)
-
-        postInit()
     }
 
     @available(*, unavailable)

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -120,12 +120,16 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
             publicationBaseURL = try httpServer.serve(
                 at: uuidEndpoint,
                 publication: publication,
-                failureHandler: { href, url, error in
+                failureHandler: { request, error in
                     DispatchQueue.main.async { [weak self] in
                         guard let self = self else {
                             return
                         }
-                        self.delegate?.navigator(self, didFailToLoadResourceAt: href, url: url, withError: error)
+                        self.delegate?.navigator(
+                            self,
+                            didFailToLoadResourceAt: request.href,
+                            url: request.url,
+                            withError: error)
                     }
                 }
             )

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -122,13 +122,10 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
                 publication: publication,
                 failureHandler: { request, error in
                     DispatchQueue.main.async { [weak self] in
-                        guard let self = self else {
+                        guard let self = self, let href = request.href else {
                             return
                         }
-                        self.delegate?.navigator(self,
-                                                 didFailToLoadResourceAt: request.href,
-                                                 url: request.url,
-                                                 withError: error)
+                        self.delegate?.navigator(self, didFailToLoadResourceAt: href, withError: error)
                     }
                 }
             )

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -125,11 +125,10 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
                         guard let self = self else {
                             return
                         }
-                        self.delegate?.navigator(
-                            self,
-                            didFailToLoadResourceAt: request.href,
-                            url: request.url,
-                            withError: error)
+                        self.delegate?.navigator(self,
+                                                 didFailToLoadResourceAt: request.href,
+                                                 url: request.url,
+                                                 withError: error)
                     }
                 }
             )

--- a/Sources/Shared/Fetcher/ArchiveFetcher.swift
+++ b/Sources/Shared/Fetcher/ArchiveFetcher.swift
@@ -28,6 +28,7 @@ public final class ArchiveFetcher: Fetcher, Loggable {
             let entry = findEntry(at: link.href),
             let reader = archive.readEntry(at: entry.path)
         else {
+            log(.warning, "Unable to create ArchiveResource from link \(link)")
             return FailureResource(link: link, error: .notFound(nil))
         }
 

--- a/Sources/Shared/Fetcher/FileFetcher.swift
+++ b/Sources/Shared/Fetcher/FileFetcher.swift
@@ -34,6 +34,7 @@ public final class FileFetcher: Fetcher, Loggable {
             }
         }
 
+        log(.warning, "Unable to create FileResource from link \(link)")
         return FailureResource(link: link, error: .notFound(nil))
     }
 

--- a/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
@@ -19,7 +19,7 @@ public protocol HTTPServer {
     ///
     /// - Returns the base URL for this endpoint.
     @discardableResult
-    func serve(at endpoint: HTTPServerEndpoint, 
+    func serve(at endpoint: HTTPServerEndpoint,
                handler: @escaping (HTTPServerRequest) -> Resource) throws -> URL
 
     /// Serves resources at the given `endpoint`.
@@ -30,7 +30,7 @@ public protocol HTTPServer {
     ///
     /// - Returns the base URL for this endpoint.
     @discardableResult
-    func serve(at endpoint: HTTPServerEndpoint, 
+    func serve(at endpoint: HTTPServerEndpoint,
                handler: @escaping (HTTPServerRequest) -> Resource,
                failureHandler: FailureHandler?) throws -> URL
 
@@ -45,8 +45,10 @@ public protocol HTTPServer {
 
 public extension HTTPServer {
     @discardableResult
-    func serve(at endpoint: HTTPServerEndpoint,
-               handler: @escaping (HTTPServerRequest) -> Resource) throws -> URL {
+    func serve(
+        at endpoint: HTTPServerEndpoint,
+        handler: @escaping (HTTPServerRequest) -> Resource
+    ) throws -> URL {
         try serve(at: endpoint, handler: handler, failureHandler: nil)
     }
 
@@ -89,7 +91,7 @@ public extension HTTPServer {
             )
         }
 
-        return try serve(at: endpoint, 
+        return try serve(at: endpoint,
                          handler: handler(request:),
                          failureHandler: failureHandler)
     }
@@ -124,7 +126,6 @@ public extension HTTPServer {
                     error: .notFound(nil)
                 )
             }
-
 
             return publication.get(href)
         }

--- a/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
@@ -101,8 +101,8 @@ public extension HTTPServer {
     /// - Returns the base URL to access the publication's resources on the
     /// server.
     @discardableResult
-    func serve(at endpoint: HTTPServerEndpoint, publication: Publication) throws {
-        try serve(at: endpoint, publication: publication)
+    func serve(at endpoint: HTTPServerEndpoint, publication: Publication) throws -> URL {
+        try serve(at: endpoint, publication: publication, failureHandler: nil)
     }
 
     /// Serves a `publication`'s resources at the given `endpoint`.

--- a/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
@@ -19,8 +19,10 @@ public protocol HTTPServer {
     ///
     /// - Returns the base URL for this endpoint.
     @discardableResult
-    func serve(at endpoint: HTTPServerEndpoint,
-               handler: @escaping (HTTPServerRequest) -> Resource) throws -> URL
+    func serve(
+        at endpoint: HTTPServerEndpoint,
+        handler: @escaping (HTTPServerRequest) -> Resource
+    ) throws -> URL
 
     /// Serves resources at the given `endpoint`.
     ///
@@ -30,9 +32,11 @@ public protocol HTTPServer {
     ///
     /// - Returns the base URL for this endpoint.
     @discardableResult
-    func serve(at endpoint: HTTPServerEndpoint,
-               handler: @escaping (HTTPServerRequest) -> Resource,
-               failureHandler: FailureHandler?) throws -> URL
+    func serve(
+        at endpoint: HTTPServerEndpoint,
+        handler: @escaping (HTTPServerRequest) -> Resource,
+        failureHandler: FailureHandler?
+    ) throws -> URL
 
     /// Registers a `Resource` transformer that will be run on all responses
     /// matching the given `endpoint`.
@@ -47,21 +51,10 @@ public extension HTTPServer {
     @discardableResult
     func serve(
         at endpoint: HTTPServerEndpoint,
-        handler: @escaping (HTTPServerRequest) -> Resource
+        handler: @escaping (HTTPServerRequest) -> Resource,
+        failureHandler: FailureHandler?
     ) throws -> URL {
-        try serve(at: endpoint, handler: handler, failureHandler: nil)
-    }
-
-    /// Serves the local file `url` at the given `endpoint`.
-    ///
-    /// If the provided `url` is a directory, then all the files in the
-    /// directory are served. Subsequent calls with the same served `endpoint`
-    /// overwrite each other.
-    ///
-    /// - Returns the URL to access the file(s) on the server.
-    @discardableResult
-    func serve(at endpoint: HTTPServerEndpoint, contentsOf url: URL) throws -> URL {
-        try serve(at: endpoint, contentsOf: url, failureHandler: nil)
+        try serve(at: endpoint, handler: handler)
     }
 
     /// Serves the local file `url` at the given `endpoint`.
@@ -77,7 +70,7 @@ public extension HTTPServer {
     func serve(
         at endpoint: HTTPServerEndpoint,
         contentsOf url: URL,
-        failureHandler: FailureHandler?
+        failureHandler: FailureHandler? = nil
     ) throws -> URL {
         func handler(request: HTTPServerRequest) -> Resource {
             let file = url.appendingPathComponent(request.href ?? "")
@@ -91,18 +84,11 @@ public extension HTTPServer {
             )
         }
 
-        return try serve(at: endpoint,
-                         handler: handler(request:),
-                         failureHandler: failureHandler)
-    }
-
-    /// Serves a `publication`'s resources at the given `endpoint`.
-    ///
-    /// - Returns the base URL to access the publication's resources on the
-    /// server.
-    @discardableResult
-    func serve(at endpoint: HTTPServerEndpoint, publication: Publication) throws -> URL {
-        try serve(at: endpoint, publication: publication, failureHandler: nil)
+        return try serve(
+            at: endpoint,
+            handler: handler(request:),
+            failureHandler: failureHandler
+        )
     }
 
     /// Serves a `publication`'s resources at the given `endpoint`.
@@ -115,7 +101,7 @@ public extension HTTPServer {
     func serve(
         at endpoint: HTTPServerEndpoint,
         publication: Publication,
-        failureHandler: FailureHandler?
+        failureHandler: FailureHandler? = nil
     ) throws -> URL {
         func handler(request: HTTPServerRequest) -> Resource {
             guard let href = request.href else {
@@ -130,9 +116,11 @@ public extension HTTPServer {
             return publication.get(href)
         }
 
-        return try serve(at: endpoint,
-                         handler: handler(request:),
-                         failureHandler: failureHandler)
+        return try serve(
+            at: endpoint,
+            handler: handler(request:),
+            failureHandler: failureHandler
+        )
     }
 }
 

--- a/TestApp/Sources/Reader/Common/ReaderViewController.swift
+++ b/TestApp/Sources/Reader/Common/ReaderViewController.swift
@@ -107,6 +107,10 @@ class ReaderViewController<N: Navigator>: UIViewController,
         moduleDelegate?.presentError(error, from: self)
     }
 
+    func navigator(_ navigator: any Navigator, didFailToLoadResourceAt href: String, withError error: ResourceError) {
+        log(.error, "Failed to load resource at \(href): \(error)")
+    }
+
     // MARK: - Locations
 
     var currentBookmark: Bookmark? {


### PR DESCRIPTION
Errors are bubbled up to the app via a new NavigatorDelegate method:
```
navigator(_:didFailToLoadResourceAt:url:withError)
```

No breaking changes to the Navigators client-facing APIs.

This solves issue https://github.com/readium/swift-toolkit/issues/398.

The 2nd commit depends on PR https://github.com/readium/GCDWebServer/pull/11. It is not strictly required but it is nice to have, because it attaches the underlying error to the `GCDWebServerErrorResponse`. 