### PR TITLE
Support for the new 2.x LCP Profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+* [#417](https://github.com/readium/swift-toolkit/issues/417) Support for the new 2.x LCP Profiles.
+
 
 ## [2.7.0]
 

--- a/Sources/LCP/License/LicenseValidation.swift
+++ b/Sources/LCP/License/LicenseValidation.swift
@@ -11,6 +11,16 @@ import R2Shared
 private let supportedProfiles = [
     "http://readium.org/lcp/basic-profile",
     "http://readium.org/lcp/profile-1.0",
+    "http://readium.org/lcp/profile-2.0",
+    "http://readium.org/lcp/profile-2.1",
+    "http://readium.org/lcp/profile-2.2",
+    "http://readium.org/lcp/profile-2.3",
+    "http://readium.org/lcp/profile-2.4",
+    "http://readium.org/lcp/profile-2.5",
+    "http://readium.org/lcp/profile-2.6",
+    "http://readium.org/lcp/profile-2.7",
+    "http://readium.org/lcp/profile-2.8",
+    "http://readium.org/lcp/profile-2.9",
 ]
 
 typealias Context = Either<LCPClientContext, StatusError>


### PR DESCRIPTION
### Added

* [#417](https://github.com/readium/swift-toolkit/issues/417) Support for the new 2.x LCP Profiles.

---

* Closes #417 