### PR TITLE
Rename `archive` Link property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+#### Shared
+
+* The `Link` property key for archive-based publication assets (e.g. an EPUB/ZIP) is now `https://readium.org/webpub-manifest/properties#archive` instead of `archive`.
+
 
 ## [3.0.0-alpha.1]
 

--- a/Sources/Shared/Fetcher/ArchiveFetcher.swift
+++ b/Sources/Shared/Fetcher/ArchiveFetcher.swift
@@ -90,10 +90,7 @@ public final class ArchiveFetcher: Fetcher, Loggable {
 private extension ArchiveEntry {
     var linkProperties: [String: Any] {
         [
-            // FIXME: Legacy property, should be removed in 3.0.0
-            "compressedLength": compressedLength as Any,
-
-            "archive": [
+            "https://readium.org/webpub-manifest/properties#archive": [
                 "entryLength": compressedLength ?? length,
                 "isEntryCompressed": compressedLength != nil,
             ] as [String: Any],

--- a/Sources/Shared/Publication/Extensions/Archive/Properties+Archive.swift
+++ b/Sources/Shared/Publication/Extensions/Archive/Properties+Archive.swift
@@ -50,6 +50,6 @@ public extension Properties {
 
     /// Provides information about how the resource is stored in the publication archive.
     var archive: Archive? {
-        try? Archive(json: otherProperties["archive"], warnings: self)
+        try? Archive(json: otherProperties["https://readium.org/webpub-manifest/properties#archive"], warnings: self)
     }
 }

--- a/Tests/SharedTests/Fetcher/ArchiveFetcherTests.swift
+++ b/Tests/SharedTests/Fetcher/ArchiveFetcherTests.swift
@@ -32,8 +32,7 @@ class ArchiveFetcherTests: XCTestCase {
                 ("META-INF/container.xml", "application/xml", 176, true),
             ].map { href, type, entryLength, isCompressed in
                 Link(href: href, type: type, properties: .init([
-                    "compressedLength": (isCompressed ? entryLength : nil) as Any, // legacy
-                    "archive": [
+                    "https://readium.org/webpub-manifest/properties#archive": [
                         "entryLength": entryLength,
                         "isEntryCompressed": isCompressed,
                     ] as [String: Any],
@@ -89,11 +88,10 @@ class ArchiveFetcherTests: XCTestCase {
         AssertJSONEqual(
             resource.link.properties.json,
             [
-                "archive": [
+                "https://readium.org/webpub-manifest/properties#archive": [
                     "entryLength": 595,
                     "isEntryCompressed": true,
                 ] as [String: Any],
-                "compressedLength": 595,
             ] as [String: Any]
         )
     }

--- a/Tests/SharedTests/Publication/Extensions/Archive/Properties+ArchiveTests.swift
+++ b/Tests/SharedTests/Publication/Extensions/Archive/Properties+ArchiveTests.swift
@@ -14,7 +14,7 @@ class PropertiesArchiveTests: XCTestCase {
     }
 
     func testArchive() {
-        let sut = Properties(["archive": [
+        let sut = Properties(["https://readium.org/webpub-manifest/properties#archive": [
             "entryLength": 8273,
             "isEntryCompressed": true,
         ] as [String: Any]])
@@ -23,19 +23,19 @@ class PropertiesArchiveTests: XCTestCase {
     }
 
     func testInvalidArchive() {
-        let sut = Properties(["archive": [
+        let sut = Properties(["https://readium.org/webpub-manifest/properties#archive": [
             "foo": "bar",
         ]])
         XCTAssertNil(sut.archive)
     }
 
     func testIncompleteArchive() {
-        var sut = Properties(["archive": [
+        var sut = Properties(["https://readium.org/webpub-manifest/properties#archive": [
             "entryLength": 8273,
         ]])
         XCTAssertNil(sut.archive)
 
-        sut = Properties(["archive": [
+        sut = Properties(["https://readium.org/webpub-manifest/properties#archive": [
             "isEntryCompressed": true,
         ]])
         XCTAssertNil(sut.archive)

--- a/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
@@ -440,7 +440,7 @@ private func makeProperties(layout: EPUBLayout? = nil, archiveEntryLength: UInt6
         ] as [String: Any]
     }
     if let archiveEntryLength = archiveEntryLength {
-        props["archive"] = [
+        props["https://readium.org/webpub-manifest/properties#archive"] = [
             "entryLength": archiveEntryLength as NSNumber,
             "isEntryCompressed": true,
         ]


### PR DESCRIPTION

### Changed

#### Shared

* The `Link` property key for archive-based publication assets (e.g. an EPUB/ZIP) is now `https://readium.org/webpub-manifest/properties#archive` instead of `archive`.
