### PR TITLE
Disable EPUB pagination with vertical text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * The `Link` property key for archive-based publication assets (e.g. an EPUB/ZIP) is now `https://readium.org/webpub-manifest/properties#archive` instead of `archive`.
 
+#### Navigator
+
+* EPUB: The `scroll` preference is now forced to `true` when rendering vertical text (e.g. CJK vertical). [See this discussion for the rationale](https://github.com/readium/swift-toolkit/discussions/370).
+
 
 ## [3.0.0-alpha.1]
 

--- a/Sources/Navigator/EPUB/Preferences/EPUBPreferencesEditor.swift
+++ b/Sources/Navigator/EPUB/Preferences/EPUBPreferencesEditor.swift
@@ -304,7 +304,9 @@ public final class EPUBPreferencesEditor: StatefulPreferencesEditor<EPUBPreferen
             preference: \.scroll,
             setting: \.scroll,
             defaultEffectiveValue: defaults.scroll ?? false,
-            isEffective: { [layout] _ in layout == .reflowable }
+            isEffective: { [layout] in
+                layout == .reflowable && !$0.settings.verticalText
+            }
         )
 
     /// Indicates if the fixed-layout publication should be rendered with a

--- a/Sources/Navigator/EPUB/Preferences/EPUBSettings.swift
+++ b/Sources/Navigator/EPUB/Preferences/EPUBSettings.swift
@@ -124,6 +124,16 @@ public struct EPUBSettings: ConfigurableSettings {
             ?? language?.verticalText(for: readingProgression)
             ?? false
 
+        var scroll = preferences.scroll
+            ?? defaults.scroll
+            ?? false
+
+        /// We disable pagination with vertical text, because CSS columns don't support it properly.
+        /// See https://github.com/readium/swift-toolkit/discussions/370
+        if verticalText {
+            scroll = true
+        }
+
         self.init(
             backgroundColor: preferences.backgroundColor,
             columnCount: preferences.columnCount
@@ -157,9 +167,7 @@ public struct EPUBSettings: ConfigurableSettings {
                 ?? defaults.publisherStyles
                 ?? true,
             readingProgression: readingProgression,
-            scroll: preferences.scroll
-                ?? defaults.scroll
-                ?? false,
+            scroll: scroll,
             spread: preferences.spread
                 ?? Spread(metadata.presentation.spread)
                 ?? defaults.spread


### PR DESCRIPTION
### Changed

#### Navigator

* EPUB: The `scroll` preference is now forced to `true` when rendering vertical text (e.g. CJK vertical). [See this discussion for the rationale](https://github.com/readium/swift-toolkit/discussions/370).