### PR TITLE
Update `HTTPServer` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Shared
 
 * The `Link` property key for archive-based publication assets (e.g. an EPUB/ZIP) is now `https://readium.org/webpub-manifest/properties#archive` instead of `archive`.
+* The API of `HTTPServer` slightly changed to be more future-proof.
 
 #### Navigator
 

--- a/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
+++ b/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
@@ -182,10 +182,6 @@ public class GCDHTTPServer: HTTPServer, Loggable {
 
     // MARK: HTTPServer
 
-    public func serve(at endpoint: HTTPServerEndpoint, handler: @escaping (HTTPServerRequest) -> Resource) throws -> HTTPURL {
-        try serve(at: endpoint, handler: handler, failureHandler: nil)
-    }
-
     public func serve(
         at endpoint: HTTPServerEndpoint,
         handler: @escaping (HTTPServerRequest) -> Resource,

--- a/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
+++ b/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
@@ -59,7 +59,7 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
             publicationBaseURL = try httpServer.serve(
                 at: uuidEndpoint,
                 publication: publication,
-                failureHandler: { [weak self] request, error in
+                onFailure: { [weak self] request, error in
                     DispatchQueue.main.async { [weak self] in
                         guard let self = self, let href = request.href else {
                             return

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -61,8 +61,7 @@ final class EPUBNavigatorViewModel: Loggable {
             assetsURL: httpServer.serve(
                 at: "readium",
                 contentsOf: Bundle.module.resourceURL!.fileURL!
-                    .appendingPath("Assets/Static", isDirectory: true),
-                onFailure: nil
+                    .appendingPath("Assets/Static", isDirectory: true)
             ),
             useLegacySettings: false
         )

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -62,7 +62,7 @@ final class EPUBNavigatorViewModel: Loggable {
                 at: "readium",
                 contentsOf: Bundle.module.resourceURL!.fileURL!
                     .appendingPath("Assets/Static", isDirectory: true),
-                failureHandler: nil
+                onFailure: nil
             ),
             useLegacySettings: false
         )
@@ -73,7 +73,7 @@ final class EPUBNavigatorViewModel: Loggable {
             publicationBaseURL = try httpServer.serve(
                 at: uuidEndpoint, // serving the chapters endpoint
                 publication: publication,
-                failureHandler: { [weak self] request, error in
+                onFailure: { [weak self] request, error in
                     guard let self = self, let href = request.href else {
                         return
                     }
@@ -187,7 +187,7 @@ final class EPUBNavigatorViewModel: Loggable {
             throw Error.noHTTPServer
         }
         let endpoint = baseEndpoint.addingSuffix("/") + file.lastPathSegment
-        let url = try httpServer.serve(at: endpoint, contentsOf: file, failureHandler: nil)
+        let url = try httpServer.serve(at: endpoint, contentsOf: file)
         $servedFiles.write { $0[file] = url }
         return url
     }

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -121,7 +121,7 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
             publicationBaseURL = try httpServer.serve(
                 at: uuidEndpoint,
                 publication: publication,
-                failureHandler: { request, error in
+                onFailure: { request, error in
                     DispatchQueue.main.async { [weak self] in
                         guard let self = self, let href = request.href else {
                             return

--- a/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
@@ -11,20 +11,15 @@ import Foundation
 /// This is required by some Navigators to access a local publication's
 /// resources.
 public protocol HTTPServer {
-    typealias FailureHandler = (_ request: HTTPServerRequest, _ error: ResourceError) -> Void
-
     /// Serves resources at the given `endpoint`.
     ///
     /// Subsequent calls with the same `endpoint` overwrite each other.
-    ///
-    /// If the resource cannot be served, the `failureHandler` is called.
     ///
     /// - Returns the base URL for this endpoint.
     @discardableResult
     func serve(
         at endpoint: HTTPServerEndpoint,
-        handler: @escaping (HTTPServerRequest) -> Resource,
-        failureHandler: FailureHandler?
+        handler: HTTPRequestHandler
     ) throws -> HTTPURL
 
     /// Registers a `Resource` transformer that will be run on all responses
@@ -37,7 +32,6 @@ public protocol HTTPServer {
 }
 
 public extension HTTPServer {
-
     /// Serves the local file `url` at the given `endpoint`.
     ///
     /// If the provided `url` is a directory, then all the files in the
@@ -51,9 +45,9 @@ public extension HTTPServer {
     func serve(
         at endpoint: HTTPServerEndpoint,
         contentsOf url: FileURL,
-        failureHandler: FailureHandler? = nil
+        onFailure: HTTPRequestHandler.OnFailure? = nil
     ) throws -> HTTPURL {
-        func handler(request: HTTPServerRequest) -> Resource {
+        func onRequest(request: HTTPServerRequest) -> Resource {
             let file = request.href.flatMap { url.resolve($0) }
                 ?? url
 
@@ -68,8 +62,10 @@ public extension HTTPServer {
 
         return try serve(
             at: endpoint,
-            handler: handler(request:),
-            failureHandler: failureHandler
+            handler: HTTPRequestHandler(
+                onRequest: onRequest,
+                onFailure: onFailure
+            )
         )
     }
 
@@ -83,11 +79,11 @@ public extension HTTPServer {
     func serve(
         at endpoint: HTTPServerEndpoint,
         publication: Publication,
-        failureHandler: FailureHandler? = nil
+        onFailure: HTTPRequestHandler.OnFailure? = nil
     ) throws -> HTTPURL {
-        func handler(request: HTTPServerRequest) -> Resource {
+        func onRequest(request: HTTPServerRequest) -> Resource {
             guard let href = request.href else {
-                failureHandler?(request, .notFound(nil))
+                onFailure?(request, .notFound(nil))
 
                 return FailureResource(
                     link: Link(href: request.url.string),
@@ -100,8 +96,10 @@ public extension HTTPServer {
 
         return try serve(
             at: endpoint,
-            handler: handler(request:),
-            failureHandler: failureHandler
+            handler: HTTPRequestHandler(
+                onRequest: onRequest,
+                onFailure: onFailure
+            )
         )
     }
 }
@@ -120,5 +118,21 @@ public struct HTTPServerRequest {
     public init(url: HTTPURL, href: RelativeURL?) {
         self.url = url
         self.href = href
+    }
+}
+
+/// Callbacks handling a request.
+///
+/// If the resource cannot be served, the `onFailure` callback is called.
+public struct HTTPRequestHandler {
+    public typealias OnRequest = (_ request: HTTPServerRequest) -> Resource
+    public typealias OnFailure = (_ request: HTTPServerRequest, _ error: ResourceError) -> Void
+
+    public let onRequest: OnRequest
+    public let onFailure: OnFailure?
+
+    public init(onRequest: @escaping OnRequest, onFailure: OnFailure? = nil) {
+        self.onRequest = onRequest
+        self.onFailure = onFailure
     }
 }

--- a/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
@@ -17,17 +17,6 @@ public protocol HTTPServer {
     ///
     /// Subsequent calls with the same `endpoint` overwrite each other.
     ///
-    /// - Returns the base URL for this endpoint.
-    @discardableResult
-    func serve(
-        at endpoint: HTTPServerEndpoint,
-        handler: @escaping (HTTPServerRequest) -> Resource
-    ) throws -> HTTPURL
-
-    /// Serves resources at the given `endpoint`.
-    ///
-    /// Subsequent calls with the same `endpoint` overwrite each other.
-    ///
     /// If the resource cannot be served, the `failureHandler` is called.
     ///
     /// - Returns the base URL for this endpoint.
@@ -48,14 +37,6 @@ public protocol HTTPServer {
 }
 
 public extension HTTPServer {
-    @discardableResult
-    func serve(
-        at endpoint: HTTPServerEndpoint,
-        handler: @escaping (HTTPServerRequest) -> Resource,
-        failureHandler: FailureHandler?
-    ) throws -> HTTPURL {
-        try serve(at: endpoint, handler: handler)
-    }
 
     /// Serves the local file `url` at the given `endpoint`.
     ///


### PR DESCRIPTION
### Changed

#### Shared

* The API of `HTTPServer` slightly changed to be more future-proof.

---

* Remove deprecated `HTTPServer` API.