### PR TITLE
Bump the minimum iOS version to 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Changed
 
+The Readium Swift toolkit now requires a minimum of iOS 13.
+
 #### Shared
 
 * The `Link` property key for archive-based publication assets (e.g. an EPUB/ZIP) is now `https://readium.org/webpub-manifest/properties#archive` instead of `archive`.

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ import PackageDescription
 let package = Package(
     name: "Readium",
     defaultLocalization: "en",
-    platforms: [.iOS(.v11)],
+    platforms: [.iOS(.v13)],
     products: [
         .library(name: "ReadiumShared", targets: ["ReadiumShared"]),
         .library(name: "ReadiumStreamer", targets: ["ReadiumStreamer"]),

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This toolkit is a modular project, which follows the [Readium Architecture](http
 
 | Readium   | iOS  | Swift compiler | Xcode  |
 |-----------|------|----------------|--------|
-| `develop` | 11.0 | 5.9            | 15.0.1 |
+| `develop` | 13.0 | 5.9            | 15.0.1 |
+| 3.0.0     | 13.0 | 5.9            | 15.0.1 |
 | 2.5.1     | 11.0 | 5.6.1          | 13.4   |
 | 2.5.0     | 10.0 | 5.6.1          | 13.4   |
 | 2.4.0     | 10.0 | 5.3.2          | 12.4   |

--- a/Support/Carthage/.xcodegen
+++ b/Support/Carthage/.xcodegen
@@ -74,7 +74,7 @@
           "target" : "ReadiumInternal"
         }
       ],
-      "deploymentTarget" : "11.0",
+      "deploymentTarget" : "13.0",
       "platform" : "iOS",
       "settings" : {
         "INFOPLIST_FILE" : "Info.plist",
@@ -88,7 +88,7 @@
       "type" : "framework"
     },
     "ReadiumInternal" : {
-      "deploymentTarget" : "11.0",
+      "deploymentTarget" : "13.0",
       "platform" : "iOS",
       "settings" : {
         "INFOPLIST_FILE" : "Info.plist",
@@ -125,7 +125,7 @@
           "target" : "ReadiumInternal"
         }
       ],
-      "deploymentTarget" : "11.0",
+      "deploymentTarget" : "13.0",
       "platform" : "iOS",
       "settings" : {
         "INFOPLIST_FILE" : "Info.plist",
@@ -159,7 +159,7 @@
           "target" : "ReadiumInternal"
         }
       ],
-      "deploymentTarget" : "11.0",
+      "deploymentTarget" : "13.0",
       "platform" : "iOS",
       "settings" : {
         "INFOPLIST_FILE" : "Info.plist",
@@ -195,7 +195,7 @@
           "target" : "ReadiumInternal"
         }
       ],
-      "deploymentTarget" : "11.0",
+      "deploymentTarget" : "13.0",
       "platform" : "iOS",
       "settings" : {
         "INFOPLIST_FILE" : "Info.plist",
@@ -226,7 +226,7 @@
           "sdk" : "CoreServices.framework"
         }
       ],
-      "deploymentTarget" : "11.0",
+      "deploymentTarget" : "13.0",
       "platform" : "iOS",
       "settings" : {
         "INFOPLIST_FILE" : "Info.plist",
@@ -263,7 +263,7 @@
           "target" : "ReadiumInternal"
         }
       ],
-      "deploymentTarget" : "11.0",
+      "deploymentTarget" : "13.0",
       "platform" : "iOS",
       "settings" : {
         "INFOPLIST_FILE" : "Info.plist",

--- a/Support/Carthage/Readium.xcodeproj/project.pbxproj
+++ b/Support/Carthage/Readium.xcodeproj/project.pbxproj
@@ -2579,7 +2579,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2607,7 +2607,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2635,7 +2635,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2663,7 +2663,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2691,7 +2691,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2719,7 +2719,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2747,7 +2747,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2775,7 +2775,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2803,7 +2803,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2893,7 +2893,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2921,7 +2921,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3004,7 +3004,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3032,7 +3032,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3056,7 +3056,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Support/Carthage/project-as-submodule.yml
+++ b/Support/Carthage/project-as-submodule.yml
@@ -11,7 +11,7 @@ targets:
   ReadiumShared:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/Shared
         excludes:
@@ -29,7 +29,7 @@ targets:
   ReadiumStreamer:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/Streamer
         excludes:
@@ -50,7 +50,7 @@ targets:
   ReadiumNavigator:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/Navigator
         excludes:
@@ -72,7 +72,7 @@ targets:
   ReadiumOPDS:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/OPDS
     dependencies:
@@ -87,7 +87,7 @@ targets:
   ReadiumLCP:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/LCP
     dependencies:
@@ -105,7 +105,7 @@ targets:
   ReadiumAdapterGCDWebServer:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/Adapters/GCDWebServer
     dependencies:
@@ -119,7 +119,7 @@ targets:
   ReadiumInternal:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/Internal
     settings:

--- a/Support/Carthage/project.yml
+++ b/Support/Carthage/project.yml
@@ -9,7 +9,7 @@ targets:
   ReadiumShared:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/Shared
         excludes:
@@ -27,7 +27,7 @@ targets:
   ReadiumStreamer:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/Streamer
         excludes:
@@ -48,7 +48,7 @@ targets:
   ReadiumNavigator:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/Navigator
         excludes:
@@ -70,7 +70,7 @@ targets:
   ReadiumOPDS:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/OPDS
     dependencies:
@@ -85,7 +85,7 @@ targets:
   ReadiumLCP:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/LCP
     dependencies:
@@ -103,7 +103,7 @@ targets:
   ReadiumAdapterGCDWebServer:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/Adapters/GCDWebServer
     dependencies:
@@ -117,7 +117,7 @@ targets:
   ReadiumInternal:
     type: framework
     platform: iOS
-    deploymentTarget: "11.0"
+    deploymentTarget: "13.0"
     sources: 
       - path: ../../Sources/Internal
     settings:

--- a/Support/CocoaPods/ReadiumAdapterGCDWebServer.podspec
+++ b/Support/CocoaPods/ReadiumAdapterGCDWebServer.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.source_files  = "Sources/Adapters/GCDWebServer/**/*.{m,h,swift}"
   s.platform      = :ios
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "13.0"
   s.xcconfig      = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
 
   s.dependency 'ReadiumShared'

--- a/Support/CocoaPods/ReadiumInternal.podspec
+++ b/Support/CocoaPods/ReadiumInternal.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.source_files  = "Sources/Internal/**/*.{m,h,swift}"
   s.platform      = :ios
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "13.0"
   s.xcconfig      = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
 
 end

--- a/Support/CocoaPods/ReadiumLCP.podspec
+++ b/Support/CocoaPods/ReadiumLCP.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sources/LCP/**/*.{m,h,swift}"
   s.platform      = :ios
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "13.0"
   s.xcconfig      = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2'}
   
   s.dependency 'ReadiumShared' 

--- a/Support/CocoaPods/ReadiumNavigator.podspec
+++ b/Support/CocoaPods/ReadiumNavigator.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sources/Navigator/**/*.{m,h,swift}"
   s.platform      = :ios
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "13.0"
   s.dependency 'ReadiumShared'
   s.dependency 'ReadiumInternal'
   s.dependency 'DifferenceKit', '~> 1.0'

--- a/Support/CocoaPods/ReadiumOPDS.podspec
+++ b/Support/CocoaPods/ReadiumOPDS.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sources/OPDS/**/*.{m,h,swift}"
   s.platform      = :ios
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "13.0"
   s.xcconfig      = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
 
   s.dependency 'ReadiumShared'

--- a/Support/CocoaPods/ReadiumShared.podspec
+++ b/Support/CocoaPods/ReadiumShared.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sources/Shared/**/*.{m,h,swift}"
   s.platform     = :ios
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "13.0"
   s.frameworks   = "CoreServices"
   s.libraries =  "xml2"
   s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }

--- a/Support/CocoaPods/ReadiumStreamer.podspec
+++ b/Support/CocoaPods/ReadiumStreamer.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   }
   s.source_files  = "Sources/Streamer/**/*.{m,h,swift}"
   s.platform      = :ios
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "13.0"
   s.libraries     =  'z', 'xml2'
   s.xcconfig      = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
 


### PR DESCRIPTION

### Changed

The Readium Swift toolkit now requires a minimum of iOS 13.

---

This will allow us to use the new async/await constructs.