### PR TITLE
Add ChatGPT option to EPUB EditAction menu

### DIFF
--- a/TestApp/Sources/Reader/EPUB/EPUBViewController.swift
+++ b/TestApp/Sources/Reader/EPUB/EPUBViewController.swift
@@ -43,6 +43,10 @@ class EPUBViewController: VisualReaderViewController<EPUBNavigatorViewController
                     .appending(EditingAction(
                         title: "Highlight",
                         action: #selector(highlightSelection)
+                    ))
+                    .appending(EditingAction(
+                        title: "ChatGPT",
+                        action: #selector(gptSelection)
                     )),
                 decorationTemplates: templates,
                 fontFamilyDeclarations: [
@@ -95,6 +99,13 @@ class EPUBViewController: VisualReaderViewController<EPUBNavigatorViewController
         if let selection = navigator.currentSelection {
             let highlight = Highlight(bookId: bookId, locator: selection.locator, color: .yellow)
             saveHighlight(highlight)
+            navigator.clearSelection()
+        }
+    }
+
+    @objc func gptSelection() {
+        if let selection = navigator.currentSelection {
+            print(selection)
             navigator.clearSelection()
         }
     }


### PR DESCRIPTION
Added a ChatGPT button option to the EPUB highlight menu. Clicking on this option prints out the `before`, `after`, and `highlight` text in the Xcode console. 

<img width="374" alt="Screenshot 2024-05-19 at 11 43 42 PM" src="https://github.com/readium/swift-toolkit/assets/6856480/8d0945ee-33d7-4caf-bf77-9ca18576537e">

<img width="744" alt="Screenshot 2024-05-19 at 11 44 09 PM" src="https://github.com/readium/swift-toolkit/assets/6856480/950890fe-ed19-4996-8a13-a9904ce8f51f">