### PR TITLE
Fix resolving search results title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+#### Shared
+
+* [#444](https://github.com/readium/swift-toolkit/issues/444) Fixed resolving titles of search results when the table of contents items contain fragment identifiers.
+
 
 ## [2.7.1]
 

--- a/Sources/Internal/Extensions/String.swift
+++ b/Sources/Internal/Extensions/String.swift
@@ -67,7 +67,7 @@ public extension String {
         guard let range = range(of: delimiter, options: [.backwards, .literal]) else {
             return self
         }
-        return String(self[...range.lowerBound])
+        return String(self[..<range.lowerBound])
     }
 
     /// Replaces multiple whitespaces by a single space.

--- a/Tests/InternalTests/Extensions/StringTests.swift
+++ b/Tests/InternalTests/Extensions/StringTests.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright 2024 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+@testable import ReadiumInternal
+import XCTest
+
+class StringTests: XCTestCase {
+    func testSubstringBeforeLast() {
+        XCTAssertEqual("href".substringBeforeLast("#"), "href")
+        XCTAssertEqual("href#anchor".substringBeforeLast("#"), "href")
+        XCTAssertEqual("href#anchor#test".substringBeforeLast("#"), "href#anchor")
+    }
+}


### PR DESCRIPTION
### Fixed

#### Shared

* [#444](https://github.com/readium/swift-toolkit/issues/444) Fixed resolving titles of search results when the table of contents items contain fragment identifiers.

---

* Fixes #444 