### PR TITLE
Fixed editing actions on iOS 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project will be documented in this file. Take a look
 
 * [#444](https://github.com/readium/swift-toolkit/issues/444) Fixed resolving titles of search results when the table of contents items contain fragment identifiers.
 
+#### Navigator
+
+* [#428](https://github.com/readium/swift-toolkit/issues/428) Fixed crash with the `share` editing action on iOS 17.
+* [#428](https://github.com/readium/swift-toolkit/issues/428) Fixed showing look up and translate editing actions on iOS 17.
+
 
 ## [2.7.1]
 


### PR DESCRIPTION
### Fixed

#### Navigator

* [#428](https://github.com/readium/swift-toolkit/issues/428) Fixed crash with the `share` editing action on iOS 17.
* [#428](https://github.com/readium/swift-toolkit/issues/428) Fixed showing look up and translate editing actions on iOS 17.

---

* Fixes #428 