### PR TITLE
Change `localizedCaseInsensitiveCompare` to `localizedStandardCompare`

### DIFF
--- a/Sources/Shared/Toolkit/Archive/ExplodedArchive.swift
+++ b/Sources/Shared/Toolkit/Archive/ExplodedArchive.swift
@@ -35,7 +35,7 @@ final class ExplodedArchive: Archive, Loggable {
                 }
             }
         }
-        return entries.sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
+        return entries.sorted { $0.path.localizedStandardCompare($1.path) == .orderedAscending }
     }()
 
     func readEntry(at path: ArchivePath) -> ArchiveEntryReader? {

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -25,7 +25,7 @@ public final class AudioParser: PublicationParser {
 
         let defaultReadingOrder = fetcher.links
             .filter { !ignores($0) && $0.mediaType.isAudio }
-            .sorted { $0.href.localizedCaseInsensitiveCompare($1.href) == .orderedAscending }
+            .sorted { $0.href.localizedStandardCompare($1.href) == .orderedAscending }
 
         guard !defaultReadingOrder.isEmpty else {
             return nil

--- a/Sources/Streamer/Parser/Image/ImageParser.swift
+++ b/Sources/Streamer/Parser/Image/ImageParser.swift
@@ -21,7 +21,7 @@ public final class ImageParser: PublicationParser {
 
         var readingOrder = fetcher.links
             .filter { !ignores($0) && $0.mediaType.isBitmap }
-            .sorted { $0.href.localizedCaseInsensitiveCompare($1.href) == .orderedAscending }
+            .sorted { $0.href.localizedStandardCompare($1.href) == .orderedAscending }
 
         guard !readingOrder.isEmpty else {
             return nil


### PR DESCRIPTION
Both Finder and Files sort by name using `localizedStandardCompare`. By using `localizedCaseInsensitiveCompare`, we introduce potentially counterintuitive behavior. For example, a user may import multiple files which appear to be sorted correctly in Finder/Files and then discover that we play them in a different order.

Like `localizedCaseInsensitiveCompare`, `localizedStandardCompare` is also case insensitive, but also accounts for numeric non-lexicographic sorting. For example `(1...25).map { String($0) }` will not change order when sorted with `localizedStandardCompare`, but with `localizedCaseInsensitiveCompare` the order will change to `["1", "10", "11", "12", ...]`.

I also noticed `localizedCaseInsensitiveContains` being used. Based on my reading of the code, I think normal `contains` may be appropriate, but, if not, perhaps `localizedStandardContains` should be used instead.
https://github.com/readium/swift-toolkit/blob/8fad4d5acd4603270c9d333545b58a6fb649d98d/Sources/Navigator/EPUB/CSS/ReadiumCSS.swift#L140-L144