### PR TITLE
Normalize URLs on-the-fly when comparing

### DIFF
--- a/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
+++ b/Sources/Adapters/GCDWebServer/GCDHTTPServer.swift
@@ -138,7 +138,7 @@ public class GCDHTTPServer: HTTPServer, Loggable {
             let pathWithoutAnchor = url.removingQuery().removingFragment()
 
             for (endpoint, handler) in handlers {
-                if endpoint == pathWithoutAnchor {
+                if endpoint.isEquivalentTo(pathWithoutAnchor) {
                     let request = HTTPServerRequest(url: url, href: nil)
                     let resource = handler.onRequest(request)
                     completion(

--- a/Sources/Adapters/GCDWebServer/ResourceResponse.swift
+++ b/Sources/Adapters/GCDWebServer/ResourceResponse.swift
@@ -77,7 +77,7 @@ class ResourceResponse: ReadiumGCDWebServerFileResponse, Loggable {
 
         super.init()
 
-        contentType = resource.link.type ?? ""
+        contentType = resource.link.mediaType?.string ?? ""
 
         // Disable HTTP caching for publication resources, because it poses a security threat for protected
         // publications.

--- a/Sources/Navigator/Audiobook/AudioNavigator.swift
+++ b/Sources/Navigator/Audiobook/AudioNavigator.swift
@@ -382,6 +382,8 @@ open class AudioNavigator: Navigator, Configurable, AudioSessionUser, Loggable {
 
     @discardableResult
     public func go(to locator: Locator, animated: Bool = false, completion: @escaping () -> Void = {}) -> Bool {
+        let locator = publication.normalizeLocator(locator)
+
         guard let newResourceIndex = publication.readingOrder.firstIndex(withHREF: locator.href) else {
             return false
         }

--- a/Sources/Navigator/Audiobook/AudioNavigator.swift
+++ b/Sources/Navigator/Audiobook/AudioNavigator.swift
@@ -339,8 +339,8 @@ open class AudioNavigator: Navigator, Configurable, AudioSessionUser, Loggable {
         }
 
         return Locator(
-            href: link.href,
-            type: link.type ?? "audio/*",
+            href: link.url(),
+            mediaType: link.mediaType ?? MediaType("audio/*")!,
             title: link.title,
             locations: Locator.Locations(
                 fragments: ["t=\(time)"],
@@ -384,7 +384,7 @@ open class AudioNavigator: Navigator, Configurable, AudioSessionUser, Loggable {
     public func go(to locator: Locator, animated: Bool = false, completion: @escaping () -> Void = {}) -> Bool {
         let locator = publication.normalizeLocator(locator)
 
-        guard let newResourceIndex = publication.readingOrder.firstIndex(withHREF: locator.href) else {
+        guard let newResourceIndex = publication.readingOrder.firstIndexWithHREF(locator.href) else {
             return false
         }
         let link = publication.readingOrder[newResourceIndex]

--- a/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
+++ b/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
@@ -12,8 +12,6 @@ import ReadiumShared
 ///
 /// Useful for local resources or when you need to customize the way HTTP requests are sent.
 final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate {
-    private typealias HREF = String
-
     public enum AssetError: LocalizedError {
         case invalidHREF(String)
 
@@ -35,10 +33,8 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate {
 
     /// Creates a new `AVURLAsset` to serve the given `link`.
     func makeAsset(for link: Link) throws -> AVURLAsset {
-        guard
-            let originalURL = try? link.url(relativeTo: publication.baseURL),
-            var components = URLComponents(url: originalURL.url, resolvingAgainstBaseURL: true)
-        else {
+        let originalURL = link.url(relativeTo: publication.baseURL)
+        guard var components = URLComponents(url: originalURL.url, resolvingAgainstBaseURL: true) else {
             throw AssetError.invalidHREF(link.href)
         }
 
@@ -55,9 +51,10 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate {
 
     // MARK: - Resource Management
 
-    private var resources: [HREF: Resource] = [:]
+    private var resources: [AnyURL: Resource] = [:]
 
-    private func resource(forHREF href: HREF) -> Resource {
+    private func resource<T: URLConvertible>(forHREF href: T) -> Resource {
+        let href = href.anyURL
         if let res = resources[href] {
             return res
         }
@@ -72,10 +69,11 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate {
     private typealias CancellableRequest = (request: AVAssetResourceLoadingRequest, cancellable: Cancellable)
 
     /// List of on-going loading requests.
-    private var requests: [HREF: [CancellableRequest]] = [:]
+    private var requests: [AnyURL: [CancellableRequest]] = [:]
 
     /// Adds a new loading request.
-    private func registerRequest(_ request: AVAssetResourceLoadingRequest, cancellable: Cancellable, for href: HREF) {
+    private func registerRequest<T: URLConvertible>(_ request: AVAssetResourceLoadingRequest, cancellable: Cancellable, for href: T) {
+        let href = href.anyURL
         var reqs: [CancellableRequest] = requests[href] ?? []
         reqs.append((request, cancellable))
         requests[href] = reqs
@@ -129,7 +127,7 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate {
 
     private func fillInfo(_ infoRequest: AVAssetResourceLoadingContentInformationRequest, of request: AVAssetResourceLoadingRequest, using resource: Resource) {
         infoRequest.isByteRangeAccessSupported = true
-        infoRequest.contentType = resource.link.mediaType.uti
+        infoRequest.contentType = resource.link.mediaType?.uti
         if case let .success(length) = resource.length {
             infoRequest.contentLength = Int64(length)
         }
@@ -153,7 +151,7 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate {
             }
         )
 
-        registerRequest(request, cancellable: cancellable, for: resource.link.href)
+        registerRequest(request, cancellable: cancellable, for: resource.link.url())
     }
 
     func resourceLoader(_ resourceLoader: AVAssetResourceLoader, didCancel loadingRequest: AVAssetResourceLoadingRequest) {
@@ -164,7 +162,7 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate {
 private let schemePrefix = "readium"
 
 extension URL {
-    var audioHREF: String? {
+    var audioHREF: AnyURL? {
         guard let url = absoluteURL, url.scheme.rawValue.hasPrefix(schemePrefix) == true else {
             return nil
         }
@@ -173,6 +171,6 @@ extension URL {
         // * readium:relative/file.mp3
         // * readiumfile:///directory/local-file.mp3
         // * readiumhttp(s)://domain.com/external-file.mp3
-        return url.string.removingPrefix(schemePrefix).removingPrefix(":")
+        return AnyURL(string: url.string.removingPrefix(schemePrefix).removingPrefix(":"))
     }
 }

--- a/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
+++ b/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
@@ -55,7 +55,7 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate {
 
     private func resource<T: URLConvertible>(forHREF href: T) -> Resource {
         let href = href.anyURL
-        if let res = resources[href] {
+        if let res = resources[equivalent: href] {
             return res
         }
 

--- a/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
+++ b/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
@@ -209,6 +209,8 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
     }
 
     public func go(to locator: Locator, animated: Bool, completion: @escaping () -> Void) -> Bool {
+        let locator = publication.normalizeLocator(locator)
+
         guard let index = publication.readingOrder.firstIndex(withHREF: locator.href) else {
             return false
         }

--- a/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
+++ b/Sources/Navigator/CBZ/CBZNavigatorViewController.swift
@@ -87,7 +87,7 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
         self.publicationEndpoint = publicationEndpoint
 
         initialIndex = {
-            guard let initialLocation = initialLocation, let initialIndex = publication.readingOrder.firstIndex(withHREF: initialLocation.href) else {
+            guard let initialLocation = initialLocation, let initialIndex = publication.readingOrder.firstIndexWithHREF(initialLocation.href) else {
                 return 0
             }
             return initialIndex
@@ -180,13 +180,10 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
     }
 
     private func imageViewController(at index: Int) -> ImageViewController? {
-        guard
-            publication.readingOrder.indices.contains(index),
-            let url = try? publication.readingOrder[index].url(relativeTo: publicationBaseURL)
-        else {
+        guard publication.readingOrder.indices.contains(index) else {
             return nil
         }
-
+        let url = publication.readingOrder[index].url(relativeTo: publicationBaseURL)
         return ImageViewController(index: index, url: url.url)
     }
 
@@ -211,14 +208,14 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
     public func go(to locator: Locator, animated: Bool, completion: @escaping () -> Void) -> Bool {
         let locator = publication.normalizeLocator(locator)
 
-        guard let index = publication.readingOrder.firstIndex(withHREF: locator.href) else {
+        guard let index = publication.readingOrder.firstIndexWithHREF(locator.href) else {
             return false
         }
         return goToResourceAtIndex(index, animated: animated, isJump: true, completion: completion)
     }
 
     public func go(to link: Link, animated: Bool, completion: @escaping () -> Void) -> Bool {
-        guard let index = publication.readingOrder.firstIndex(withHREF: link.href) else {
+        guard let index = publication.readingOrder.firstIndexWithHREF(link.url()) else {
             return false
         }
         return goToResourceAtIndex(index, animated: animated, isJump: true, completion: completion)

--- a/Sources/Navigator/Decorator/DiffableDecoration.swift
+++ b/Sources/Navigator/Decorator/DiffableDecoration.swift
@@ -20,10 +20,10 @@ enum DecorationChange {
 }
 
 extension Array where Element == DiffableDecoration {
-    func changesByHREF(from source: [DiffableDecoration]) -> [String: [DecorationChange]] {
+    func changesByHREF(from source: [DiffableDecoration]) -> [AnyURL: [DecorationChange]] {
         let changeset = StagedChangeset(source: source, target: self)
 
-        var changes: [String: [DecorationChange]] = [:]
+        var changes: [AnyURL: [DecorationChange]] = [:]
 
         func register(_ change: DecorationChange, at locator: Locator) {
             var resourceChanges: [DecorationChange] = changes[locator.href] ?? []

--- a/Sources/Navigator/EPUB/EPUBFixedSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBFixedSpreadView.swift
@@ -103,8 +103,8 @@ final class EPUBFixedSpreadView: EPUBSpreadView {
         goToCompletions.complete()
     }
 
-    override func evaluateScript(_ script: String, inHREF href: String?, completion: ((Result<Any, Error>) -> Void)?) {
-        let href = href ?? ""
+    override func evaluateScript(_ script: String, inHREF href: AnyURL? = nil, completion: ((Result<Any, any Error>) -> Void)? = nil) {
+        let href = href?.string ?? ""
         let script = "spread.eval('\(href)', `\(script.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "`", with: "\\`"))`);"
         super.evaluateScript(script, completion: completion)
     }

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -726,6 +726,8 @@ open class EPUBNavigatorViewController: UIViewController,
     }
 
     public func go(to locator: Locator, animated: Bool, completion: @escaping () -> Void) -> Bool {
+        let locator = publication.normalizeLocator(locator)
+
         guard
             let spreadIndex = spreads.firstIndex(withHref: locator.href),
             on(.jump(locator))
@@ -796,7 +798,11 @@ open class EPUBNavigatorViewController: UIViewController,
 
     public func apply(decorations: [Decoration], in group: String) {
         let source = self.decorations[group] ?? []
-        let target = decorations.map { DiffableDecoration(decoration: $0) }
+        let target = decorations.map { d in
+            var d = d
+            d.locator = publication.normalizeLocator(d.locator)
+            return DiffableDecoration(decoration: d)
+        }
 
         self.decorations[group] = target
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -685,7 +685,7 @@ open class EPUBNavigatorViewController: UIViewController,
             // Gets the current locator from the positionList, and fill its missing data.
             let positionIndex = Int(ceil(progression * Double(positionList.count - 1)))
             return positionList[positionIndex].copy(
-                title: tableOfContentsTitleByHref[href],
+                title: tableOfContentsTitleByHref[equivalent: href],
                 locations: { $0.progression = progression }
             )
         } else {
@@ -975,7 +975,7 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
                 let href = link.url()
                 for (group, decorations) in self.decorations {
                     let decorations = decorations
-                        .filter { $0.decoration.locator.href == href }
+                        .filter { $0.decoration.locator.href.isEquivalentTo(href) }
                         .map { DecorationChange.add($0.decoration) }
 
                     guard let script = decorations.javascript(forGroup: group, styles: self.config.decorationTemplates) else {

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -17,7 +17,7 @@ protocol EPUBNavigatorViewModelDelegate: AnyObject {
 enum EPUBScriptScope {
     case currentResource
     case loadedResources
-    case resource(href: String)
+    case resource(href: AnyURL)
 }
 
 final class EPUBNavigatorViewModel: Loggable {
@@ -173,8 +173,8 @@ final class EPUBNavigatorViewModel: Loggable {
         }
     }
 
-    func url(to link: Link) -> AnyURL? {
-        try? link.url(relativeTo: publicationBaseURL)
+    func url(to link: Link) -> AnyURL {
+        link.url(relativeTo: publicationBaseURL)
     }
 
     private func serveFile(at file: FileURL, baseEndpoint: HTTPServerEndpoint) throws -> HTTPURL {
@@ -351,7 +351,7 @@ final class EPUBNavigatorViewModel: Loggable {
     func injectReadiumCSS(in resource: Resource) -> Resource {
         let link = resource.link
         guard
-            link.mediaType.isHTML,
+            link.mediaType?.isHTML == true,
             publication.metadata.presentation.layout(of: link) == .reflowable
         else {
             return resource

--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -77,10 +77,7 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
             return
         }
         let link = spread.leading
-        guard let url = viewModel.url(to: link) else {
-            log(.error, "Can't get URL for link \(link.href)")
-            return
-        }
+        let url = viewModel.url(to: link)
         webView.load(URLRequest(url: url.url))
     }
 
@@ -172,8 +169,8 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
 
     // MARK: - Location and progression
 
-    override func progression(in href: String) -> Double {
-        guard spread.leading.href == href, let progression = progression else {
+    override func progression<T>(in href: T) -> Double where T : URLConvertible {
+        guard spread.leading.url() == href.anyURL, let progression = progression else {
             return 0
         }
         return progression
@@ -261,7 +258,7 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
     }
 
     private func go(to locator: Locator, completion: @escaping (Bool) -> Void) {
-        guard ["", "#"].contains(locator.href) || spread.contains(href: locator.href) else {
+        guard ["", "#"].contains(locator.href.string) || spread.contains(href: locator.href) else {
             log(.warning, "The locator's href is not in the spread")
             completion(false)
             return

--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -170,7 +170,10 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
     // MARK: - Location and progression
 
     override func progression<T>(in href: T) -> Double where T: URLConvertible {
-        guard spread.leading.url() == href.anyURL, let progression = progression else {
+        guard
+            spread.leading.url().isEquivalentTo(href),
+            let progression = progression
+        else {
             return 0
         }
         return progression

--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -169,7 +169,7 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
 
     // MARK: - Location and progression
 
-    override func progression<T>(in href: T) -> Double where T : URLConvertible {
+    override func progression<T>(in href: T) -> Double where T: URLConvertible {
         guard spread.leading.url() == href.anyURL, let progression = progression else {
             return 0
         }

--- a/Sources/Navigator/EPUB/EPUBSpread.swift
+++ b/Sources/Navigator/EPUB/EPUBSpread.swift
@@ -201,9 +201,9 @@ struct EPUBSpread: Loggable {
 extension Array where Element == EPUBSpread {
     /// Returns the index of the first spread containing a resource with the given `href`.
     func firstIndexWithHREF<T: URLConvertible>(_ href: T) -> Int? {
-        let href = href.anyURL
+        let href = href.anyURL.normalized
         return firstIndex { spread in
-            spread.links.contains { $0.url() == href }
+            spread.links.contains { $0.url().normalized.string == href.string }
         }
     }
 }

--- a/Sources/Navigator/EPUB/EPUBSpread.swift
+++ b/Sources/Navigator/EPUB/EPUBSpread.swift
@@ -58,15 +58,15 @@ struct EPUBSpread: Loggable {
     }
 
     /// Returns whether the spread contains a resource with the given href.
-    func contains(href: String) -> Bool {
-        links.first(withHREF: href) != nil
+    func contains<T: URLConvertible>(href: T) -> Bool {
+        links.firstWithHREF(href) != nil
     }
 
     /// Return the number of positions (as in `Publication.positionList`) contained in the spread.
     func positionCount(in readingOrder: [Link], positionsByReadingOrder: [[Locator]]) -> Int {
         links
             .map {
-                if let index = readingOrder.firstIndex(withHREF: $0.href) {
+                if let index = readingOrder.firstIndexWithHREF($0.url()) {
                     return positionsByReadingOrder[index].count
                 } else {
                     return 0
@@ -83,14 +83,10 @@ struct EPUBSpread: Loggable {
     ///   - page [left|center|right]: (optional) Page position of the linked resource in the spread.
     func json(forBaseURL baseURL: HTTPURL) -> [[String: Any]] {
         func makeLinkJSON(_ link: Link, page: Presentation.Page? = nil) -> [String: Any]? {
-            guard let url = try? link.url(relativeTo: baseURL) else {
-                return nil
-            }
-
             let page = page ?? link.properties.page ?? readingProgression.leadingPage
             return [
                 "link": link.json,
-                "url": url.string,
+                "url": link.url(relativeTo: baseURL).string,
                 "page": page.rawValue,
             ]
         }
@@ -204,9 +200,10 @@ struct EPUBSpread: Loggable {
 
 extension Array where Element == EPUBSpread {
     /// Returns the index of the first spread containing a resource with the given `href`.
-    func firstIndex(withHref href: String) -> Int? {
-        firstIndex { spread in
-            spread.links.contains { $0.href == href }
+    func firstIndexWithHREF<T: URLConvertible>(_ href: T) -> Int? {
+        let href = href.anyURL
+        return firstIndex { spread in
+            spread.links.contains { $0.url() == href }
         }
     }
 }

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -375,7 +375,7 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
         if isPDFFile {
             return publication.readingOrder.first
         } else {
-            return publication.readingOrder.first(withHREF: locator.href)
+            return publication.readingOrder.firstWithHREF(locator.href)
         }
     }
 
@@ -397,10 +397,8 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
         }
 
         if currentResourceIndex != index {
-            guard
-                let url = try? link.url(relativeTo: publicationBaseURL),
-                let document = PDFDocument(url: url.url)
-            else {
+            let url = link.url(relativeTo: publicationBaseURL)
+            guard let document = PDFDocument(url: url.url) else {
                 log(.error, "Can't open PDF document at \(link)")
                 return false
             }
@@ -455,7 +453,7 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
 
         if
             publication.readingOrder.count > 1,
-            let index = publication.readingOrder.firstIndex(withHREF: locator.href),
+            let index = publication.readingOrder.firstIndexWithHREF(locator.href),
             let firstPosition = publication.positionsByReadingOrder[index].first?.locations.position
         {
             position = position - firstPosition + 1

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -357,6 +357,8 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Select
 
     @discardableResult
     private func go(to locator: Locator, isJump: Bool, completion: @escaping () -> Void = {}) -> Bool {
+        let locator = publication.normalizeLocator(locator)
+
         guard let link = findLink(at: locator) else {
             return false
         }

--- a/Sources/OPDS/OPDS1Parser.swift
+++ b/Sources/OPDS/OPDS1Parser.swift
@@ -156,7 +156,7 @@ public class OPDS1Parser: Loggable {
 
                 let newLink = Link(
                     href: absoluteHref,
-                    type: link.attr("type"),
+                    mediaType: link.attr("type").flatMap { MediaType($0) },
                     title: entry.firstChild(tag: "title")?.stringValue,
                     rel: link.attr("rel").map { LinkRelation($0) },
                     properties: .init(properties)
@@ -196,7 +196,7 @@ public class OPDS1Parser: Loggable {
 
             let newLink = Link(
                 href: absoluteHref,
-                type: link.attributes["type"],
+                mediaType: link.attributes["type"].flatMap { MediaType($0) },
                 title: link.attributes["title"],
                 rels: rels,
                 properties: .init(properties)
@@ -228,7 +228,7 @@ public class OPDS1Parser: Loggable {
     /// Fetch an Open Search template from an OPDS feed.
     /// - parameter feed: The OPDS feed
     public static func fetchOpenSearchTemplate(feed: Feed, completion: @escaping (String?, Error?) -> Void) {
-        guard let openSearchHref = feed.links.first(withRel: .search)?.href,
+        guard let openSearchHref = feed.links.firstWithRel(.search)?.href,
               let openSearchURL = URL(string: openSearchHref)
         else {
             completion(nil, OPDSParserOpenSearchHelperError.searchLinkNotFound)
@@ -256,8 +256,8 @@ public class OPDS1Parser: Loggable {
             // We match by mimetype and profile; if that fails, by mimetype; and if that fails, the first url is returned
             var typeAndProfileMatch: Fuzi.XMLElement? = nil
             var typeMatch: Fuzi.XMLElement? = nil
-            if let selfMimeType = feed.links.first(withRel: .self)?.type {
-                let selfMimeParams = parseMimeType(mimeTypeString: selfMimeType)
+            if let selfMimeType = feed.links.firstWithRel(.self)?.mediaType {
+                let selfMimeParams = parseMimeType(mimeTypeString: selfMimeType.string)
                 for url in urls {
                     guard let urlMimeType = url.attributes["type"] else {
                         continue
@@ -365,7 +365,7 @@ public class OPDS1Parser: Loggable {
 
             let link = Link(
                 href: absoluteHref,
-                type: linkElement.attributes["type"],
+                mediaType: linkElement.attributes["type"].flatMap { MediaType($0) },
                 title: linkElement.attributes["title"],
                 rel: linkElement.attributes["rel"].map { LinkRelation($0) },
                 properties: .init(properties)

--- a/Sources/Shared/Fetcher/ArchiveFetcher.swift
+++ b/Sources/Shared/Fetcher/ArchiveFetcher.swift
@@ -21,14 +21,14 @@ public final class ArchiveFetcher: Fetcher, Loggable {
             }
             return Link(
                 href: url.string,
-                type: MediaType.of(fileExtension: url.pathExtension)?.string,
+                mediaType: MediaType.of(fileExtension: url.pathExtension),
                 properties: Properties(entry.linkProperties)
             )
         }
 
     public func get(_ link: Link) -> Resource {
         guard
-            let path = try? link.url().relativeURL?.path,
+            let path = link.url().relativeURL?.path,
             let entry = findEntry(at: path),
             let reader = archive.readEntry(at: entry.path)
         else {

--- a/Sources/Shared/Fetcher/FileFetcher.swift
+++ b/Sources/Shared/Fetcher/FileFetcher.swift
@@ -23,7 +23,7 @@ public final class FileFetcher: Fetcher, Loggable {
     }
 
     public func get(_ link: Link) -> Resource {
-        if let linkHREF = try? link.url().relativeURL {
+        if let linkHREF = link.url().relativeURL {
             for (href, url) in paths {
                 if linkHREF == href {
                     return FileResource(link: link, file: url)
@@ -67,7 +67,7 @@ public final class FileFetcher: Fetcher, Loggable {
             let subPath = url.standardizedFileURL.path.removingPrefix(path.path)
             return Link(
                 href: href.appendingPath(subPath, isDirectory: false).string,
-                type: FileURL(url: url).flatMap { MediaType.of($0)?.string }
+                mediaType: FileURL(url: url).flatMap { MediaType.of($0) }
             )
         }
     }

--- a/Sources/Shared/Fetcher/FileFetcher.swift
+++ b/Sources/Shared/Fetcher/FileFetcher.swift
@@ -25,7 +25,7 @@ public final class FileFetcher: Fetcher, Loggable {
     public func get(_ link: Link) -> Resource {
         if let linkHREF = link.url().relativeURL {
             for (href, url) in paths {
-                if linkHREF == href {
+                if linkHREF.isEquivalentTo(href) {
                     return FileResource(link: link, file: url)
 
                 } else if let relativeHREF = href.relativize(linkHREF)?.path {

--- a/Sources/Shared/Fetcher/HTTPFetcher.swift
+++ b/Sources/Shared/Fetcher/HTTPFetcher.swift
@@ -21,7 +21,7 @@ public final class HTTPFetcher: Fetcher, Loggable {
     public let links: [Link] = []
 
     public func get(_ link: Link) -> Resource {
-        guard let url = try? link.url(relativeTo: baseURL).httpURL else {
+        guard let url = link.url(relativeTo: baseURL).httpURL else {
             log(.error, "Not a valid HTTP URL: \(link.href)")
             return FailureResource(link: link, error: .badRequest(HTTPError(kind: .malformedRequest(url: link.href))))
         }

--- a/Sources/Shared/Fetcher/Resource/Resource.swift
+++ b/Sources/Shared/Fetcher/Resource/Resource.swift
@@ -100,7 +100,7 @@ public extension Resource {
     /// falls back on UTF-8.
     func readAsString(encoding: String.Encoding? = nil) -> ResourceResult<String> {
         read().map {
-            let encoding = encoding ?? link.mediaType.encoding ?? .utf8
+            let encoding = encoding ?? link.mediaType?.encoding ?? .utf8
             return String(data: $0, encoding: encoding) ?? ""
         }
     }

--- a/Sources/Shared/Fetcher/Resource/ResourceContentExtractor.swift
+++ b/Sources/Shared/Fetcher/Resource/ResourceContentExtractor.swift
@@ -37,7 +37,7 @@ public class _DefaultResourceContentExtractorFactory: _ResourceContentExtractorF
 
     public func makeExtractor(for resource: Resource) -> _ResourceContentExtractor? {
         switch resource.link.mediaType {
-        case .html, .xhtml:
+        case MediaType.html, MediaType.xhtml:
             return _HTMLResourceContentExtractor()
         default:
             return nil

--- a/Sources/Shared/Fetcher/Resource/TransformingResource.swift
+++ b/Sources/Shared/Fetcher/Resource/TransformingResource.swift
@@ -51,7 +51,7 @@ public extension Resource {
     }
 
     func mapAsString(encoding: String.Encoding? = nil, transform: @escaping (String) -> String) -> Resource {
-        let encoding = encoding ?? link.mediaType.encoding ?? .utf8
+        let encoding = encoding ?? link.mediaType?.encoding ?? .utf8
         return TransformingResource(self) {
             $0.map { data in
                 let string = String(data: data, encoding: encoding) ?? ""

--- a/Sources/Shared/OPDS/Feed.swift
+++ b/Sources/Shared/OPDS/Feed.swift
@@ -22,6 +22,6 @@ public class Feed {
     ///
     /// - Returns: The HREF value of the search link
     internal func getSearchLinkHref() -> String? {
-        links.first(withRel: .search)?.href
+        links.firstWithRel(.search)?.href
     }
 }

--- a/Sources/Shared/Publication/Asset/FileAsset.swift
+++ b/Sources/Shared/Publication/Asset/FileAsset.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Represents a publication stored as a file on the local file system.
-public final class FileAsset: PublicationAsset, Loggable, Sendable {
+public final class FileAsset: PublicationAsset, Loggable {
     /// File URL on the file system.
     public let file: FileURL
 

--- a/Sources/Shared/Publication/HREFNormalizer.swift
+++ b/Sources/Shared/Publication/HREFNormalizer.swift
@@ -9,7 +9,7 @@ import Foundation
 public extension Manifest {
     /// Resolves the HREFs in the ``Manifest`` to the link with `rel="self"`.
     mutating func normalizeHREFsToSelf() throws {
-        guard let base = try link(withRel: .self)?.url() else {
+        guard let base = linkWithRel(.self)?.url() else {
             return
         }
 
@@ -45,6 +45,6 @@ private struct HREFNormalizer: ManifestTransformer, Loggable {
             return
         }
 
-        link.href = try link.url(relativeTo: baseURL).string
+        link.href = link.url(relativeTo: baseURL).string
     }
 }

--- a/Sources/Shared/Publication/Link.swift
+++ b/Sources/Shared/Publication/Link.swift
@@ -178,7 +178,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
         guard let url = AnyURL(string: href) else {
             throw LinkError.invalidHREF(href)
         }
-        return url
+        return url.normalized
     }
 
     /// Returns the URL represented by this link's HREF, resolved to the given

--- a/Sources/Shared/Publication/Link.swift
+++ b/Sources/Shared/Publication/Link.swift
@@ -167,7 +167,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
         if href.isEmpty {
             href = "#"
         }
-        return (AnyURL(string: href) ?? AnyURL(legacyHREF: href))!.normalized
+        return (AnyURL(string: href) ?? AnyURL(legacyHREF: href))!
     }
 
     /// Returns the URL represented by this link's HREF, resolved to the given
@@ -286,12 +286,14 @@ public extension Array where Element == Link {
 
     /// Finds the first link matching the given HREF.
     func firstWithHREF<T: URLConvertible>(_ href: T) -> Link? {
-        first { $0.url() == href.anyURL }
+        let href = href.anyURL.normalized.string
+        return first { $0.url().normalized.string == href }
     }
 
     /// Finds the index of the first link matching the given HREF.
     func firstIndexWithHREF<T: URLConvertible>(_ href: T) -> Int? {
-        firstIndex { $0.url() == href.anyURL }
+        let href = href.anyURL.normalized.string
+        return firstIndex { $0.url().normalized.string == href }
     }
 
     /// Finds the first link matching the given media type.

--- a/Sources/Shared/Publication/Link.swift
+++ b/Sources/Shared/Publication/Link.swift
@@ -19,8 +19,8 @@ public struct Link: JSONEquatable, Hashable, Sendable {
     /// Note: a String because templates are lost with URL.
     public var href: String // URI
 
-    /// MIME type of the linked resource.
-    public var type: String?
+    /// Media type of the linked resource.
+    public var mediaType: MediaType?
 
     /// Indicates that a URI template is used in href.
     public var templated: Bool
@@ -57,7 +57,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
 
     public init(
         href: String,
-        type: String? = nil,
+        mediaType: MediaType? = nil,
         templated: Bool = false,
         title: String? = nil,
         rels: [LinkRelation] = [],
@@ -77,7 +77,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
             rels.append(rel)
         }
         self.href = href
-        self.type = type
+        self.mediaType = mediaType
         self.templated = templated
         self.title = title
         self.rels = rels
@@ -117,7 +117,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
 
         self.init(
             href: href,
-            type: jsonObject["type"] as? String,
+            mediaType: (jsonObject["type"] as? String).flatMap { MediaType($0) },
             templated: templated,
             title: jsonObject["title"] as? String,
             rels: .init(json: jsonObject["rel"]),
@@ -135,7 +135,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
     public var json: JSONDictionary.Wrapped {
         makeJSON([
             "href": href,
-            "type": encodeIfNotNil(type),
+            "type": encodeIfNotNil(mediaType?.string),
             "templated": templated,
             "title": encodeIfNotNil(title),
             "rel": encodeIfNotEmpty(rels.json),
@@ -150,15 +150,8 @@ public struct Link: JSONEquatable, Hashable, Sendable {
         ])
     }
 
-    /// Media type of the linked resource.
-    public var mediaType: MediaType {
-        MediaType.of(
-            mediaType: type,
-            fileExtension: href
-                .components(separatedBy: ".")
-                .last
-        ) ?? .binary
-    }
+    @available(*, unavailable, renamed: "mediaType")
+    public var type: String? { mediaType?.string }
 
     /// Returns the URL represented by this link's HREF.
     ///
@@ -166,7 +159,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
     /// according to RFC 6570.
     public func url(
         parameters: [String: LosslessStringConvertible] = [:]
-    ) throws -> AnyURL {
+    ) -> AnyURL {
         var href = href
         if templated {
             href = URITemplate(href).expand(with: parameters)
@@ -174,11 +167,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
         if href.isEmpty {
             href = "#"
         }
-
-        guard let url = AnyURL(string: href) else {
-            throw LinkError.invalidHREF(href)
-        }
-        return url.normalized
+        return AnyURL(string: href)!.normalized
     }
 
     /// Returns the URL represented by this link's HREF, resolved to the given
@@ -189,8 +178,8 @@ public struct Link: JSONEquatable, Hashable, Sendable {
     public func url<T: URLConvertible>(
         relativeTo baseURL: T?,
         parameters: [String: LosslessStringConvertible] = [:]
-    ) throws -> AnyURL {
-        let url = try url(parameters: parameters)
+    ) -> AnyURL {
+        let url = url(parameters: parameters)
         return baseURL?.anyURL.resolve(url) ?? url
     }
 
@@ -221,7 +210,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
     /// Makes a copy of the `Link`, after modifying some of its properties.
     public func copy(
         href: String? = nil,
-        type: String?? = nil,
+        mediaType: MediaType?? = nil,
         templated: Bool? = nil,
         title: String?? = nil,
         rels: [LinkRelation]? = nil,
@@ -236,7 +225,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
     ) -> Link {
         Link(
             href: href ?? self.href,
-            type: type ?? self.type,
+            mediaType: mediaType ?? self.mediaType,
             templated: templated ?? self.templated,
             title: title ?? self.title,
             rels: rels ?? self.rels,
@@ -286,71 +275,71 @@ public extension Array where Element == Link {
     }
 
     /// Finds the first link with the given relation.
-    func first(withRel rel: LinkRelation) -> Link? {
+    func firstWithRel(_ rel: LinkRelation) -> Link? {
         first { $0.rels.contains(rel) }
     }
 
     /// Finds all the links with the given relation.
-    func filter(byRel rel: LinkRelation) -> [Link] {
+    func filterByRel(_ rel: LinkRelation) -> [Link] {
         filter { $0.rels.contains(rel) }
     }
 
     /// Finds the first link matching the given HREF.
-    func first(withHREF href: String) -> Link? {
-        first { $0.href == href }
+    func firstWithHREF<T: URLConvertible>(_ href: T) -> Link? {
+        first { $0.url() == href.anyURL }
     }
 
     /// Finds the index of the first link matching the given HREF.
-    func firstIndex(withHREF href: String) -> Int? {
-        firstIndex { $0.href == href }
+    func firstIndexWithHREF<T: URLConvertible>(_ href: T) -> Int? {
+        firstIndex { $0.url() == href.anyURL }
     }
 
     /// Finds the first link matching the given media type.
-    func first(withMediaType mediaType: MediaType) -> Link? {
-        first { mediaType.matches($0.type) }
+    func firstWithMediaType(_ mediaType: MediaType) -> Link? {
+        first { mediaType.matches($0.mediaType) }
     }
 
     /// Finds all the links matching the given media type.
-    func filter(byMediaType mediaType: MediaType) -> [Link] {
-        filter { mediaType.matches($0.type) }
+    func filterByMediaType(_ mediaType: MediaType) -> [Link] {
+        filter { mediaType.matches($0.mediaType) }
     }
 
     /// Finds all the links matching any of the given media types.
-    func filter(byMediaTypes mediaTypes: [MediaType]) -> [Link] {
+    func filterByMediaTypes(_ mediaTypes: [MediaType]) -> [Link] {
         filter { link in
             mediaTypes.contains { mediaType in
-                mediaType.matches(link.type)
+                mediaType.matches(link.mediaType)
             }
         }
     }
 
     /// Returns whether all the resources in the collection are bitmaps.
     var allAreBitmap: Bool {
-        allSatisfy(\.mediaType.isBitmap)
+        allSatisfy { $0.mediaType?.isBitmap == true }
     }
 
     /// Returns whether all the resources in the collection are audio clips.
     var allAreAudio: Bool {
-        allSatisfy(\.mediaType.isAudio)
+        allSatisfy { $0.mediaType?.isAudio == true }
     }
 
     /// Returns whether all the resources in the collection are video clips.
     var allAreVideo: Bool {
-        allSatisfy(\.mediaType.isVideo)
+        allSatisfy { $0.mediaType?.isVideo == true }
     }
 
     /// Returns whether all the resources in the collection are HTML documents.
     var allAreHTML: Bool {
-        allSatisfy(\.mediaType.isHTML)
+        allSatisfy { $0.mediaType?.isHTML == true }
     }
 
     /// Returns whether all the resources in the collection are matching the given media type.
-    func all(matchMediaType mediaType: MediaType) -> Bool {
+    func allMatchingMediaType(_ mediaType: MediaType) -> Bool {
         allSatisfy { mediaType.matches($0.mediaType) }
     }
 
     /// Returns whether all the resources in the collection are matching any of the given media types.
-    func all(matchMediaTypes mediaTypes: [MediaType]) -> Bool {
+    func allMatchingMediaTypes(_ mediaTypes: [MediaType]) -> Bool {
         allSatisfy { link in
             mediaTypes.contains { mediaType in
                 mediaType.matches(link.mediaType)
@@ -363,13 +352,13 @@ public extension Array where Element == Link {
         firstIndex { ($0.properties.otherProperties[otherProperty] as? T) == matching }
     }
 
-    @available(*, unavailable, renamed: "first(withHREF:)")
+    @available(*, unavailable, renamed: "firstWithHREF")
     func first(withHref href: String) -> Link? {
-        first(withHREF: href)
+        fatalError()
     }
 
-    @available(*, unavailable, renamed: "firstIndex(withHREF:)")
+    @available(*, unavailable, renamed: "firstIndexWithHREF")
     func firstIndex(withHref href: String) -> Int? {
-        firstIndex(withHREF: href)
+        fatalError()
     }
 }

--- a/Sources/Shared/Publication/Link.swift
+++ b/Sources/Shared/Publication/Link.swift
@@ -167,7 +167,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
         if href.isEmpty {
             href = "#"
         }
-        return AnyURL(string: href)!.normalized
+        return (AnyURL(string: href) ?? AnyURL(legacyHREF: href))!.normalized
     }
 
     /// Returns the URL represented by this link's HREF, resolved to the given

--- a/Sources/Shared/Publication/Locator.swift
+++ b/Sources/Shared/Publication/Locator.swift
@@ -75,12 +75,12 @@ public struct Locator: Hashable, CustomStringConvertible, Loggable, Sendable {
             warnings?.log("`href` and `type` required", model: Self.self, source: json)
             throw JSONError.parsing(Self.self)
         }
-        
+
         guard let type = MediaType(typeString) else {
             warnings?.log("`type` is not a valid media type", model: Self.self, source: json)
             throw JSONError.parsing(Self.self)
         }
-        
+
         guard let href = legacyHREF ? AnyURL(legacyHREF: hrefString) : AnyURL(string: hrefString) else {
             warnings?.log("`href` is not a valid URL", model: Self.self, source: json)
             throw JSONError.parsing(Self.self)

--- a/Sources/Shared/Publication/Locator.swift
+++ b/Sources/Shared/Publication/Locator.swift
@@ -10,10 +10,10 @@ import ReadiumInternal
 /// https://github.com/readium/architecture/tree/master/locators
 public struct Locator: Hashable, CustomStringConvertible, Loggable, Sendable {
     /// The URI of the resource that the Locator Object points to.
-    public var href: String // URI
+    public var href: AnyURL
 
     /// The media type of the resource that the Locator Object points to.
-    public var type: String
+    public var mediaType: MediaType
 
     /// The title of the chapter or section which is more relevant in the context of this locator.
     public var title: String?
@@ -24,45 +24,23 @@ public struct Locator: Hashable, CustomStringConvertible, Loggable, Sendable {
     /// Textual context of the locator.
     public var text: Text
 
-    public init(href: String, type: String, title: String? = nil, locations: Locations = .init(), text: Text = .init()) {
-        self.href = href
-        self.type = type
+    @available(*, unavailable, renamed: "mediaType")
+    public var type: String { mediaType.string }
+
+    public init<T: URLConvertible>(href: T, mediaType: MediaType, title: String? = nil, locations: Locations = .init(), text: Text = .init()) {
+        self.href = href.anyURL
+        self.mediaType = mediaType
         self.title = title
         self.locations = locations
         self.text = text
     }
 
     public init?(json: Any?, warnings: WarningLogger? = nil) throws {
-        if json == nil {
-            return nil
-        }
-        guard let jsonObject = json as? JSONDictionary.Wrapped,
-              let href = jsonObject["href"] as? String,
-              let type = jsonObject["type"] as? String
-        else {
-            warnings?.log("`href` and `type` required", model: Self.self, source: json)
-            throw JSONError.parsing(Self.self)
-        }
-
-        try self.init(
-            href: href,
-            type: type,
-            title: jsonObject["title"] as? String,
-            locations: Locations(json: jsonObject["locations"], warnings: warnings),
-            text: Text(json: jsonObject["text"], warnings: warnings)
-        )
+        try self.init(json: json, warnings: warnings, legacyHREF: false)
     }
 
     public init?(jsonString: String, warnings: WarningLogger? = nil) throws {
-        let json: Any
-        do {
-            json = try JSONSerialization.jsonObject(with: jsonString.data(using: .utf8)!)
-        } catch {
-            warnings?.log("Invalid Locator object: \(error)", model: Self.self)
-            throw JSONError.parsing(Self.self)
-        }
-
-        try self.init(json: json, warnings: warnings)
+        try self.init(jsonString: jsonString, warnings: warnings, legacyHREF: false)
     }
 
     /// Creates a ``Locator`` from its legacy JSON representation.
@@ -71,12 +49,50 @@ public struct Locator: Hashable, CustomStringConvertible, Loggable, Sendable {
     /// the ``Locator`` objects stored in your database. See the migration guide
     /// for more information.
     public init?(legacyJSONString: String, warnings: WarningLogger? = nil) throws {
-        try self.init(jsonString: legacyJSONString, warnings: warnings)
+        try self.init(jsonString: legacyJSONString, warnings: warnings, legacyHREF: true)
+    }
 
-        guard let url = AnyURL(legacyHREF: href) else {
+    private init?(jsonString: String, warnings: WarningLogger?, legacyHREF: Bool) throws {
+        let json: Any
+        do {
+            json = try JSONSerialization.jsonObject(with: jsonString.data(using: .utf8)!)
+        } catch {
+            warnings?.log("Invalid Locator object: \(error)", model: Self.self)
+            throw JSONError.parsing(Self.self)
+        }
+
+        try self.init(json: json, warnings: warnings, legacyHREF: legacyHREF)
+    }
+
+    private init?(json: Any?, warnings: WarningLogger?, legacyHREF: Bool) throws {
+        if json == nil {
             return nil
         }
-        href = url.string
+        guard let jsonObject = json as? JSONDictionary.Wrapped,
+              let hrefString = jsonObject["href"] as? String,
+              let typeString = jsonObject["type"] as? String
+        else {
+            warnings?.log("`href` and `type` required", model: Self.self, source: json)
+            throw JSONError.parsing(Self.self)
+        }
+        
+        guard let type = MediaType(typeString) else {
+            warnings?.log("`type` is not a valid media type", model: Self.self, source: json)
+            throw JSONError.parsing(Self.self)
+        }
+        
+        guard let href = legacyHREF ? AnyURL(legacyHREF: hrefString) : AnyURL(string: hrefString) else {
+            warnings?.log("`href` is not a valid URL", model: Self.self, source: json)
+            throw JSONError.parsing(Self.self)
+        }
+
+        try self.init(
+            href: href,
+            mediaType: type,
+            title: jsonObject["title"] as? String,
+            locations: Locations(json: jsonObject["locations"], warnings: warnings),
+            text: Text(json: jsonObject["text"], warnings: warnings)
+        )
     }
 
     @available(*, unavailable, message: "This may create an incorrect `Locator` if the link `type` is missing. Use `publication.locate(Link)` instead.")
@@ -84,8 +100,8 @@ public struct Locator: Hashable, CustomStringConvertible, Loggable, Sendable {
 
     public var json: JSONDictionary.Wrapped {
         makeJSON([
-            "href": href,
-            "type": type,
+            "href": href.string,
+            "type": mediaType.string,
             "title": encodeIfNotNil(title),
             "locations": encodeIfNotEmpty(locations.json),
             "text": encodeIfNotEmpty(text.json),
@@ -101,15 +117,38 @@ public struct Locator: Hashable, CustomStringConvertible, Loggable, Sendable {
     }
 
     /// Makes a copy of the `Locator`, after modifying some of its components.
-    public func copy(href: String? = nil, type: String? = nil, title: String?? = nil, locations transformLocations: ((inout Locations) -> Void)? = nil, text transformText: ((inout Text) -> Void)? = nil) -> Locator {
+    public func copy(
+        href: AnyURL? = nil,
+        mediaType: MediaType? = nil,
+        title: String?? = nil,
+        locations transformLocations: ((inout Locations) -> Void)? = nil,
+        text transformText: ((inout Text) -> Void)? = nil
+    ) -> Locator {
         var locations = locations
         var text = text
         transformLocations?(&locations)
         transformText?(&text)
         return Locator(
             href: href ?? self.href,
-            type: type ?? self.type,
+            mediaType: mediaType ?? self.mediaType,
             title: title ?? self.title,
+            locations: locations,
+            text: text
+        )
+    }
+
+    /// Makes a copy of the `Locator`, after modifying some of its components.
+    public func copy<T: URLConvertible>(
+        href: T?,
+        mediaType: MediaType? = nil,
+        title: String?? = nil,
+        locations: ((inout Locations) -> Void)? = nil,
+        text: ((inout Text) -> Void)? = nil
+    ) -> Locator {
+        copy(
+            href: href?.anyURL,
+            mediaType: mediaType,
+            title: title,
             locations: locations,
             text: text
         )

--- a/Sources/Shared/Publication/Manifest.swift
+++ b/Sources/Shared/Publication/Manifest.swift
@@ -125,7 +125,7 @@ public struct Manifest: JSONEquatable, Hashable, Sendable {
         func deepFind(href: AnyURL, in linkLists: [[Link]]) -> Link? {
             for links in linkLists {
                 for link in links {
-                    if link.url() == href {
+                    if link.url().normalized.string == href.string {
                         return link
                     } else if let child = deepFind(href: href, in: [link.alternates, link.children]) {
                         return child

--- a/Sources/Shared/Publication/Manifest.swift
+++ b/Sources/Shared/Publication/Manifest.swift
@@ -77,9 +77,9 @@ public struct Manifest: JSONEquatable, Hashable, Sendable {
 
         // `readingOrder` used to be `spine`, so we parse `spine` as a fallback.
         readingOrder = [Link](json: json.pop("readingOrder") ?? json.pop("spine"), warnings: warnings)
-            .filter { $0.type != nil }
+            .filter { $0.mediaType != nil }
         resources = [Link](json: json.pop("resources"), warnings: warnings)
-            .filter { $0.type != nil }
+            .filter { $0.mediaType != nil }
 
         // Parses sub-collections from remaining JSON properties.
         subcollections = PublicationCollection.makeCollections(json: json.json, warnings: warnings)
@@ -112,7 +112,7 @@ public struct Manifest: JSONEquatable, Hashable, Sendable {
             // it could be a regular Web Publication.
             return readingOrder.allAreHTML && metadata.conformsTo.contains(.epub)
         case .pdf:
-            return readingOrder.all(matchMediaType: .pdf)
+            return readingOrder.allMatchingMediaType(.pdf)
         default:
             break
         }
@@ -121,13 +121,13 @@ public struct Manifest: JSONEquatable, Hashable, Sendable {
     }
 
     /// Finds the first Link having the given `href` in the manifest's links.
-    public func link(withHREF href: String) -> Link? {
-        func deepFind(in linkLists: [Link]...) -> Link? {
+    public func linkWithHREF<T: URLConvertible>(_ href: T) -> Link? {
+        func deepFind(href: AnyURL, in linkLists: [[Link]]) -> Link? {
             for links in linkLists {
                 for link in links {
-                    if link.href == href {
+                    if link.url() == href {
                         return link
-                    } else if let child = deepFind(in: link.alternates, link.children) {
+                    } else if let child = deepFind(href: href, in: [link.alternates, link.children]) {
                         return child
                     }
                 }
@@ -136,29 +136,38 @@ public struct Manifest: JSONEquatable, Hashable, Sendable {
             return nil
         }
 
-        var link = deepFind(in: readingOrder, resources, links)
-        if
-            link == nil,
-            let shortHREF = href.components(separatedBy: .init(charactersIn: "#?")).first,
-            shortHREF != href
-        {
-            // Tries again, but without the anchor and query parameters.
-            link = self.link(withHREF: shortHREF)
-        }
+        let href = href.anyURL.normalized
+        let links = [readingOrder, resources, links]
 
-        return link
+        return deepFind(href: href, in: links)
+            ?? deepFind(href: href.removingQuery().removingFragment(), in: links)
     }
 
     /// Finds the first link with the given relation in the manifest's links.
-    public func link(withRel rel: LinkRelation) -> Link? {
-        readingOrder.first(withRel: rel)
-            ?? resources.first(withRel: rel)
-            ?? links.first(withRel: rel)
+    public func linkWithRel(_ rel: LinkRelation) -> Link? {
+        readingOrder.firstWithRel(rel)
+            ?? resources.firstWithRel(rel)
+            ?? links.firstWithRel(rel)
     }
 
     /// Finds all the links with the given relation in the manifest's links.
+    public func linksWithRel(_ rel: LinkRelation) -> [Link] {
+        (readingOrder + resources + links).filterByRel(rel)
+    }
+
+    @available(*, unavailable, renamed: "linkWithHREF")
+    public func link(withHREF href: String) -> Link? {
+        fatalError()
+    }
+
+    @available(*, unavailable, renamed: "linkWithRel")
+    public func link(withRel rel: LinkRelation) -> Link? {
+        fatalError()
+    }
+
+    @available(*, unavailable, renamed: "linksWithRel")
     public func links(withRel rel: LinkRelation) -> [Link] {
-        (readingOrder + resources + links).filter(byRel: rel)
+        fatalError()
     }
 
     /// Makes a copy of the `Manifest`, after modifying some of its properties.

--- a/Sources/Shared/Publication/Publication.swift
+++ b/Sources/Shared/Publication/Publication.swift
@@ -169,15 +169,12 @@ public class Publication: Loggable {
                     ?? relativeHREF.anyURL
             }
 
-            locator.href = locator.href.normalized
-
         } else { // Packaged publication
             if let href = AnyURL(string: locator.href.string.removingPrefix("/")) {
                 locator.href = href
             }
         }
 
-        locator.href = locator.href.normalized
         return locator
     }
 

--- a/Sources/Shared/Publication/Publication.swift
+++ b/Sources/Shared/Publication/Publication.swift
@@ -78,24 +78,39 @@ public class Publication: Loggable {
     ///
     /// e.g. https://provider.com/pub1293/manifest.json gives https://provider.com/pub1293/
     public var baseURL: HTTPURL? {
-        links.first(withRel: .`self`)
+        links.firstWithRel(.`self`)
             .takeIf { !$0.templated }
             .flatMap { HTTPURL(string: $0.href)?.removingLastPathSegment() }
     }
 
     /// Finds the first Link having the given `href` in the publication's links.
-    public func link(withHREF href: String) -> Link? {
-        manifest.link(withHREF: href)
+    public func linkWithHREF<T: URLConvertible>(_ href: T) -> Link? {
+        manifest.linkWithHREF(href)
     }
 
     /// Finds the first link with the given relation in the publication's links.
-    public func link(withRel rel: LinkRelation) -> Link? {
-        manifest.link(withRel: rel)
+    public func linkWithRel(_ rel: LinkRelation) -> Link? {
+        manifest.linkWithRel(rel)
     }
 
     /// Finds all the links with the given relation in the publication's links.
+    public func linksWithRel(_ rel: LinkRelation) -> [Link] {
+        manifest.linksWithRel(rel)
+    }
+
+    @available(*, unavailable, renamed: "linkWithHREF")
+    public func link(withHREF href: String) -> Link? {
+        fatalError()
+    }
+
+    @available(*, unavailable, renamed: "linkWithRel")
+    public func link(withRel rel: LinkRelation) -> Link? {
+        fatalError()
+    }
+
+    @available(*, unavailable, renamed: "linksWithRel")
     public func links(withRel rel: LinkRelation) -> [Link] {
-        manifest.links(withRel: rel)
+        fatalError()
     }
 
     /// Returns the resource targeted by the given `link`.
@@ -107,10 +122,10 @@ public class Publication: Loggable {
     }
 
     /// Returns the resource targeted by the given `href`.
-    public func get(_ href: String) -> Resource {
-        var link = link(withHREF: href) ?? Link(href: href)
+    public func get<T: URLConvertible>(_ href: T) -> Resource {
+        var link = linkWithHREF(href) ?? Link(href: href.anyURL.string)
         // Uses the original href to keep the query parameters
-        link.href = href
+        link.href = href.anyURL.string
         link.templated = false
         return get(link)
     }
@@ -145,25 +160,24 @@ public class Publication: Loggable {
     /// we still need to support the locators created with the old absolute
     /// HREFs.
     public func normalizeLocator(_ locator: Locator) -> Locator {
-        guard var href = AnyURL(string: locator.href) else {
-            return locator
-        }
-
         var locator = locator
 
         if let baseURL = baseURL { // Remote publication
             // Check that the locator HREF relative to `baseURL` exists in the manifest.
-            if let relativeHREF = baseURL.relativize(href) {
-                href = (try? link(withHREF: relativeHREF.string)?.url())
+            if let relativeHREF = baseURL.relativize(locator.href) {
+                locator.href = linkWithHREF(relativeHREF)?.url()
                     ?? relativeHREF.anyURL
             }
 
-            locator.href = href.normalized.string
+            locator.href = locator.href.normalized
 
         } else { // Packaged publication
-            locator.href = href.normalized.string.removingPrefix("/")
+            if let href = AnyURL(string: locator.href.string.removingPrefix("/")) {
+                locator.href = href
+            }
         }
         
+        locator.href = locator.href.normalized
         return locator
     }
 

--- a/Sources/Shared/Publication/Publication.swift
+++ b/Sources/Shared/Publication/Publication.swift
@@ -151,7 +151,7 @@ public class Publication: Loggable {
     /// Sets the URL where this `Publication`'s RWPM manifest is served.
     @available(*, unavailable, message: "Not used anymore")
     public func setSelfLink(href: String?) { fatalError() }
-    
+
     /// Historically, we used to have "absolute" HREFs in the manifest:
     ///  - starting with a `/` for packaged publications.
     ///  - resolved to the `self` link for remote publications.
@@ -176,11 +176,10 @@ public class Publication: Loggable {
                 locator.href = href
             }
         }
-        
+
         locator.href = locator.href.normalized
         return locator
     }
-
 
     /// Represents a Readium Web Publication Profile a `Publication` can conform to.
     ///

--- a/Sources/Shared/Publication/Services/Content/Iterators/HTMLResourceContentIterator.swift
+++ b/Sources/Shared/Publication/Services/Content/Iterators/HTMLResourceContentIterator.swift
@@ -28,7 +28,7 @@ public class HTMLResourceContentIterator: ContentIterator {
             resource: Resource,
             locator: Locator
         ) -> ContentIterator? {
-            guard resource.link.mediaType.isHTML else {
+            guard resource.link.mediaType?.isHTML == true else {
                 return nil
             }
 
@@ -158,7 +158,7 @@ public class HTMLResourceContentIterator: ContentIterator {
 
         init(baseLocator: Locator, startElement: Element?, beforeMaxLength: Int) {
             self.baseLocator = baseLocator
-            baseHREF = AnyURL(string: baseLocator.href)
+            baseHREF = baseLocator.href
             self.startElement = startElement
             self.beforeMaxLength = beforeMaxLength
         }
@@ -257,7 +257,12 @@ public class HTMLResourceContentIterator: ContentIterator {
                             let sources = try node.select("source")
                                 .compactMap { source in
                                     try source.srcRelativeToHREF(baseHREF).map { href in
-                                        try Link(href: href.string, type: source.attr("type").takeUnlessBlank())
+                                        try Link(
+                                            href: href.string,
+                                            mediaType: source.attr("type")
+                                                .takeUnlessBlank()
+                                                .flatMap { MediaType($0) }
+                                        )
                                     }
                                 }
 

--- a/Sources/Shared/Publication/Services/Content/Iterators/PublicationContentIterator.swift
+++ b/Sources/Shared/Publication/Services/Content/Iterators/PublicationContentIterator.swift
@@ -86,7 +86,7 @@ public class PublicationContentIterator: ContentIterator, Loggable {
 
     /// Returns the first iterator starting at `startLocator` or the beginning of the publication.
     private func initialIterator() -> IndexedIterator? {
-        let index = startLocator.flatMap { publication.readingOrder.firstIndex(withHREF: $0.href) } ?? 0
+        let index = startLocator.flatMap { publication.readingOrder.firstIndexWithHREF($0.href) } ?? 0
         let location = startLocator.orProgression(0.0)
 
         return loadIterator(at: index, location: location)

--- a/Sources/Shared/Publication/Services/Cover/CoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/CoverService.swift
@@ -63,7 +63,7 @@ public extension Publication {
 
     /// Extracts the first valid cover from the manifest links with `cover` relation.
     private func coverFromManifest() -> UIImage? {
-        for link in links(withRel: .cover) {
+        for link in linksWithRel(.cover) {
             if let cover = try? get(link).read().map(UIImage.init).get() {
                 return cover
             }

--- a/Sources/Shared/Publication/Services/Cover/GeneratedCoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/GeneratedCoverService.swift
@@ -26,7 +26,7 @@ public final class GeneratedCoverService: CoverService {
 
     private let coverLink = Link(
         href: "/~readium/cover",
-        type: "image/png",
+        mediaType: .png,
         rel: .cover
     )
 

--- a/Sources/Shared/Publication/Services/Locator/DefaultLocatorService.swift
+++ b/Sources/Shared/Publication/Services/Locator/DefaultLocatorService.swift
@@ -24,7 +24,7 @@ open class DefaultLocatorService: LocatorService, Loggable {
             return nil
         }
 
-        if publication.link(withHREF: locator.href) != nil {
+        if publication.linkWithHREF(locator.href) != nil {
             return locator
         }
 
@@ -39,20 +39,20 @@ open class DefaultLocatorService: LocatorService, Loggable {
     }
 
     open func locate(_ link: Link) -> Locator? {
-        let components = link.href.split(separator: "#", maxSplits: 1).map(String.init)
-        let href = components.first ?? link.href
-        let fragment = components.getOrNil(1)
+        let originalHREF = link.url()
+        let fragment = originalHREF.fragment
+        let href = originalHREF.removingFragment()
 
         guard
-            let resourceLink = publication()?.link(withHREF: href),
-            let type = resourceLink.type
+            let resourceLink = publication()?.linkWithHREF(href),
+            let type = resourceLink.mediaType
         else {
             return nil
         }
 
         return Locator(
             href: href,
-            type: type,
+            mediaType: type,
             title: resourceLink.title ?? link.title,
             locations: Locator.Locations(
                 fragments: Array(ofNotNil: fragment),

--- a/Sources/Shared/Publication/Services/Positions/PerResourcePositionsService.swift
+++ b/Sources/Shared/Publication/Services/Positions/PerResourcePositionsService.swift
@@ -12,9 +12,9 @@ public final class PerResourcePositionsService: PositionsService {
     private let readingOrder: [Link]
 
     /// Media type that will be used as a fallback if the `Link` doesn't specify any.
-    private let fallbackMediaType: String
+    private let fallbackMediaType: MediaType
 
-    init(readingOrder: [Link], fallbackMediaType: String) {
+    init(readingOrder: [Link], fallbackMediaType: MediaType) {
         self.readingOrder = readingOrder
         self.fallbackMediaType = fallbackMediaType
     }
@@ -24,8 +24,8 @@ public final class PerResourcePositionsService: PositionsService {
     public lazy var positionsByReadingOrder: [[Locator]] = readingOrder.enumerated().map { index, link in
         [
             Locator(
-                href: link.href,
-                type: link.type ?? fallbackMediaType,
+                href: link.url(),
+                mediaType: link.mediaType ?? fallbackMediaType,
                 title: link.title,
                 locations: Locator.Locations(
                     totalProgression: Double(index) / Double(pageCount),
@@ -35,7 +35,7 @@ public final class PerResourcePositionsService: PositionsService {
         ]
     }
 
-    public static func makeFactory(fallbackMediaType: String) -> (PublicationServiceContext) -> PerResourcePositionsService {
+    public static func makeFactory(fallbackMediaType: MediaType) -> (PublicationServiceContext) -> PerResourcePositionsService {
         { context in
             PerResourcePositionsService(readingOrder: context.manifest.readingOrder, fallbackMediaType: fallbackMediaType)
         }

--- a/Sources/Shared/Publication/Services/Positions/PositionsService.swift
+++ b/Sources/Shared/Publication/Services/Positions/PositionsService.swift
@@ -25,7 +25,7 @@ public extension PositionsService {
 
 private let positionsLink = Link(
     href: "/~readium/positions",
-    type: MediaType.readiumPositions.string
+    mediaType: MediaType.readiumPositions
 )
 
 public extension PositionsService {
@@ -63,7 +63,7 @@ public extension Publication {
         }
 
         let positionsByResource = Dictionary(grouping: positionsFromManifest(), by: { $0.href })
-        return readingOrder.map { positionsByResource[$0.href] ?? [] }
+        return readingOrder.map { positionsByResource[$0.url()] ?? [] }
     }
 
     /// List of all the positions in the publication.
@@ -74,7 +74,7 @@ public extension Publication {
 
     /// Fetches the positions from a web service declared in the manifest, if there's one.
     private func positionsFromManifest() -> [Locator] {
-        links.first(withMediaType: .readiumPositions)
+        links.firstWithMediaType(.readiumPositions)
             .map { get($0) }?
             .readAsJSON()
             .map { $0["positions"] }

--- a/Sources/Shared/Toolkit/HTTP/HTTPRequest.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPRequest.swift
@@ -180,7 +180,7 @@ extension String: HTTPRequestConvertible {
 
 extension Link: HTTPRequestConvertible {
     public func httpRequest() -> HTTPResult<HTTPRequest> {
-        guard let url = try? url().httpURL else {
+        guard let url = url().httpURL else {
             return .failure(HTTPError(kind: .malformedRequest(url: href)))
         }
         return url.httpRequest()

--- a/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPServer.swift
@@ -54,7 +54,7 @@ public extension HTTPServer {
             return FileResource(
                 link: Link(
                     href: request.url.string,
-                    type: MediaType.of(file)?.string
+                    mediaType: MediaType.of(file)
                 ),
                 file: file
             )
@@ -91,7 +91,7 @@ public extension HTTPServer {
                 )
             }
 
-            return publication.get(href.string)
+            return publication.get(href)
         }
 
         return try serve(

--- a/Sources/Shared/Toolkit/Media Type/MediaTypeSniffer.swift
+++ b/Sources/Shared/Toolkit/Media Type/MediaTypeSniffer.swift
@@ -146,7 +146,7 @@ public extension MediaType {
             return .opds2Publication
         }
         if let rwpm = context.contentAsRWPM {
-            if rwpm.link(withRel: .`self`)?.type == "application/opds+json" {
+            if rwpm.linkWithRel(.`self`)?.mediaType?.matches(.opds2) == true {
                 return .opds2
             }
             if rwpm.link(withRelMatching: { $0.hasPrefix("http://opds-spec.org/acquisition") }) != nil {
@@ -238,7 +238,7 @@ public extension MediaType {
             if isLCPProtected, rwpm.conforms(to: .pdf) {
                 return .lcpProtectedPDF
             }
-            if rwpm.link(withRel: .`self`)?.type == "application/webpub+json" {
+            if rwpm.linkWithRel(.`self`)?.mediaType?.matches(.readiumWebPubManifest) == true {
                 return isManifest ? .readiumWebPubManifest : .readiumWebPub
             }
         }

--- a/Sources/Shared/Toolkit/PDF/PDFOutlineNode.swift
+++ b/Sources/Shared/Toolkit/PDF/PDFOutlineNode.swift
@@ -29,7 +29,7 @@ public struct PDFOutlineNode {
     public func link(withDocumentHREF documentHREF: String) -> Link {
         Link(
             href: "\(documentHREF)#page=\(pageNumber)",
-            type: MediaType.pdf.string,
+            mediaType: .pdf,
             title: title,
             children: children.links(withDocumentHREF: documentHREF)
         )

--- a/Sources/Shared/Toolkit/URL/Absolute URL/FileURL.swift
+++ b/Sources/Shared/Toolkit/URL/Absolute URL/FileURL.swift
@@ -66,16 +66,6 @@ public struct FileURL: AbsoluteURL, Hashable, Sendable {
     public func isDirectory() throws -> Bool {
         try (url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
     }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(path)
-        hasher.combine(url.user)
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.path == rhs.path
-            && lhs.url.user == rhs.url.user
-    }
 }
 
 public extension URLConvertible {

--- a/Sources/Shared/Toolkit/URL/Absolute URL/FileURL.swift
+++ b/Sources/Shared/Toolkit/URL/Absolute URL/FileURL.swift
@@ -66,6 +66,17 @@ public struct FileURL: AbsoluteURL, Hashable, Sendable {
     public func isDirectory() throws -> Bool {
         try (url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
     }
+
+    /// Strict URL comparisons can be a source of bug, if the URLs are not
+    /// normalized. In most cases, you should compare using
+    /// `isEquivalent()`.
+    ///
+    /// To ignore this warning, compare `FileURL.string` instead of
+    /// `FileURL` itself.
+    @available(*, deprecated, message: "Strict URL comparisons can be a source of bug. Use isEquivalent() instead.")
+    public static func == (lhs: FileURL, rhs: FileURL) -> Bool {
+        lhs.string == rhs.string
+    }
 }
 
 public extension URLConvertible {

--- a/Sources/Shared/Toolkit/URL/Absolute URL/HTTPURL.swift
+++ b/Sources/Shared/Toolkit/URL/Absolute URL/HTTPURL.swift
@@ -35,6 +35,17 @@ public struct HTTPURL: AbsoluteURL, Hashable, Sendable {
         }
         return o
     }
+
+    /// Strict URL comparisons can be a source of bug, if the URLs are not
+    /// normalized. In most cases, you should compare using
+    /// `isEquivalent()`.
+    ///
+    /// To ignore this warning, compare `HTTPURL.string` instead of
+    /// `HTTPURL` itself.
+    @available(*, deprecated, message: "Strict URL comparisons can be a source of bug. Use isEquivalent() instead.")
+    public static func == (lhs: HTTPURL, rhs: HTTPURL) -> Bool {
+        lhs.string == rhs.string
+    }
 }
 
 public extension URLConvertible {

--- a/Sources/Shared/Toolkit/URL/Absolute URL/HTTPURL.swift
+++ b/Sources/Shared/Toolkit/URL/Absolute URL/HTTPURL.swift
@@ -35,22 +35,6 @@ public struct HTTPURL: AbsoluteURL, Hashable, Sendable {
         }
         return o
     }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(origin)
-        hasher.combine(path)
-        hasher.combine(query)
-        hasher.combine(fragment)
-        hasher.combine(url.user)
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.origin == rhs.origin
-            && lhs.path == rhs.path
-            && lhs.query == rhs.query
-            && lhs.fragment == rhs.fragment
-            && lhs.url.user == rhs.url.user
-    }
 }
 
 public extension URLConvertible {

--- a/Sources/Shared/Toolkit/URL/Absolute URL/UnknownAbsoluteURL.swift
+++ b/Sources/Shared/Toolkit/URL/Absolute URL/UnknownAbsoluteURL.swift
@@ -23,24 +23,4 @@ struct UnknownAbsoluteURL: AbsoluteURL, Hashable {
     let url: URL
     let scheme: URLScheme
     let origin: String? = nil
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(scheme)
-        hasher.combine(host)
-        hasher.combine(url.port)
-        hasher.combine(path)
-        hasher.combine(query)
-        hasher.combine(fragment)
-        hasher.combine(url.user)
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.scheme == rhs.scheme
-            && lhs.host == rhs.host
-            && lhs.url.port == rhs.url.port
-            && lhs.path == rhs.path
-            && lhs.query == rhs.query
-            && lhs.fragment == rhs.fragment
-            && lhs.url.user == rhs.url.user
-    }
 }

--- a/Sources/Shared/Toolkit/URL/Absolute URL/UnknownAbsoluteURL.swift
+++ b/Sources/Shared/Toolkit/URL/Absolute URL/UnknownAbsoluteURL.swift
@@ -23,4 +23,15 @@ struct UnknownAbsoluteURL: AbsoluteURL, Hashable {
     let url: URL
     let scheme: URLScheme
     let origin: String? = nil
+
+    /// Strict URL comparisons can be a source of bug, if the URLs are not
+    /// normalized. In most cases, you should compare using
+    /// `isEquivalent()`.
+    ///
+    /// To ignore this warning, compare `UnknownAbsoluteURL.string` instead of
+    /// `UnknownAbsoluteURL` itself.
+    @available(*, deprecated, message: "Strict URL comparisons can be a source of bug. Use isEquivalent() instead.")
+    public static func == (lhs: UnknownAbsoluteURL, rhs: UnknownAbsoluteURL) -> Bool {
+        lhs.string == rhs.string
+    }
 }

--- a/Sources/Shared/Toolkit/URL/AnyURL.swift
+++ b/Sources/Shared/Toolkit/URL/AnyURL.swift
@@ -114,6 +114,13 @@ extension AnyURL: URLConvertible {
 
 /// Implements `Hashable` and `Equatable`.
 extension AnyURL: Hashable {
+    /// Strict URL comparisons can be a source of bug, if the URLs are not
+    /// normalized. In most cases, you should compare using
+    /// `isEquivalent()`.
+    ///
+    /// To ignore this warning, compare `AnyURL.string` instead of
+    /// `AnyURL` itself.
+    @available(*, deprecated, message: "Strict URL comparisons can be a source of bug. Use isEquivalent() instead.")
     public static func == (lhs: AnyURL, rhs: AnyURL) -> Bool {
         lhs.string == rhs.string
     }

--- a/Sources/Shared/Toolkit/URL/RelativeURL.swift
+++ b/Sources/Shared/Toolkit/URL/RelativeURL.swift
@@ -96,6 +96,17 @@ public struct RelativeURL: URLProtocol, Hashable {
                 .removingPrefix("/")
         )
     }
+
+    /// Strict URL comparisons can be a source of bug, if the URLs are not
+    /// normalized. In most cases, you should compare using
+    /// `isEquivalent()`.
+    ///
+    /// To ignore this warning, compare `RelativeURL.string` instead of
+    /// `RelativeURL` itself.
+    @available(*, deprecated, message: "Strict URL comparisons can be a source of bug. Use isEquivalent() instead.")
+    public static func == (lhs: RelativeURL, rhs: RelativeURL) -> Bool {
+        lhs.string == rhs.string
+    }
 }
 
 /// Implements `URLConvertible`.

--- a/Sources/Shared/Toolkit/URL/RelativeURL.swift
+++ b/Sources/Shared/Toolkit/URL/RelativeURL.swift
@@ -96,18 +96,6 @@ public struct RelativeURL: URLProtocol, Hashable {
                 .removingPrefix("/")
         )
     }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(path)
-        hasher.combine(query)
-        hasher.combine(fragment)
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.path == rhs.path
-            && lhs.query == rhs.query
-            && lhs.fragment == rhs.fragment
-    }
 }
 
 /// Implements `URLConvertible`.

--- a/Sources/Shared/Toolkit/URL/URLProtocol.swift
+++ b/Sources/Shared/Toolkit/URL/URLProtocol.swift
@@ -23,7 +23,7 @@ public extension URLProtocol {
         }
         self.init(url: url)
     }
-    
+
     /// Normalizes the URL using a subset of the RFC-3986 rules.
     /// https://datatracker.ietf.org/doc/html/rfc3986#section-6
     var normalized: Self {
@@ -136,7 +136,6 @@ public extension URLProtocol {
     var description: String { string }
 }
 
-
 private extension String {
     var normalizedPath: String {
         guard !isEmpty else {
@@ -145,7 +144,7 @@ private extension String {
 
         var segments = [String]()
         let pathComponents = split(separator: "/", omittingEmptySubsequences: false)
-        
+
         for component in pathComponents {
             let segment = String(component)
             if segment == ".." {
@@ -160,7 +159,7 @@ private extension String {
                 segments.append(segment)
             }
         }
-        
+
         return segments.joined(separator: "/")
     }
 }

--- a/Sources/Shared/Toolkit/URL/URLProtocol.swift
+++ b/Sources/Shared/Toolkit/URL/URLProtocol.swift
@@ -24,6 +24,9 @@ public extension URLProtocol {
         self.init(url: url)
     }
 
+    /// Returns the string representation for this URL.
+    var string: String { url.absoluteString }
+
     /// Normalizes the URL using a subset of the RFC-3986 rules.
     /// https://datatracker.ietf.org/doc/html/rfc3986#section-6
     var normalized: Self {
@@ -33,8 +36,10 @@ public extension URLProtocol {
         }!)!
     }
 
-    /// Returns the string representation for this URL.
-    var string: String { url.absoluteString }
+    /// Returns whether the two URLs are equivalent after normalization.
+    func isEquivalentTo<T: URLConvertible>(_ url: T) -> Bool {
+        normalized.string == url.anyURL.normalized.string
+    }
 
     /// Decoded path segments identifying a location.
     var path: String {
@@ -161,5 +166,17 @@ private extension String {
         }
 
         return segments.joined(separator: "/")
+    }
+}
+
+public extension Dictionary where Key: URLProtocol {
+    /// Returns the value of the first key matching `key` after normalization.
+    subscript<T: URLConvertible>(equivalent key: T) -> Value? {
+        for (k, v) in self {
+            if k.isEquivalentTo(key) {
+                return v
+            }
+        }
+        return nil
     }
 }

--- a/Sources/Shared/Toolkit/URL/URLProtocol.swift
+++ b/Sources/Shared/Toolkit/URL/URLProtocol.swift
@@ -23,6 +23,15 @@ public extension URLProtocol {
         }
         self.init(url: url)
     }
+    
+    /// Normalizes the URL using a subset of the RFC-3986 rules.
+    /// https://datatracker.ietf.org/doc/html/rfc3986#section-6
+    var normalized: Self {
+        Self(url: url.copy {
+            $0.scheme = $0.scheme?.lowercased()
+            $0.path = path
+        }!.standardized)!
+    }
 
     /// Returns the string representation for this URL.
     var string: String { url.absoluteString }

--- a/Sources/Shared/Toolkit/URL/URLProtocol.swift
+++ b/Sources/Shared/Toolkit/URL/URLProtocol.swift
@@ -8,7 +8,7 @@ import Foundation
 import ReadiumInternal
 
 /// A type that can represent a URL.
-public protocol URLProtocol: CustomStringConvertible, URLConvertible {
+public protocol URLProtocol: URLConvertible, Sendable, CustomStringConvertible {
     /// Creates a new instance of this type from a Foundation ``URL``.
     init?(url: URL)
 

--- a/Sources/Shared/Toolkit/URL/URLProtocol.swift
+++ b/Sources/Shared/Toolkit/URL/URLProtocol.swift
@@ -29,8 +29,8 @@ public extension URLProtocol {
     var normalized: Self {
         Self(url: url.copy {
             $0.scheme = $0.scheme?.lowercased()
-            $0.path = path
-        }!.standardized)!
+            $0.path = path.normalizedPath
+        }!)!
     }
 
     /// Returns the string representation for this URL.
@@ -134,4 +134,33 @@ public extension URLProtocol {
 /// Implements `CustomStringConvertible`
 public extension URLProtocol {
     var description: String { string }
+}
+
+
+private extension String {
+    var normalizedPath: String {
+        guard !isEmpty else {
+            return ""
+        }
+
+        var segments = [String]()
+        let pathComponents = split(separator: "/", omittingEmptySubsequences: false)
+        
+        for component in pathComponents {
+            let segment = String(component)
+            if segment == ".." {
+                if !segments.isEmpty {
+                    // Remove last added directory
+                    segments.removeLast()
+                } else {
+                    // Add ".." to the beginning
+                    segments.append(segment)
+                }
+            } else if segment != "." {
+                segments.append(segment)
+            }
+        }
+        
+        return segments.joined(separator: "/")
+    }
 }

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -24,7 +24,7 @@ public final class AudioParser: PublicationParser {
         }
 
         let defaultReadingOrder = fetcher.links
-            .filter { !ignores($0) && $0.mediaType.isAudio }
+            .filter { !ignores($0) && $0.mediaType?.isAudio == true }
             .sorted { $0.href.localizedStandardCompare($1.href) == .orderedAscending }
 
         guard !defaultReadingOrder.isEmpty else {
@@ -59,7 +59,7 @@ public final class AudioParser: PublicationParser {
 
         // Checks if the fetcher contains only bitmap-based resources.
         return !fetcher.links.isEmpty
-            && fetcher.links.allSatisfy { ignores($0) || $0.mediaType.isAudio }
+            && fetcher.links.allSatisfy { ignores($0) || $0.mediaType?.isAudio == true }
     }
 
     private func ignores(_ link: Link) -> Bool {

--- a/Sources/Streamer/Parser/Audio/Services/AudioLocatorService.swift
+++ b/Sources/Streamer/Parser/Audio/Services/AudioLocatorService.swift
@@ -39,8 +39,8 @@ final class AudioLocatorService: DefaultLocatorService {
         let positionInResource = positionInPublication - resourcePosition
 
         return Locator(
-            href: link.href,
-            type: link.type ?? MediaType.binary.string,
+            href: link.url(),
+            mediaType: link.mediaType ?? .binary,
             locations: .init(
                 fragments: ["t=\(Int(positionInResource))"],
                 progression: link.duration.map { duration in

--- a/Sources/Streamer/Parser/EPUB/EPUBParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBParser.swift
@@ -102,7 +102,7 @@ public final class EPUBParser: PublicationParser {
     private func parseNavigationDocument(in fetcher: Fetcher, links: [Link]) -> [String: [PublicationCollection]] {
         // Get the link in the readingOrder pointing to the Navigation Document.
         guard
-            let navLink = links.first(withRel: .contents),
+            let navLink = links.firstWithRel(.contents),
             let navURI = RelativeURL(string: navLink.href),
             let navDocumentData = try? fetcher.readData(at: navURI)
         else {
@@ -137,7 +137,7 @@ public final class EPUBParser: PublicationParser {
     private func parseNCXDocument(in fetcher: Fetcher, links: [Link]) -> [String: [PublicationCollection]] {
         // Get the link in the readingOrder pointing to the NCX document.
         guard
-            let ncxLink = links.first(withMediaType: .ncx),
+            let ncxLink = links.firstWithMediaType(.ncx),
             let ncxURI = RelativeURL(string: ncxLink.href),
             let ncxDocumentData = try? fetcher.readData(at: ncxURI)
         else {

--- a/Sources/Streamer/Parser/EPUB/OPFParser.swift
+++ b/Sources/Streamer/Parser/EPUB/OPFParser.swift
@@ -174,7 +174,7 @@ final class OPFParser: Loggable {
 
         var properties = parseStringProperties(stringProperties)
 
-        if let encryption = encryptions[href]?.json, !encryption.isEmpty {
+        if let encryption = encryptions[equivalent: href]?.json, !encryption.isEmpty {
             properties["encrypted"] = encryption
         }
 

--- a/Sources/Streamer/Parser/EPUB/OPFParser.swift
+++ b/Sources/Streamer/Parser/EPUB/OPFParser.swift
@@ -186,7 +186,7 @@ final class OPFParser: Loggable {
 
         return Link(
             href: href.string,
-            type: type,
+            mediaType: type.flatMap { MediaType($0) },
             rels: rels,
             properties: Properties(properties)
         )

--- a/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBHTMLInjector.swift
+++ b/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBHTMLInjector.swift
@@ -25,7 +25,7 @@ final class EPUBHTMLInjector {
             // Will be empty when the new Settings API is in use.
             !userProperties.properties.isEmpty,
             // We only transform HTML resources.
-            resource.link.mediaType.isHTML
+            resource.link.mediaType?.isHTML == true
         else {
             return resource
         }

--- a/Sources/Streamer/Parser/EPUB/Services/EPUBPositionsService.swift
+++ b/Sources/Streamer/Parser/EPUB/Services/EPUBPositionsService.swift
@@ -134,8 +134,8 @@ public final class EPUBPositionsService: PositionsService {
 
     private func makeLocator(for link: Link, progression: Double, position: Int) -> Locator {
         Locator(
-            href: link.href,
-            type: link.type ?? MediaType.html.string,
+            href: link.url(),
+            mediaType: link.mediaType ?? .html,
             title: link.title,
             locations: .init(
                 progression: progression,

--- a/Sources/Streamer/Parser/Image/ImageParser.swift
+++ b/Sources/Streamer/Parser/Image/ImageParser.swift
@@ -20,7 +20,7 @@ public final class ImageParser: PublicationParser {
         }
 
         var readingOrder = fetcher.links
-            .filter { !ignores($0) && $0.mediaType.isBitmap }
+            .filter { !ignores($0) && $0.mediaType?.isBitmap == true }
             .sorted { $0.href.localizedStandardCompare($1.href) == .orderedAscending }
 
         guard !readingOrder.isEmpty else {
@@ -41,7 +41,7 @@ public final class ImageParser: PublicationParser {
             ),
             fetcher: fetcher,
             servicesBuilder: .init(
-                positions: PerResourcePositionsService.makeFactory(fallbackMediaType: "image/*")
+                positions: PerResourcePositionsService.makeFactory(fallbackMediaType: MediaType("image/*")!)
             )
         )
     }
@@ -53,7 +53,7 @@ public final class ImageParser: PublicationParser {
 
         // Checks if the fetcher contains only bitmap-based resources.
         return !fetcher.links.isEmpty
-            && fetcher.links.allSatisfy { ignores($0) || $0.mediaType.isBitmap }
+            && fetcher.links.allSatisfy { ignores($0) || $0.mediaType?.isBitmap == true }
     }
 
     private func ignores(_ link: Link) -> Bool {

--- a/Sources/Streamer/Parser/PDF/PDFParser.swift
+++ b/Sources/Streamer/Parser/PDF/PDFParser.swift
@@ -36,7 +36,7 @@ public final class PDFParser: PublicationParser, Loggable {
             return nil
         }
 
-        let readingOrder = fetcher.links.filter(byMediaType: .pdf)
+        let readingOrder = fetcher.links.filterByMediaType(.pdf)
         guard let firstLink = readingOrder.first else {
             throw PDFDocumentError.openFailed
         }

--- a/Sources/Streamer/Parser/PDF/Services/LCPDFPositionsService.swift
+++ b/Sources/Streamer/Parser/PDF/Services/LCPDFPositionsService.swift
@@ -50,8 +50,8 @@ final class LCPDFPositionsService: PositionsService, PDFPublicationService, Logg
             let progression = Double(position - 1) / Double(pageCount)
             let totalProgression = Double(startPosition + position - 1) / Double(totalPageCount)
             return Locator(
-                href: link.href,
-                type: link.type ?? MediaType.pdf.string,
+                href: link.url(),
+                mediaType: link.mediaType ?? .pdf,
                 locations: .init(
                     fragments: ["page=\(position)"],
                     progression: progression,

--- a/Sources/Streamer/Parser/PDF/Services/PDFPositionsService.swift
+++ b/Sources/Streamer/Parser/PDF/Services/PDFPositionsService.swift
@@ -18,8 +18,8 @@ final class PDFPositionsService: PositionsService {
             (1 ... pageCount).map { position in
                 let progression = Double(position - 1) / Double(pageCount)
                 return Locator(
-                    href: link.href,
-                    type: link.type ?? MediaType.pdf.string,
+                    href: link.url(),
+                    mediaType: link.mediaType ?? .pdf,
                     locations: .init(
                         fragments: ["page=\(position)"],
                         progression: progression,

--- a/Sources/Streamer/Parser/Readium/ReadiumWebPubParser.swift
+++ b/Sources/Streamer/Parser/Readium/ReadiumWebPubParser.swift
@@ -59,7 +59,7 @@ public class ReadiumWebPubParser: PublicationParser, Loggable {
         // used to read the manifest file. We use an `HTTPFetcher` instead to serve the remote
         // resources.
         if !isPackage {
-            let baseURL = try manifest.link(withRel: .`self`)?.url().httpURL
+            let baseURL = manifest.linkWithRel(.`self`)?.url().httpURL
             fetcher = HTTPFetcher(client: httpClient, baseURL: baseURL)
         }
 
@@ -74,7 +74,7 @@ public class ReadiumWebPubParser: PublicationParser, Loggable {
             // Checks the requirements from the spec, see. https://readium.org/lcp-specs/drafts/lcpdf
             guard
                 !manifest.readingOrder.isEmpty,
-                manifest.readingOrder.all(matchMediaType: .pdf)
+                manifest.readingOrder.allMatchingMediaType(.pdf)
             else {
                 throw Error.invalidManifest
             }
@@ -89,7 +89,7 @@ public class ReadiumWebPubParser: PublicationParser, Loggable {
                     $0.setPositionsServiceFactory(EPUBPositionsService.makeFactory(reflowableStrategy: epubReflowablePositionsStrategy))
 
                 } else if manifest.conforms(to: .divina) {
-                    $0.setPositionsServiceFactory(PerResourcePositionsService.makeFactory(fallbackMediaType: "image/*"))
+                    $0.setPositionsServiceFactory(PerResourcePositionsService.makeFactory(fallbackMediaType: MediaType("image/*")!))
 
                 } else if manifest.conforms(to: .audiobook) {
                     $0.setLocatorServiceFactory(AudioLocatorService.makeFactory())

--- a/Sources/Streamer/Toolkit/Extensions/Fetcher.swift
+++ b/Sources/Streamer/Toolkit/Extensions/Fetcher.swift
@@ -36,8 +36,8 @@ extension Fetcher {
             guard !ignoring(link) else {
                 continue
             }
+            let components = link.url().pathSegments
             guard
-                let components = try? link.url().pathSegments,
                 components.count > 1,
                 title == nil || title == components.first
             else {

--- a/TestApp/Sources/App/AppModule.swift
+++ b/TestApp/Sources/App/AppModule.swift
@@ -86,7 +86,7 @@ extension AppModule: ReaderModuleDelegate {}
 
 extension AppModule: OPDSModuleDelegate {
     func opdsDownloadPublication(_ publication: Publication?, at link: Link, sender: UIViewController) async throws -> Book {
-        guard let url = try link.url(relativeTo: publication?.baseURL).absoluteURL else {
+        guard let url = link.url(relativeTo: publication?.baseURL).absoluteURL else {
             throw OPDSError.invalidURL(link.href)
         }
         return try await library.importPublication(from: url, sender: sender)

--- a/TestApp/Sources/Common/Publication.swift
+++ b/TestApp/Sources/Common/Publication.swift
@@ -12,8 +12,8 @@ extension Publication {
     /// Finds all the downloadable links for this publication.
     var downloadLinks: [Link] {
         links.filter {
-            DocumentTypes.main.supportsMediaType($0.type)
-                || DocumentTypes.main.supportsFileExtension(try? $0.url().url.pathExtension)
+            ($0.mediaType.map { DocumentTypes.main.supportsMediaType($0.string) } == true)
+                || DocumentTypes.main.supportsFileExtension($0.url().pathExtension)
         }
     }
 }

--- a/TestApp/Sources/OPDS/OPDSGroupTableViewCell.swift
+++ b/TestApp/Sources/OPDS/OPDSGroupTableViewCell.swift
@@ -89,7 +89,7 @@ extension OPDSGroupTableViewCell: UICollectionViewDataSource {
                         .joined(separator: ", ")
                 )
 
-                let coverURL: URL? = try? publication.link(withRel: .cover)?.url(relativeTo: publication.baseURL).url
+                let coverURL: URL? = publication.linkWithRel(.cover)?.url(relativeTo: publication.baseURL).url
                     ?? publication.images.first.flatMap { URL(string: $0.href) }
 
                 if let coverURL = coverURL {

--- a/TestApp/Sources/OPDS/OPDSPublicationTableViewCell.swift
+++ b/TestApp/Sources/OPDS/OPDSPublicationTableViewCell.swift
@@ -64,7 +64,7 @@ extension OPDSPublicationTableViewCell: UICollectionViewDataSource {
                     .joined(separator: ", ")
             )
 
-            let coverURL: URL? = try? publication.link(withRel: .cover)?.url(relativeTo: publication.baseURL).url
+            let coverURL: URL? = publication.linkWithRel(.cover)?.url(relativeTo: publication.baseURL).url
                 ?? publication.images.first.flatMap { URL(string: $0.href) }
 
             if let coverURL = coverURL {

--- a/TestApp/Sources/OPDS/OPDSRootTableViewController.swift
+++ b/TestApp/Sources/OPDS/OPDSRootTableViewController.swift
@@ -152,7 +152,7 @@ class OPDSRootTableViewController: UITableViewController {
     }
 
     func findNextPageURL(feed: Feed) -> URL? {
-        guard let href = feed.links.first(withRel: .next)?.href else {
+        guard let href = feed.links.firstWithRel(.next)?.href else {
             return nil
         }
         return URL(string: href)

--- a/Tests/NavigatorTests/Audio/PublicationMediaLoaderTests.swift
+++ b/Tests/NavigatorTests/Audio/PublicationMediaLoaderTests.swift
@@ -9,18 +9,18 @@ import XCTest
 
 class PublicationMediaLoaderTests: XCTestCase {
     func testURLToHREF() {
-        XCTAssertEqual(URL(string: "readium:relative/file.mp3")!.audioHREF, "relative/file.mp3")
-        XCTAssertEqual(URL(string: "readium:/absolute/file.mp3")!.audioHREF, "/absolute/file.mp3")
-        XCTAssertEqual(URL(string: "readiumfile:///directory/file.mp3")!.audioHREF, "file:///directory/file.mp3")
-        XCTAssertEqual(URL(string: "readiumhttp:///domain.com/file.mp3")!.audioHREF, "http:///domain.com/file.mp3")
-        XCTAssertEqual(URL(string: "readiumhttps:///domain.com/file.mp3")!.audioHREF, "https:///domain.com/file.mp3")
+        XCTAssertEqual(URL(string: "readium:relative/file.mp3")!.audioHREF!.string, "relative/file.mp3")
+        XCTAssertEqual(URL(string: "readium:/absolute/file.mp3")!.audioHREF!.string, "/absolute/file.mp3")
+        XCTAssertEqual(URL(string: "readiumfile:///directory/file.mp3")!.audioHREF!.string, "file:///directory/file.mp3")
+        XCTAssertEqual(URL(string: "readiumhttp:///domain.com/file.mp3")!.audioHREF!.string, "http:///domain.com/file.mp3")
+        XCTAssertEqual(URL(string: "readiumhttps:///domain.com/file.mp3")!.audioHREF!.string, "https:///domain.com/file.mp3")
 
         // Encoded characters
-        XCTAssertEqual(URL(string: "readium:relative/a%20file.mp3")!.audioHREF, "relative/a%20file.mp3")
-        XCTAssertEqual(URL(string: "readium:/absolute/a%20file.mp3")!.audioHREF, "/absolute/a%20file.mp3")
-        XCTAssertEqual(URL(string: "readiumfile:///directory/a%20file.mp3")!.audioHREF, "file:///directory/a%20file.mp3")
-        XCTAssertEqual(URL(string: "readiumhttp:///domain.com/a%20file.mp3")!.audioHREF, "http:///domain.com/a%20file.mp3")
-        XCTAssertEqual(URL(string: "readiumhttps:///domain.com/a%20file.mp3")!.audioHREF, "https:///domain.com/a%20file.mp3")
+        XCTAssertEqual(URL(string: "readium:relative/a%20file.mp3")!.audioHREF!.string, "relative/a%20file.mp3")
+        XCTAssertEqual(URL(string: "readium:/absolute/a%20file.mp3")!.audioHREF!.string, "/absolute/a%20file.mp3")
+        XCTAssertEqual(URL(string: "readiumfile:///directory/a%20file.mp3")!.audioHREF!.string, "file:///directory/a%20file.mp3")
+        XCTAssertEqual(URL(string: "readiumhttp:///domain.com/a%20file.mp3")!.audioHREF!.string, "http:///domain.com/a%20file.mp3")
+        XCTAssertEqual(URL(string: "readiumhttps:///domain.com/a%20file.mp3")!.audioHREF!.string, "https:///domain.com/a%20file.mp3")
 
         // Ignores if the r2 prefix is missing.
         XCTAssertNil(URL(string: "relative/file.mp3")!.audioHREF)

--- a/Tests/OPDSTests/readium_opds1_1_test.swift
+++ b/Tests/OPDSTests/readium_opds1_1_test.swift
@@ -53,7 +53,7 @@ class readium_opds1_1_test: XCTestCase {
     func testLinks() {
         XCTAssertEqual(feed.links.count, 4)
         XCTAssertEqual(feed.links[0].rels, ["related"])
-        XCTAssertEqual(feed.links[1].type, "application/atom+xml;profile=opds-catalog;kind=acquisition")
+        XCTAssertEqual(feed.links[1].mediaType, MediaType("application/atom+xml;profile=opds-catalog;kind=acquisition")!)
         XCTAssertEqual(feed.links[2].href, "http://test.com/opds-catalogs/root.xml")
         // TODO: add more tests...
     }

--- a/Tests/SharedTests/Extensions.swift
+++ b/Tests/SharedTests/Extensions.swift
@@ -1,0 +1,14 @@
+//
+//  Copyright 2024 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+import ReadiumShared
+
+public extension Locator {
+    init(href: String, type: MediaType) {
+        self.init(href: AnyURL(string: href)!, type: type)
+    }
+}

--- a/Tests/SharedTests/Extensions.swift
+++ b/Tests/SharedTests/Extensions.swift
@@ -8,7 +8,7 @@ import Foundation
 import ReadiumShared
 
 public extension Locator {
-    init(href: String, type: MediaType) {
-        self.init(href: AnyURL(string: href)!, type: type)
+    init(href: String, mediaType: MediaType, title: String? = nil, locations: Locations = .init(), text: Text = .init()) {
+        self.init(href: AnyURL(string: href)!, mediaType: mediaType, title: title, locations: locations, text: text)
     }
 }

--- a/Tests/SharedTests/Extensions.swift
+++ b/Tests/SharedTests/Extensions.swift
@@ -7,7 +7,7 @@
 import Foundation
 import ReadiumShared
 
-public extension Locator {
+extension Locator {
     init(href: String, mediaType: MediaType, title: String? = nil, locations: Locations = .init(), text: Text = .init()) {
         self.init(href: AnyURL(string: href)!, mediaType: mediaType, title: title, locations: locations, text: text)
     }

--- a/Tests/SharedTests/Fetcher/ArchiveFetcherTests.swift
+++ b/Tests/SharedTests/Fetcher/ArchiveFetcherTests.swift
@@ -21,17 +21,17 @@ class ArchiveFetcherTests: XCTestCase {
             fetcher.links,
             [
                 ("mimetype", nil, 20, false),
-                ("EPUB/cover.xhtml", "text/html", 259, true),
-                ("EPUB/css/epub.css", "text/css", 595, true),
-                ("EPUB/css/nav.css", "text/css", 306, true),
-                ("EPUB/images/cover.png", "image/png", 35809, true),
-                ("EPUB/nav.xhtml", "text/html", 2293, true),
+                ("EPUB/cover.xhtml", .html, 259, true),
+                ("EPUB/css/epub.css", .css, 595, true),
+                ("EPUB/css/nav.css", .css, 306, true),
+                ("EPUB/images/cover.png", .png, 35809, true),
+                ("EPUB/nav.xhtml", .html, 2293, true),
                 ("EPUB/package.opf", nil, 773, true),
-                ("EPUB/s04.xhtml", "text/html", 118_269, true),
+                ("EPUB/s04.xhtml", .html, 118_269, true),
                 ("EPUB/toc.ncx", nil, 1697, true),
-                ("META-INF/container.xml", "application/xml", 176, true),
+                ("META-INF/container.xml", .xml, 176, true),
             ].map { href, type, entryLength, isCompressed in
-                Link(href: href, type: type, properties: .init([
+                Link(href: href, mediaType: type, properties: .init([
                     "https://readium.org/webpub-manifest/properties#archive": [
                         "entryLength": entryLength,
                         "isEntryCompressed": isCompressed,

--- a/Tests/SharedTests/Fetcher/FileFetcherTests.swift
+++ b/Tests/SharedTests/Fetcher/FileFetcherTests.swift
@@ -20,10 +20,10 @@ class FileFetcherTests: XCTestCase {
 
     func testLinks() {
         XCTAssertEqual(fetcher.links, [
-            Link(href: "dir_href/subdirectory/hello.mp3", type: "audio/mpeg"),
-            Link(href: "dir_href/subdirectory/text2.txt", type: "text/plain"),
-            Link(href: "dir_href/text1.txt", type: "text/plain"),
-            Link(href: "file_href", type: "text/plain"),
+            Link(href: "dir_href/subdirectory/hello.mp3", mediaType: .mp3),
+            Link(href: "dir_href/subdirectory/text2.txt", mediaType: .text),
+            Link(href: "dir_href/text1.txt", mediaType: .text),
+            Link(href: "file_href", mediaType: .text),
         ])
     }
 

--- a/Tests/SharedTests/Publication/Extensions/OPDS/Properties+OPDSTests.swift
+++ b/Tests/SharedTests/Publication/Extensions/OPDS/Properties+OPDSTests.swift
@@ -103,7 +103,7 @@ class PropertiesOPDSTests: XCTestCase {
         ]])
         XCTAssertEqual(sut.authenticate, Link(
             href: "https://example.com/authentication.json",
-            type: "application/opds-authentication+json"
+            mediaType: .opdsAuthentication
         ))
     }
 

--- a/Tests/SharedTests/Publication/LinkArrayTests.swift
+++ b/Tests/SharedTests/Publication/LinkArrayTests.swift
@@ -162,7 +162,7 @@ class LinkArrayTests: XCTestCase {
     func testAllAreBitmap() {
         let links = [
             Link(href: "l1", mediaType: .png),
-            Link(href: "l2", mediaType: .gif)
+            Link(href: "l2", mediaType: .gif),
         ]
 
         XCTAssertTrue(links.allAreBitmap)

--- a/Tests/SharedTests/Publication/LinkArrayTests.swift
+++ b/Tests/SharedTests/Publication/LinkArrayTests.swift
@@ -16,13 +16,13 @@ class LinkArrayTests: XCTestCase {
             Link(href: "l3", rel: "test"),
         ]
 
-        XCTAssertEqual(links.first(withRel: "test")?.href, "l2")
+        XCTAssertEqual(links.firstWithRel("test")?.href, "l2")
     }
 
     /// Finds the first `Link` with given `rel` when none is found.
     func testFirstWithRelNotFound() {
         let links = [Link(href: "l1", rel: "other")]
-        XCTAssertNil(links.first(withRel: "strawberry"))
+        XCTAssertNil(links.firstWithRel("strawberry"))
     }
 
     /// Finds all the `Link` with given `rel`.
@@ -34,7 +34,7 @@ class LinkArrayTests: XCTestCase {
         ]
 
         XCTAssertEqual(
-            links.filter(byRel: "test"),
+            links.filterByRel("test"),
             [
                 Link(href: "l2", rels: ["test", "other"]),
                 Link(href: "l3", rel: "test"),
@@ -45,7 +45,7 @@ class LinkArrayTests: XCTestCase {
     /// Finds all the `Link` with given `rel` when none is found.
     func testFilterByRelNotFound() {
         let links = [Link(href: "l1", rel: "other")]
-        XCTAssertEqual(links.filter(byRel: "strawberry").count, 0)
+        XCTAssertEqual(links.filterByRel("strawberry").count, 0)
     }
 
     /// Finds the first `Link` with given `href`.
@@ -56,13 +56,13 @@ class LinkArrayTests: XCTestCase {
             Link(href: "l2", rel: "test"),
         ]
 
-        XCTAssertEqual(links.first(withHREF: "l2"), Link(href: "l2"))
+        XCTAssertEqual(links.firstWithHREF(AnyURL(string: "l2")!), Link(href: "l2"))
     }
 
     /// Finds the first `Link` with given `href` when none is found.
     func testFirstWithHREFNotFound() {
         let links = [Link(href: "l1")]
-        XCTAssertNil(links.first(withHREF: "unknown"))
+        XCTAssertNil(links.firstWithHREF(AnyURL(string: "unknown")!))
     }
 
     /// Finds the index of the first `Link` with given `href`.
@@ -73,53 +73,53 @@ class LinkArrayTests: XCTestCase {
             Link(href: "l2", rel: "test"),
         ]
 
-        XCTAssertEqual(links.firstIndex(withHREF: "l2"), 1)
+        XCTAssertEqual(links.firstIndexWithHREF(AnyURL(string: "l2")!), 1)
     }
 
     /// Finds the index of the first `Link` with given `href` when none is found.
     func testFirstIndexWithHREFNotFound() {
         let links = [Link(href: "l1")]
-        XCTAssertNil(links.firstIndex(withHREF: "unknown"))
+        XCTAssertNil(links.firstIndexWithHREF(AnyURL(string: "unknown")!))
     }
 
     /// Finds the first `Link` with a `type` matching the given `mediaType`.
     func testFirstWithMediaType() {
         let links = [
-            Link(href: "l1", type: "text/css"),
-            Link(href: "l2", type: "text/html"),
-            Link(href: "l3", type: "text/html"),
+            Link(href: "l1", mediaType: .css),
+            Link(href: "l2", mediaType: .html),
+            Link(href: "l3", mediaType: .html),
         ]
 
-        XCTAssertEqual(links.first(withMediaType: .html)?.href, "l2")
+        XCTAssertEqual(links.firstWithMediaType(.html)?.href, "l2")
     }
 
     /// Finds the first `Link` with a `type` matching the given `mediaType`, even if the `type` has
     /// extra parameters.
     func testFirstWithMediaTypeWithExtraParameter() {
         let links = [
-            Link(href: "l1", type: "text/html;charset=utf-8"),
+            Link(href: "l1", mediaType: MediaType("text/html;charset=utf-8")!),
         ]
 
-        XCTAssertEqual(links.first(withMediaType: .html)?.href, "l1")
+        XCTAssertEqual(links.firstWithMediaType(.html)?.href, "l1")
     }
 
     /// Finds the first `Link` with a `type` matching the given `mediaType`.
     func testFirstWithMediaTypeNotFound() {
-        let links = [Link(href: "l1", type: "text/css")]
-        XCTAssertNil(links.first(withMediaType: .html))
+        let links = [Link(href: "l1", mediaType: .css)]
+        XCTAssertNil(links.firstWithMediaType(.html))
     }
 
     /// Finds all the `Link` with a `type` matching the given `mediaType`.
     func testFilterByMediaType() {
         let links = [
-            Link(href: "l1", type: "text/css"),
-            Link(href: "l2", type: "text/html"),
-            Link(href: "l3", type: "text/html"),
+            Link(href: "l1", mediaType: .css),
+            Link(href: "l2", mediaType: .html),
+            Link(href: "l3", mediaType: .html),
         ]
 
-        XCTAssertEqual(links.filter(byMediaType: .html), [
-            Link(href: "l2", type: "text/html"),
-            Link(href: "l3", type: "text/html"),
+        XCTAssertEqual(links.filterByMediaType(.html), [
+            Link(href: "l2", mediaType: .html),
+            Link(href: "l3", mediaType: .html),
         ])
     }
 
@@ -127,42 +127,42 @@ class LinkArrayTests: XCTestCase {
     /// extra parameters.
     func testFilterByMediaTypeWithExtraParameter() {
         let links = [
-            Link(href: "l1", type: "text/css"),
-            Link(href: "l2", type: "text/html"),
-            Link(href: "l1", type: "text/html;charset=utf-8"),
+            Link(href: "l1", mediaType: .css),
+            Link(href: "l2", mediaType: .html),
+            Link(href: "l1", mediaType: MediaType("text/html;charset=utf-8")!),
         ]
 
-        XCTAssertEqual(links.filter(byMediaType: .html), [
-            Link(href: "l2", type: "text/html"),
-            Link(href: "l1", type: "text/html;charset=utf-8"),
+        XCTAssertEqual(links.filterByMediaType(.html), [
+            Link(href: "l2", mediaType: .html),
+            Link(href: "l1", mediaType: MediaType("text/html;charset=utf-8")!),
         ])
     }
 
     /// Finds all the `Link` with a `type` matching the given `mediaType`, when none is found.
     func testFilterByMediaTypeNotFound() {
-        let links = [Link(href: "l1", type: "text/css")]
-        XCTAssertEqual(links.filter(byMediaType: .html).count, 0)
+        let links = [Link(href: "l1", mediaType: .css)]
+        XCTAssertEqual(links.filterByMediaType(.html).count, 0)
     }
 
     /// Finds all the `Link` with a `type` matching any of the given `mediaTypes`.
     func testFilterByMediaTypes() {
         let links = [
-            Link(href: "l1", type: "text/css"),
-            Link(href: "l2", type: "text/html;charset=utf-8"),
-            Link(href: "l3", type: "application/xml"),
+            Link(href: "l1", mediaType: .css),
+            Link(href: "l2", mediaType: MediaType("text/html;charset=utf-8")!),
+            Link(href: "l3", mediaType: .xml),
         ]
 
-        XCTAssertEqual(links.filter(byMediaTypes: [.html, .xml]), [
-            Link(href: "l2", type: "text/html;charset=utf-8"),
-            Link(href: "l3", type: "application/xml"),
+        XCTAssertEqual(links.filterByMediaTypes([.html, .xml]), [
+            Link(href: "l2", mediaType: MediaType("text/html;charset=utf-8")!),
+            Link(href: "l3", mediaType: .xml),
         ])
     }
 
     /// Checks if all the links are bitmaps.
     func testAllAreBitmap() {
         let links = [
-            Link(href: "l1", type: "image/png"),
-            Link(href: "l2", type: "image/gif"),
+            Link(href: "l1", mediaType: .png),
+            Link(href: "l2", mediaType: .gif)
         ]
 
         XCTAssertTrue(links.allAreBitmap)
@@ -171,8 +171,8 @@ class LinkArrayTests: XCTestCase {
     /// Checks if all the links are bitmaps, when it's not the case.
     func testAllAreBitmapFalse() {
         let links = [
-            Link(href: "l1", type: "image/png"),
-            Link(href: "l2", type: "text/css"),
+            Link(href: "l1", mediaType: .png),
+            Link(href: "l2", mediaType: .css),
         ]
 
         XCTAssertFalse(links.allAreBitmap)
@@ -181,8 +181,8 @@ class LinkArrayTests: XCTestCase {
     /// Checks if all the links are audio clips.
     func testAllAreAudio() {
         let links = [
-            Link(href: "l1", type: "audio/mpeg"),
-            Link(href: "l2", type: "audio/aac"),
+            Link(href: "l1", mediaType: .mp3),
+            Link(href: "l2", mediaType: .aac),
         ]
 
         XCTAssertTrue(links.allAreAudio)
@@ -191,8 +191,8 @@ class LinkArrayTests: XCTestCase {
     /// Checks if all the links are audio clips, when it's not the case.
     func testAllAreAudioFalse() {
         let links = [
-            Link(href: "l1", type: "audio/mpeg"),
-            Link(href: "l2", type: "text/css"),
+            Link(href: "l1", mediaType: .mp3),
+            Link(href: "l2", mediaType: .css),
         ]
 
         XCTAssertFalse(links.allAreAudio)
@@ -201,8 +201,8 @@ class LinkArrayTests: XCTestCase {
     /// Checks if all the links are video clips.
     func testAllAreVideo() {
         let links = [
-            Link(href: "l1", type: "video/mp4"),
-            Link(href: "l2", type: "video/webm"),
+            Link(href: "l1", mediaType: MediaType("video/mp4")!),
+            Link(href: "l2", mediaType: .webmVideo),
         ]
 
         XCTAssertTrue(links.allAreVideo)
@@ -211,8 +211,8 @@ class LinkArrayTests: XCTestCase {
     /// Checks if all the links are video clips, when it's not the case.
     func testAllAreVideoFalse() {
         let links = [
-            Link(href: "l1", type: "video/mp4"),
-            Link(href: "l2", type: "text/css"),
+            Link(href: "l1", mediaType: .mp4),
+            Link(href: "l2", mediaType: .css),
         ]
 
         XCTAssertFalse(links.allAreVideo)
@@ -221,8 +221,8 @@ class LinkArrayTests: XCTestCase {
     /// Checks if all the links are HTML documents.
     func testAllAreHTML() {
         let links = [
-            Link(href: "l1", type: "text/html"),
-            Link(href: "l2", type: "application/xhtml+xml"),
+            Link(href: "l1", mediaType: .html),
+            Link(href: "l2", mediaType: .xhtml),
         ]
 
         XCTAssertTrue(links.allAreHTML)
@@ -231,8 +231,8 @@ class LinkArrayTests: XCTestCase {
     /// Checks if all the links are HTML documents, when it's not the case.
     func testAllAreHTMLFalse() {
         let links = [
-            Link(href: "l1", type: "text/html"),
-            Link(href: "l2", type: "text/css"),
+            Link(href: "l1", mediaType: .html),
+            Link(href: "l2", mediaType: .css),
         ]
 
         XCTAssertFalse(links.allAreHTML)
@@ -241,40 +241,40 @@ class LinkArrayTests: XCTestCase {
     /// Checks if all the links match the given media type.
     func testAllMatchesMediaType() {
         let links = [
-            Link(href: "l1", type: "text/css"),
-            Link(href: "l2", type: "text/css;charset=utf-8"),
+            Link(href: "l1", mediaType: .css),
+            Link(href: "l2", mediaType: MediaType("text/css;charset=utf-8")!),
         ]
 
-        XCTAssertTrue(links.all(matchMediaType: .css))
+        XCTAssertTrue(links.allMatchingMediaType(.css))
     }
 
     /// Checks if all the links match the given media type when it's not the case.
     func testAllMatchesMediaTypeFalse() {
         let links = [
-            Link(href: "l1", type: "text/css"),
-            Link(href: "l2", type: "text/plain"),
+            Link(href: "l1", mediaType: .css),
+            Link(href: "l2", mediaType: .text),
         ]
 
-        XCTAssertFalse(links.all(matchMediaType: .css))
+        XCTAssertFalse(links.allMatchingMediaType(.css))
     }
 
     /// Checks if all the links match any of the given media types.
     func testAllMatchesMediaTypes() {
         let links = [
-            Link(href: "l1", type: "text/html"),
-            Link(href: "l2", type: "application/xml"),
+            Link(href: "l1", mediaType: .html),
+            Link(href: "l2", mediaType: .xml),
         ]
 
-        XCTAssertTrue(links.all(matchMediaTypes: [.html, .xml]))
+        XCTAssertTrue(links.allMatchingMediaTypes([.html, .xml]))
     }
 
     /// Checks if all the links match any of the given media types, when it's not the case.
     func testAllMatchesMediaTypesFalse() {
         let links = [
-            Link(href: "l1", type: "text/css"),
-            Link(href: "l2", type: "text/html"),
+            Link(href: "l1", mediaType: .css),
+            Link(href: "l2", mediaType: .html),
         ]
 
-        XCTAssertFalse(links.all(matchMediaTypes: [.html, .xml]))
+        XCTAssertFalse(links.allMatchingMediaTypes([.html, .xml]))
     }
 }

--- a/Tests/SharedTests/Publication/LinkTests.swift
+++ b/Tests/SharedTests/Publication/LinkTests.swift
@@ -10,7 +10,7 @@ import XCTest
 class LinkTests: XCTestCase {
     let fullLink = Link(
         href: "http://href",
-        type: "application/pdf",
+        mediaType: .pdf,
         templated: true,
         title: "Link Title",
         rels: [.publication, .cover],
@@ -73,7 +73,7 @@ class LinkTests: XCTestCase {
     func testParseInvalidHREFWithDecodedPathInJSON() throws {
         let link = try Link(json: ["href": "01_Note de l editeur audio.mp3"])
         XCTAssertEqual(link, Link(href: "01_Note%20de%20l%20editeur%20audio.mp3"))
-        XCTAssertEqual(try link.url(), AnyURL(string: "01_Note%20de%20l%20editeur%20audio.mp3"))
+        XCTAssertEqual(link.url(), AnyURL(string: "01_Note%20de%20l%20editeur%20audio.mp3"))
     }
 
     func testParseJSONRelAsSingleString() {
@@ -222,56 +222,43 @@ class LinkTests: XCTestCase {
         )
     }
 
-    func testUnknownMediaType() {
-        XCTAssertEqual(Link(href: "file").mediaType, .binary)
-    }
-
-    func testMediaTypeFromType() {
-        XCTAssertEqual(Link(href: "file", type: "application/epub+zip").mediaType, .epub)
-        XCTAssertEqual(Link(href: "file", type: "application/pdf").mediaType, .pdf)
-    }
-
-    func testMediaTypeFromExtension() {
-        XCTAssertEqual(Link(href: "file.epub").mediaType, .epub)
-        XCTAssertEqual(Link(href: "file.pdf").mediaType, .pdf)
-    }
-
     func testURLRelativeToBaseURL() throws {
         XCTAssertEqual(
-            try Link(href: "folder/file.html").url(relativeTo: AnyURL(string: "http://host/")!),
+            Link(href: "folder/file.html").url(relativeTo: AnyURL(string: "http://host/")!),
             AnyURL(string: "http://host/folder/file.html")!
         )
     }
 
     func testURLRelativeToBaseURLWithRootPrefix() throws {
         XCTAssertEqual(
-            try Link(href: "file.html").url(relativeTo: AnyURL(string: "http://host/folder/")!),
+            Link(href: "file.html").url(relativeTo: AnyURL(string: "http://host/folder/")!),
             AnyURL(string: "http://host/folder/file.html")!
         )
     }
 
     func testURLRelativeToNil() throws {
         XCTAssertEqual(
-            try Link(href: "http://example.com/folder/file.html").url(),
+            Link(href: "http://example.com/folder/file.html").url(),
             AnyURL(string: "http://example.com/folder/file.html")!
         )
         XCTAssertEqual(
-            try Link(href: "folder/file.html").url(),
+            Link(href: "folder/file.html").url(),
             AnyURL(string: "folder/file.html")!
         )
     }
 
     func testURLWithAbsoluteHREF() throws {
         XCTAssertEqual(
-            try Link(href: "http://test.com/folder/file.html").url(relativeTo: AnyURL(string: "http://host/")!),
+            Link(href: "http://test.com/folder/file.html").url(relativeTo: AnyURL(string: "http://host/")!),
             AnyURL(string: "http://test.com/folder/file.html")!
         )
     }
 
     func testURLWithInvalidHREF() {
-        XCTAssertThrowsError(try Link(href: "01_Note de l editeur audio.mp3").url()) { error in
-            XCTAssertEqual(LinkError.invalidHREF("01_Note de l editeur audio.mp3"), error as? LinkError)
-        }
+        XCTAssertEqual(
+            Link(href: "01_Note de l editeur audio.mp3").url(),
+            AnyURL(string: "01_Note%20de%20l%20editeur%20audio.mp3")
+        )
     }
 
     func testTemplateParameters() {

--- a/Tests/SharedTests/Publication/LocatorTests.swift
+++ b/Tests/SharedTests/Publication/LocatorTests.swift
@@ -16,7 +16,7 @@ class LocatorTests: XCTestCase {
             ]),
             Locator(
                 href: "http://locator",
-                type: "text/html"
+                mediaType: .html
             )
         )
     }
@@ -36,7 +36,7 @@ class LocatorTests: XCTestCase {
             ] as [String: Any]),
             Locator(
                 href: "http://locator",
-                type: "text/html",
+                mediaType: .html,
                 title: "My Locator",
                 locations: .init(position: 42),
                 text: .init(highlight: "Excerpt")
@@ -59,8 +59,8 @@ class LocatorTests: XCTestCase {
                 ["href": "loc2", "type": "text/html"],
             ]),
             [
-                Locator(href: "loc1", type: "text/html"),
-                Locator(href: "loc2", type: "text/html"),
+                Locator(href: "loc1", mediaType: .html),
+                Locator(href: "loc2", mediaType: .html),
             ]
         )
     }
@@ -73,7 +73,7 @@ class LocatorTests: XCTestCase {
         AssertJSONEqual(
             Locator(
                 href: "http://locator",
-                type: "text/html"
+                mediaType: .html
             ).json,
             [
                 "href": "http://locator",
@@ -86,7 +86,7 @@ class LocatorTests: XCTestCase {
         AssertJSONEqual(
             Locator(
                 href: "http://locator",
-                type: "text/html",
+                mediaType: .html,
                 title: "My Locator",
                 locations: .init(position: 42),
                 text: .init(highlight: "Excerpt")
@@ -108,8 +108,8 @@ class LocatorTests: XCTestCase {
     func testGetJSONArray() {
         AssertJSONEqual(
             [
-                Locator(href: "loc1", type: "text/html"),
-                Locator(href: "loc2", type: "text/html"),
+                Locator(href: "loc1", mediaType: .html),
+                Locator(href: "loc2", mediaType: .html),
             ].json,
             [
                 ["href": "loc1", "type": "text/html"],
@@ -121,7 +121,7 @@ class LocatorTests: XCTestCase {
     func testCopy() {
         let locator = Locator(
             href: "http://locator",
-            type: "text/html",
+            mediaType: .html,
             title: "My Locator",
             locations: .init(position: 42),
             text: .init(highlight: "Excerpt")
@@ -517,13 +517,13 @@ class LocatorCollectionTests: XCTestCase {
                     ]
                 ),
                 links: [
-                    Link(href: "/978-1503222687/search?query=apple", type: "application/vnd.readium.locators+json", rel: "self"),
-                    Link(href: "/978-1503222687/search?query=apple&page=2", type: "application/vnd.readium.locators+json", rel: "next"),
+                    Link(href: "/978-1503222687/search?query=apple", mediaType: MediaType("application/vnd.readium.locators+json")!, rel: "self"),
+                    Link(href: "/978-1503222687/search?query=apple&page=2", mediaType: MediaType("application/vnd.readium.locators+json")!, rel: "next"),
                 ],
                 locators: [
                     Locator(
                         href: "/978-1503222687/chap7.html",
-                        type: "application/xhtml+xml",
+                        mediaType: .xhtml,
                         locations: Locator.Locations(
                             fragments: [":~:text=riddle,-yet%3F'"],
                             progression: 0.43
@@ -536,7 +536,7 @@ class LocatorCollectionTests: XCTestCase {
                     ),
                     Locator(
                         href: "/978-1503222687/chap7.html",
-                        type: "application/xhtml+xml",
+                        mediaType: .xhtml,
                         locations: Locator.Locations(
                             fragments: [":~:text=in%20asking-,riddles"],
                             progression: 0.47
@@ -590,13 +590,13 @@ class LocatorCollectionTests: XCTestCase {
                     ]
                 ),
                 links: [
-                    Link(href: "/978-1503222687/search?query=apple", type: "application/vnd.readium.locators+json", rel: "self"),
-                    Link(href: "/978-1503222687/search?query=apple&page=2", type: "application/vnd.readium.locators+json", rel: "next"),
+                    Link(href: "/978-1503222687/search?query=apple", mediaType: MediaType("application/vnd.readium.locators+json")!, rel: "self"),
+                    Link(href: "/978-1503222687/search?query=apple&page=2", mediaType: MediaType("application/vnd.readium.locators+json")!, rel: "next"),
                 ],
                 locators: [
                     Locator(
                         href: "/978-1503222687/chap7.html",
-                        type: "application/xhtml+xml",
+                        mediaType: .xhtml,
                         locations: Locator.Locations(
                             fragments: [":~:text=riddle,-yet%3F'"],
                             progression: 0.43
@@ -609,7 +609,7 @@ class LocatorCollectionTests: XCTestCase {
                     ),
                     Locator(
                         href: "/978-1503222687/chap7.html",
-                        type: "application/xhtml+xml",
+                        mediaType: .xhtml,
                         locations: Locator.Locations(
                             fragments: [":~:text=in%20asking-,riddles"],
                             progression: 0.47

--- a/Tests/SharedTests/Publication/ManifestTests.swift
+++ b/Tests/SharedTests/Publication/ManifestTests.swift
@@ -24,7 +24,7 @@ class ManifestTests: XCTestCase {
             Manifest(
                 metadata: Metadata(title: "Title"),
                 links: [Link(href: "manifest.json", rels: [.self])],
-                readingOrder: [Link(href: "chap1.html", type: "text/html")]
+                readingOrder: [Link(href: "chap1.html", mediaType: .html)]
             )
         )
     }
@@ -57,8 +57,8 @@ class ManifestTests: XCTestCase {
                 context: ["https://readium.org/webpub-manifest/context.jsonld"],
                 metadata: Metadata(title: "Title"),
                 links: [Link(href: "manifest.json", rels: [.self])],
-                readingOrder: [Link(href: "chap1.html", type: "text/html")],
-                resources: [Link(href: "image.png", type: "image/png")],
+                readingOrder: [Link(href: "chap1.html", mediaType: .html)],
+                resources: [Link(href: "image.png", mediaType: .png)],
                 tableOfContents: [Link(href: "cover.html"), Link(href: "chap1.html")],
                 subcollections: ["sub": [PublicationCollection(links: [Link(href: "sublink")])]]
             )
@@ -81,7 +81,7 @@ class ManifestTests: XCTestCase {
                 context: ["context1", "context2"],
                 metadata: Metadata(title: "Title"),
                 links: [Link(href: "manifest.json", rels: [.self])],
-                readingOrder: [Link(href: "chap1.html", type: "text/html")]
+                readingOrder: [Link(href: "chap1.html", mediaType: .html)]
             )
         )
     }
@@ -116,7 +116,7 @@ class ManifestTests: XCTestCase {
             Manifest(
                 metadata: Metadata(title: "Title"),
                 links: [Link(href: "manifest.json", rels: [.self])],
-                readingOrder: [Link(href: "chap1.html", type: "text/html")]
+                readingOrder: [Link(href: "chap1.html", mediaType: .html)]
             )
         )
     }
@@ -138,7 +138,7 @@ class ManifestTests: XCTestCase {
                 links: [
                     Link(href: "manifest.json", rels: [.self]),
                 ],
-                readingOrder: [Link(href: "chap1.html", type: "text/html")]
+                readingOrder: [Link(href: "chap1.html", mediaType: .html)]
             )
         )
     }
@@ -163,8 +163,8 @@ class ManifestTests: XCTestCase {
                 links: [
                     Link(href: "manifest.json", rels: [.self]),
                 ],
-                readingOrder: [Link(href: "chap1.html", type: "text/html")],
-                resources: [Link(href: "withtype", type: "text/html")]
+                readingOrder: [Link(href: "chap1.html", mediaType: .html)],
+                resources: [Link(href: "withtype", mediaType: .html)]
             )
         )
     }
@@ -174,7 +174,7 @@ class ManifestTests: XCTestCase {
             Manifest(
                 metadata: Metadata(title: "Title"),
                 links: [Link(href: "manifest.json", rels: [.self])],
-                readingOrder: [Link(href: "chap1.html", type: "text/html")]
+                readingOrder: [Link(href: "chap1.html", mediaType: .html)]
             ).json,
             [
                 "metadata": ["title": "Title", "readingProgression": "auto"],
@@ -194,8 +194,8 @@ class ManifestTests: XCTestCase {
                 context: ["https://readium.org/webpub-manifest/context.jsonld"],
                 metadata: Metadata(title: "Title"),
                 links: [Link(href: "manifest.json", rels: [.self])],
-                readingOrder: [Link(href: "chap1.html", type: "text/html")],
-                resources: [Link(href: "image.png", type: "image/png")],
+                readingOrder: [Link(href: "chap1.html", mediaType: .html)],
+                resources: [Link(href: "image.png", mediaType: .png)],
                 tableOfContents: [Link(href: "cover.html"), Link(href: "chap1.html")],
                 subcollections: ["sub": [PublicationCollection(links: [Link(href: "sublink")])]]
             ).json,
@@ -229,7 +229,7 @@ class ManifestTests: XCTestCase {
             makeManifest(readingOrder: [
                 Link(href: "l1"),
                 Link(href: "l2", rel: "rel1"),
-            ]).link(withRel: "rel1")?.href,
+            ]).linkWithRel("rel1")?.href,
             "l2"
         )
     }
@@ -239,7 +239,7 @@ class ManifestTests: XCTestCase {
             makeManifest(links: [
                 Link(href: "l1"),
                 Link(href: "l2", rel: "rel1"),
-            ]).link(withRel: "rel1")?.href,
+            ]).linkWithRel("rel1")?.href,
             "l2"
         )
     }
@@ -249,7 +249,7 @@ class ManifestTests: XCTestCase {
             makeManifest(resources: [
                 Link(href: "l1"),
                 Link(href: "l2", rel: "rel1"),
-            ]).link(withRel: "rel1")?.href,
+            ]).linkWithRel("rel1")?.href,
             "l2"
         )
     }
@@ -271,7 +271,7 @@ class ManifestTests: XCTestCase {
                     ]),
                     Link(href: "l6", rel: "rel1"),
                 ]
-            ).links(withRel: "rel1"),
+            ).linksWithRel("rel1"),
             [
                 Link(href: "l4", rel: "rel1"),
                 Link(href: "l6", rel: "rel1"),
@@ -285,7 +285,7 @@ class ManifestTests: XCTestCase {
             makeManifest(resources: [
                 Link(href: "l1"),
                 Link(href: "l2"),
-            ]).links(withRel: "rel1"),
+            ]).linksWithRel("rel1"),
             []
         )
     }

--- a/Tests/SharedTests/Publication/PublicationTests.swift
+++ b/Tests/SharedTests/Publication/PublicationTests.swift
@@ -339,26 +339,6 @@ class PublicationTests: XCTestCase {
             ),
             Locator(href: "https://other.com/chap1.html", mediaType: .html)
         )
-
-        // The HREF is normalized
-        XCTAssertEqual(
-            publication.normalizeLocator(
-                Locator(href: "https://example.com/foo/bar/c%27est%20valide.html", mediaType: .html)
-            ),
-            Locator(href: "bar/c'est%20valide.html", mediaType: .html)
-        )
-        XCTAssertEqual(
-            publication.normalizeLocator(
-                Locator(href: "bar/c%27est%20valide.html", mediaType: .html)
-            ),
-            Locator(href: "bar/c'est%20valide.html", mediaType: .html)
-        )
-        XCTAssertEqual(
-            publication.normalizeLocator(
-                Locator(href: "https://other.com/c%27est%20valide.html", mediaType: .html)
-            ),
-            Locator(href: "https://other.com/c'est%20valide.html", mediaType: .html)
-        )
     }
 
     func testNormalizeLocatorPackagedPublication() {
@@ -385,20 +365,6 @@ class PublicationTests: XCTestCase {
                 Locator(href: "foo/chap1.html", mediaType: .html)
             ),
             Locator(href: "foo/chap1.html", mediaType: .html)
-        )
-
-        // The HREF is normalized
-        XCTAssertEqual(
-            publication.normalizeLocator(
-                Locator(href: "bar/c%27est%20valide.html", mediaType: .html)
-            ),
-            Locator(href: "bar/c'est%20valide.html", mediaType: .html)
-        )
-        XCTAssertEqual(
-            publication.normalizeLocator(
-                Locator(href: "c%27est%20valide.html", mediaType: .html)
-            ),
-            Locator(href: "c'est%20valide.html", mediaType: .html)
         )
     }
 }

--- a/Tests/SharedTests/Publication/PublicationTests.swift
+++ b/Tests/SharedTests/Publication/PublicationTests.swift
@@ -339,7 +339,7 @@ class PublicationTests: XCTestCase {
             ),
             Locator(href: "https://other.com/chap1.html", mediaType: .html)
         )
-        
+
         // The HREF is normalized
         XCTAssertEqual(
             publication.normalizeLocator(
@@ -378,7 +378,7 @@ class PublicationTests: XCTestCase {
             ),
             Locator(href: "invalid", mediaType: .html)
         )
-        
+
         // Leading slashes are removed
         XCTAssertEqual(
             publication.normalizeLocator(

--- a/Tests/SharedTests/Publication/Services/Content Protection/ContentProtectionServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Content Protection/ContentProtectionServiceTests.swift
@@ -78,7 +78,7 @@ class ContentProtectionServiceTests: XCTestCase {
             manifest: Manifest(
                 metadata: Metadata(title: ""),
                 readingOrder: [
-                    Link(href: "chap1", type: "text/html"),
+                    Link(href: "chap1", mediaType: .html),
                 ]
             ),
             servicesBuilder: PublicationServicesBuilder(contentProtection: service)

--- a/Tests/SharedTests/Publication/Services/Content/Iterators/HTMLResourceContentIteratorTests.swift
+++ b/Tests/SharedTests/Publication/Services/Content/Iterators/HTMLResourceContentIteratorTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 
 class HTMLResourceContentIteratorTest: XCTestCase {
-    private let link = Link(href: "dir/res.xhtml", type: "application/xhtml+xml")
+    private let link = Link(href: "dir/res.xhtml", mediaType: .xhtml)
     private let locator = Locator(href: "dir/res.xhtml", mediaType: .xhtml)
 
     private let html = """
@@ -336,7 +336,7 @@ class HTMLResourceContentIteratorTest: XCTestCase {
         <body>
             <audio src="audio.mp3" />
             <audio>
-                <source src="audio.mp3" type="audio/mp3" />
+                <source src="audio.mp3" type="audio/mpeg" />
                 <source src="audio.ogg" type="audio/ogg" />
             </audio>
         </body>
@@ -353,8 +353,8 @@ class HTMLResourceContentIteratorTest: XCTestCase {
                 locator: locator(progression: 0.5, selector: "html > body > audio:nth-child(2)"),
                 embeddedLink: Link(
                     href: "dir/audio.mp3",
-                    type: "audio/mp3",
-                    alternates: [Link(href: "dir/audio.ogg", type: "audio/ogg")]
+                    mediaType: .mp3,
+                    alternates: [Link(href: "dir/audio.ogg", mediaType: .ogg)]
                 ),
                 attributes: []
             ).equatable(),
@@ -390,8 +390,8 @@ class HTMLResourceContentIteratorTest: XCTestCase {
                 locator: locator(progression: 0.5, selector: "html > body > video:nth-child(2)"),
                 embeddedLink: Link(
                     href: "dir/video.mp4",
-                    type: "video/mp4",
-                    alternates: [Link(href: "dir/video.m4v", type: "video/x-m4v")]
+                    mediaType: MediaType("video/mp4")!,
+                    alternates: [Link(href: "dir/video.m4v", mediaType: MediaType("video/x-m4v")!)]
                 ),
                 attributes: []
             ).equatable(),

--- a/Tests/SharedTests/Publication/Services/Content/Iterators/HTMLResourceContentIteratorTests.swift
+++ b/Tests/SharedTests/Publication/Services/Content/Iterators/HTMLResourceContentIteratorTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 class HTMLResourceContentIteratorTest: XCTestCase {
     private let link = Link(href: "dir/res.xhtml", type: "application/xhtml+xml")
-    private let locator = Locator(href: "dir/res.xhtml", type: "application/xhtml+xml")
+    private let locator = Locator(href: "dir/res.xhtml", mediaType: .xhtml)
 
     private let html = """
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/SharedTests/Publication/Services/Cover/GeneratedCoverServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Cover/GeneratedCoverServiceTests.swift
@@ -18,7 +18,7 @@ class GeneratedCoverServiceTests: XCTestCase {
 
     /// `GeneratedCoverService` adds a custom `Link` with `cover` rel in `links`.
     func testLinks() {
-        let expectedLinks = [Link(href: "/~readium/cover", type: "image/png", rels: [.cover])]
+        let expectedLinks = [Link(href: "/~readium/cover", mediaType: .png, rels: [.cover])]
         XCTAssertEqual(GeneratedCoverService(cover: cover).links, expectedLinks)
         XCTAssertEqual(GeneratedCoverService(makeCover: { self.cover }).links, expectedLinks)
     }
@@ -30,7 +30,7 @@ class GeneratedCoverServiceTests: XCTestCase {
             GeneratedCoverService(makeCover: { self.cover }),
         ] {
             let resource = try XCTUnwrap(service.get(link: Link(href: "/~readium/cover")))
-            XCTAssertEqual(resource.link, Link(href: "/~readium/cover", type: "image/png", rels: [.cover], height: 800, width: 598))
+            XCTAssertEqual(resource.link, Link(href: "/~readium/cover", mediaType: .png, rels: [.cover], height: 800, width: 598))
             try AssertImageEqual(resource.read().map(UIImage.init).get(), cover)
         }
     }

--- a/Tests/SharedTests/Publication/Services/Locator/DefaultLocatorServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Locator/DefaultLocatorServiceTests.swift
@@ -11,25 +11,25 @@ class DefaultLocatorServiceTests: XCTestCase {
     // locate(Locator) checks that the href exists.
     func testFromLocator() {
         let service = makeService(readingOrder: [
-            Link(href: "chap1", type: "application/xml"),
-            Link(href: "chap2", type: "application/xml"),
-            Link(href: "chap3", type: "application/xml"),
+            Link(href: "chap1", mediaType: .xml),
+            Link(href: "chap2", mediaType: .xml),
+            Link(href: "chap3", mediaType: .xml),
         ])
-        let locator = Locator(href: "chap2", type: "text/html", text: .init(highlight: "Highlight"))
+        let locator = Locator(href: "chap2", mediaType: .html, text: .init(highlight: "Highlight"))
         XCTAssertEqual(service.locate(locator), locator)
     }
 
     func testFromLocatorEmptyReadingOrder() {
         let service = makeService(readingOrder: [])
-        XCTAssertNil(service.locate(Locator(href: "href", type: "text/html")))
+        XCTAssertNil(service.locate(Locator(href: "href", mediaType: .html)))
     }
 
     func testFromLocatorNotFound() {
         let service = makeService(readingOrder: [
-            Link(href: "chap1", type: "application/xml"),
-            Link(href: "chap3", type: "application/xml"),
+            Link(href: "chap1", mediaType: .xml),
+            Link(href: "chap3", mediaType: .xml),
         ])
-        let locator = Locator(href: "chap2", type: "text/html", text: .init(highlight: "Highlight"))
+        let locator = Locator(href: "chap2", mediaType: .html, text: .init(highlight: "Highlight"))
         XCTAssertNil(service.locate(locator))
     }
 
@@ -38,7 +38,7 @@ class DefaultLocatorServiceTests: XCTestCase {
 
         XCTAssertEqual(service.locate(progression: 0.0), Locator(
             href: "chap1",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: 0.0,
                 totalProgression: 0.0,
@@ -48,7 +48,7 @@ class DefaultLocatorServiceTests: XCTestCase {
 
         XCTAssertEqual(service.locate(progression: 0.25), Locator(
             href: "chap3",
-            type: "text/html",
+            mediaType: .html,
             title: "Chapter 3",
             locations: Locator.Locations(
                 progression: 0.0,
@@ -62,7 +62,7 @@ class DefaultLocatorServiceTests: XCTestCase {
 
         XCTAssertEqual(service.locate(progression: 0.4), Locator(
             href: "chap4",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: (0.4 - chap4FirstTotalProg) / (chap5FirstTotalProg - chap4FirstTotalProg),
                 totalProgression: 0.4,
@@ -72,7 +72,7 @@ class DefaultLocatorServiceTests: XCTestCase {
 
         XCTAssertEqual(service.locate(progression: 0.55), Locator(
             href: "chap4",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: (0.55 - chap4FirstTotalProg) / (chap5FirstTotalProg - chap4FirstTotalProg),
                 totalProgression: 0.55,
@@ -82,7 +82,7 @@ class DefaultLocatorServiceTests: XCTestCase {
 
         XCTAssertEqual(service.locate(progression: 0.9), Locator(
             href: "chap5",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: (0.9 - chap5FirstTotalProg) / (1.0 - chap5FirstTotalProg),
                 totalProgression: 0.9,
@@ -92,7 +92,7 @@ class DefaultLocatorServiceTests: XCTestCase {
 
         XCTAssertEqual(service.locate(progression: 1.0), Locator(
             href: "chap5",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: 1.0,
                 totalProgression: 1.0,
@@ -114,63 +114,63 @@ class DefaultLocatorServiceTests: XCTestCase {
 
     func testFromMinimalLink() {
         let service = makeService(readingOrder: [
-            Link(href: "/href", type: "text/html", title: "Resource"),
+            Link(href: "/href", mediaType: .html, title: "Resource"),
         ])
 
         XCTAssertEqual(
             service.locate(Link(href: "/href")),
-            Locator(href: "/href", type: "text/html", title: "Resource", locations: Locator.Locations(progression: 0.0))
+            Locator(href: "/href", mediaType: .html, title: "Resource", locations: Locator.Locations(progression: 0.0))
         )
     }
 
     func testFromLinkInReadingOrderResourcesOrLinks() {
         let service = makeService(
-            links: [Link(href: "/href3", type: "text/html")],
-            readingOrder: [Link(href: "/href1", type: "text/html")],
-            resources: [Link(href: "/href2", type: "text/html")]
+            links: [Link(href: "/href3", mediaType: .html)],
+            readingOrder: [Link(href: "/href1", mediaType: .html)],
+            resources: [Link(href: "/href2", mediaType: .html)]
         )
 
         XCTAssertEqual(
             service.locate(Link(href: "/href1")),
-            Locator(href: "/href1", type: "text/html", locations: Locator.Locations(progression: 0.0))
+            Locator(href: "/href1", mediaType: .html, locations: Locator.Locations(progression: 0.0))
         )
 
         XCTAssertEqual(
             service.locate(Link(href: "/href2")),
-            Locator(href: "/href2", type: "text/html", locations: Locator.Locations(progression: 0.0))
+            Locator(href: "/href2", mediaType: .html, locations: Locator.Locations(progression: 0.0))
         )
 
         XCTAssertEqual(
             service.locate(Link(href: "/href3")),
-            Locator(href: "/href3", type: "text/html", locations: Locator.Locations(progression: 0.0))
+            Locator(href: "/href3", mediaType: .html, locations: Locator.Locations(progression: 0.0))
         )
     }
 
     func testFromLinkWithFragment() {
         let service = makeService(readingOrder: [
-            Link(href: "/href", type: "text/html", title: "Resource"),
+            Link(href: "/href", mediaType: .html, title: "Resource"),
         ])
 
         XCTAssertEqual(
-            service.locate(Link(href: "/href#page=42", type: "text/xml", title: "My link")),
-            Locator(href: "/href", type: "text/html", title: "Resource", locations: Locator.Locations(fragments: ["page=42"]))
+            service.locate(Link(href: "/href#page=42", mediaType: MediaType("text/xml")!, title: "My link")),
+            Locator(href: "/href", mediaType: .html, title: "Resource", locations: Locator.Locations(fragments: ["page=42"]))
         )
     }
 
     func testTitleFallbackFromLink() {
         let service = makeService(readingOrder: [
-            Link(href: "/href", type: "text/html"),
+            Link(href: "/href", mediaType: .html),
         ])
 
         XCTAssertEqual(
             service.locate(Link(href: "/href", title: "My link")),
-            Locator(href: "/href", type: "text/html", title: "My link", locations: Locator.Locations(progression: 0.0))
+            Locator(href: "/href", mediaType: .html, title: "My link", locations: Locator.Locations(progression: 0.0))
         )
     }
 
     func testFromLinkNotFound() {
         let service = makeService(readingOrder: [
-            Link(href: "/href", type: "text/html"),
+            Link(href: "/href", mediaType: .html),
         ])
 
         XCTAssertNil(service.locate(Link(href: "notfound")))
@@ -200,7 +200,7 @@ private let positionsFixture: [[Locator]] = [
     [
         Locator(
             href: "chap1",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: 0.0,
                 totalProgression: 0.0,
@@ -211,7 +211,7 @@ private let positionsFixture: [[Locator]] = [
     [
         Locator(
             href: "chap2",
-            type: "application/xml",
+            mediaType: .xml,
             locations: Locator.Locations(
                 progression: 0.0,
                 totalProgression: 1.0 / 8.0,
@@ -222,7 +222,7 @@ private let positionsFixture: [[Locator]] = [
     [
         Locator(
             href: "chap3",
-            type: "text/html",
+            mediaType: .html,
             title: "Chapter 3",
             locations: Locator.Locations(
                 progression: 0.0,
@@ -234,7 +234,7 @@ private let positionsFixture: [[Locator]] = [
     [
         Locator(
             href: "chap4",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: 0.0,
                 totalProgression: 3.0 / 8.0,
@@ -243,7 +243,7 @@ private let positionsFixture: [[Locator]] = [
         ),
         Locator(
             href: "chap4",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: 0.5,
                 totalProgression: 4.0 / 8.0,
@@ -254,7 +254,7 @@ private let positionsFixture: [[Locator]] = [
     [
         Locator(
             href: "chap5",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: 0.0,
                 totalProgression: 5.0 / 8.0,
@@ -263,7 +263,7 @@ private let positionsFixture: [[Locator]] = [
         ),
         Locator(
             href: "chap5",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: 1.0 / 3.0,
                 totalProgression: 6.0 / 8.0,
@@ -272,7 +272,7 @@ private let positionsFixture: [[Locator]] = [
         ),
         Locator(
             href: "chap5",
-            type: "text/html",
+            mediaType: .html,
             locations: Locator.Locations(
                 progression: 2.0 / 3.0,
                 totalProgression: 7.0 / 8.0,

--- a/Tests/SharedTests/Publication/Services/Positions/PerResourcePositionsServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Positions/PerResourcePositionsServiceTests.swift
@@ -9,19 +9,19 @@ import XCTest
 
 class PerResourcePositionsServiceTests: XCTestCase {
     func testFromAnEmptyReadingOrder() {
-        let service = PerResourcePositionsService(readingOrder: [], fallbackMediaType: "")
+        let service = PerResourcePositionsService(readingOrder: [], fallbackMediaType: .text)
         XCTAssertEqual(service.positionsByReadingOrder, [])
     }
 
     func testFromReadingOrderWithOneResource() {
         let service = PerResourcePositionsService(readingOrder: [
-            Link(href: "res", type: "image/png"),
-        ], fallbackMediaType: "")
+            Link(href: "res", mediaType: .png),
+        ], fallbackMediaType: .text)
 
         XCTAssertEqual(service.positionsByReadingOrder, [
             [Locator(
                 href: "res",
-                type: "image/png",
+                mediaType: .png,
                 locations: Locator.Locations(
                     totalProgression: 0.0,
                     position: 1
@@ -34,16 +34,16 @@ class PerResourcePositionsServiceTests: XCTestCase {
         let service = PerResourcePositionsService(
             readingOrder: [
                 Link(href: "res"),
-                Link(href: "chap1", type: "image/png"),
-                Link(href: "chap2", type: "image/png", title: "Chapter 2"),
+                Link(href: "chap1", mediaType: .png),
+                Link(href: "chap2", mediaType: .png, title: "Chapter 2"),
             ],
-            fallbackMediaType: ""
+            fallbackMediaType: .text
         )
 
         XCTAssertEqual(service.positionsByReadingOrder, [
             [Locator(
                 href: "res",
-                type: "",
+                mediaType: .text,
                 locations: Locator.Locations(
                     totalProgression: 0.0,
                     position: 1
@@ -51,7 +51,7 @@ class PerResourcePositionsServiceTests: XCTestCase {
             )],
             [Locator(
                 href: "chap1",
-                type: "image/png",
+                mediaType: .png,
                 locations: Locator.Locations(
                     totalProgression: 1.0 / 3.0,
                     position: 2
@@ -59,7 +59,7 @@ class PerResourcePositionsServiceTests: XCTestCase {
             )],
             [Locator(
                 href: "chap2",
-                type: "image/png",
+                mediaType: .png,
                 title: "Chapter 2",
                 locations: Locator.Locations(
                     totalProgression: 2.0 / 3.0,
@@ -72,13 +72,13 @@ class PerResourcePositionsServiceTests: XCTestCase {
     func testFallsBackOnGivenMediaType() {
         let services = PerResourcePositionsService(
             readingOrder: [Link(href: "res")],
-            fallbackMediaType: "image/*"
+            fallbackMediaType: MediaType("image/*")!
         )
 
         XCTAssertEqual(services.positionsByReadingOrder, [[
             Locator(
                 href: "res",
-                type: "image/*",
+                mediaType: MediaType("image/*")!,
                 locations: Locator.Locations(
                     totalProgression: 0.0,
                     position: 1

--- a/Tests/SharedTests/Publication/Services/Positions/PositionsServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Positions/PositionsServiceTests.swift
@@ -20,7 +20,7 @@ class PositionsServiceTests: XCTestCase {
         [
             Locator(
                 href: "res",
-                type: "application/xml",
+                mediaType: .xml,
                 locations: .init(
                     totalProgression: 0.0,
                     position: 1
@@ -30,7 +30,7 @@ class PositionsServiceTests: XCTestCase {
         [
             Locator(
                 href: "chap1",
-                type: "image/png",
+                mediaType: .png,
                 locations: .init(
                     totalProgression: 1.0 / 4.0,
                     position: 2
@@ -40,7 +40,7 @@ class PositionsServiceTests: XCTestCase {
         [
             Locator(
                 href: "chap2",
-                type: "image/png",
+                mediaType: .png,
                 title: "Chapter 2",
                 locations: .init(
                     totalProgression: 3.0 / 4.0,
@@ -49,7 +49,7 @@ class PositionsServiceTests: XCTestCase {
             ),
             Locator(
                 href: "chap2",
-                type: "image/png",
+                mediaType: .png,
                 title: "Chapter 2.5",
                 locations: .init(
                     totalProgression: 3.0 / 4.0,
@@ -66,7 +66,7 @@ class PositionsServiceTests: XCTestCase {
             service.links,
             [Link(
                 href: "/~readium/positions",
-                type: "application/vnd.readium.position-list+json"
+                mediaType: .readiumPositions
             )]
         )
     }
@@ -79,7 +79,7 @@ class PositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "res",
-                    type: "application/xml",
+                    mediaType: .xml,
                     locations: .init(
                         totalProgression: 0.0,
                         position: 1
@@ -87,7 +87,7 @@ class PositionsServiceTests: XCTestCase {
                 ),
                 Locator(
                     href: "chap1",
-                    type: "image/png",
+                    mediaType: .png,
                     locations: .init(
                         totalProgression: 1.0 / 4.0,
                         position: 2
@@ -95,7 +95,7 @@ class PositionsServiceTests: XCTestCase {
                 ),
                 Locator(
                     href: "chap2",
-                    type: "image/png",
+                    mediaType: .png,
                     title: "Chapter 2",
                     locations: .init(
                         totalProgression: 3.0 / 4.0,
@@ -104,7 +104,7 @@ class PositionsServiceTests: XCTestCase {
                 ),
                 Locator(
                     href: "chap2",
-                    type: "image/png",
+                    mediaType: .png,
                     title: "Chapter 2.5",
                     locations: .init(
                         totalProgression: 3.0 / 4.0,
@@ -149,7 +149,7 @@ class PositionsServiceTests: XCTestCase {
                 [
                     Locator(
                         href: "res",
-                        type: "application/xml",
+                        mediaType: .xml,
                         locations: .init(
                             totalProgression: 0.0,
                             position: 1
@@ -159,7 +159,7 @@ class PositionsServiceTests: XCTestCase {
                 [
                     Locator(
                         href: "chap1",
-                        type: "image/png",
+                        mediaType: .png,
                         locations: .init(
                             totalProgression: 1.0 / 4.0,
                             position: 2
@@ -169,7 +169,7 @@ class PositionsServiceTests: XCTestCase {
                 [
                     Locator(
                         href: "chap2",
-                        type: "image/png",
+                        mediaType: .png,
                         title: "Chapter 2",
                         locations: .init(
                             totalProgression: 3.0 / 4.0,
@@ -178,7 +178,7 @@ class PositionsServiceTests: XCTestCase {
                     ),
                     Locator(
                         href: "chap2",
-                        type: "image/png",
+                        mediaType: .png,
                         title: "Chapter 2.5",
                         locations: .init(
                             totalProgression: 3.0 / 4.0,
@@ -196,17 +196,17 @@ class PositionsServiceTests: XCTestCase {
         let publication = makePublication(positions: nil)
 
         XCTAssertEqual(publication.positions, [
-            Locator(href: "chap1", type: "text/html", locations: .init(position: 1)),
-            Locator(href: "chap1", type: "text/html", locations: .init(position: 2)),
-            Locator(href: "chap2", type: "text/html", locations: .init(position: 3)),
+            Locator(href: "chap1", mediaType: .html, locations: .init(position: 1)),
+            Locator(href: "chap1", mediaType: .html, locations: .init(position: 2)),
+            Locator(href: "chap2", mediaType: .html, locations: .init(position: 3)),
         ])
         XCTAssertEqual(publication.positionsByReadingOrder, [
             [
-                Locator(href: "chap1", type: "text/html", locations: .init(position: 1)),
-                Locator(href: "chap1", type: "text/html", locations: .init(position: 2)),
+                Locator(href: "chap1", mediaType: .html, locations: .init(position: 1)),
+                Locator(href: "chap1", mediaType: .html, locations: .init(position: 2)),
             ],
             [
-                Locator(href: "chap2", type: "text/html", locations: .init(position: 3)),
+                Locator(href: "chap2", mediaType: .html, locations: .init(position: 3)),
             ],
         ])
     }
@@ -253,11 +253,11 @@ class PositionsServiceTests: XCTestCase {
             manifest: Manifest(
                 metadata: Metadata(title: ""),
                 links: [
-                    Link(href: positionsHref, type: "application/vnd.readium.position-list+json"),
+                    Link(href: positionsHref, mediaType: .readiumPositions)
                 ],
                 readingOrder: [
-                    Link(href: "chap1", type: "text/html"),
-                    Link(href: "chap2", type: "text/html"),
+                    Link(href: "chap1", mediaType: .html),
+                    Link(href: "chap2", mediaType: .html),
                 ]
             ),
             fetcher: fetcher,

--- a/Tests/SharedTests/Publication/Services/Positions/PositionsServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Positions/PositionsServiceTests.swift
@@ -253,7 +253,7 @@ class PositionsServiceTests: XCTestCase {
             manifest: Manifest(
                 metadata: Metadata(title: ""),
                 links: [
-                    Link(href: positionsHref, mediaType: .readiumPositions)
+                    Link(href: positionsHref, mediaType: .readiumPositions),
                 ],
                 readingOrder: [
                     Link(href: "chap1", mediaType: .html),

--- a/Tests/SharedTests/Publication/Services/PublicationServicesBuilderTests.swift
+++ b/Tests/SharedTests/Publication/Services/PublicationServicesBuilderTests.swift
@@ -25,7 +25,7 @@ class PublicationServicesBuilderTests: XCTestCase {
     func testInitWithCustomFactories() {
         let builder = PublicationServicesBuilder(
             cover: GeneratedCoverService.makeFactory(cover: UIImage()),
-            positions: PerResourcePositionsService.makeFactory(fallbackMediaType: "")
+            positions: PerResourcePositionsService.makeFactory(fallbackMediaType: .text)
         )
 
         let services = builder.build(context: context)

--- a/Tests/SharedTests/Toolkit/Extensions/URLTests.swift
+++ b/Tests/SharedTests/Toolkit/Extensions/URLTests.swift
@@ -29,7 +29,7 @@ class URLTests: XCTestCase {
     }
 
     func testIsParentOfSiblingIsFalse() {
-        let folder = URL(fileURLWithPath: "/root/folder")
+        let folder = URL(fileURLWithPath: "/root/foldser")
         XCTAssertFalse(folder.isParentOf(URL(fileURLWithPath: "/root/sibling")))
     }
 

--- a/Tests/SharedTests/Toolkit/URL/Absolute URL/FileURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/Absolute URL/FileURLTests.swift
@@ -10,60 +10,22 @@ import XCTest
 
 class FileURLTests: XCTestCase {
     func testEquality() {
-        // Paths must be equal.
         XCTAssertEqual(
             FileURL(string: "file:///foo/bar")!,
-            FileURL(string: "file:///foo/bar")
+            FileURL(string: "file:///foo/bar")!
+        )
+        // Fragments are ignored.
+        XCTAssertEqual(
+            FileURL(string: "file:///foo/bar")!,
+            FileURL(string: "file:///foo/bar#fragment")!
         )
         XCTAssertNotEqual(
-            FileURL(string: "file:///foo/baz")!,
-            FileURL(string: "file:///foo/bar")
-        )
-
-        // Paths is compared percent and entity-decoded.
-        XCTAssertEqual(
-            FileURL(string: "file:///c%27est%20valide")!,
-            FileURL(string: "file:///c%27est%20valide")
-        )
-        XCTAssertEqual(
-            FileURL(string: "file:///c'est%20valide")!,
-            FileURL(string: "file:///c%27est%20valide")
-        )
-
-        // Authority must be equal.
-        XCTAssertEqual(
-            FileURL(string: "file://user:password@host/foo")!,
-            FileURL(string: "file://user:password@host/foo")
+            FileURL(string: "file:///foo/bar")!,
+            FileURL(string: "file:///foo/baz")!
         )
         XCTAssertNotEqual(
-            FileURL(string: "file://foo"),
-            FileURL(string: "file://host/foo")
-        )
-
-        // Query parameters are ignored.
-        XCTAssertEqual(
-            FileURL(string: "file:///foo/bar?b=b&a=a")!,
-            FileURL(string: "file:///foo/bar?a=a&b=b")
-        )
-        XCTAssertEqual(
-            FileURL(string: "file:///foo/bar?b=b")!,
-            FileURL(string: "file:///foo/bar?a=a")
-        )
-
-        // Scheme is case insensitive.
-        XCTAssertEqual(
-            FileURL(string: "FILE:///foo")!,
-            FileURL(string: "file:///foo")
-        )
-
-        // Fragment is ignored.
-        XCTAssertEqual(
-            FileURL(string: "file:///foo")!,
-            FileURL(string: "file:///foo#fragment")
-        )
-        XCTAssertEqual(
-            FileURL(string: "file:///foo#other")!,
-            FileURL(string: "file:///foo#fragment")
+            FileURL(string: "file:///foo/bar")!,
+            FileURL(string: "file:///foo/bar/")!
         )
     }
 

--- a/Tests/SharedTests/Toolkit/URL/Absolute URL/HTTPURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/Absolute URL/HTTPURLTests.swift
@@ -10,90 +10,13 @@ import XCTest
 
 class HTTPURLTests: XCTestCase {
     func testEquality() {
-        // Paths must be equal.
         XCTAssertEqual(
-            HTTPURL(string: "http://example.com/foo/bar")!,
-            HTTPURL(string: "http://example.com/foo/bar")
+            HTTPURL(string: "http://domain.com")!,
+            HTTPURL(string: "http://domain.com")!
         )
         XCTAssertNotEqual(
-            HTTPURL(string: "http://example.com/foo/baz")!,
-            HTTPURL(string: "http://example.com/foo/bar")
-        )
-
-        // Paths is compared percent and entity-decoded.
-        XCTAssertEqual(
-            HTTPURL(string: "http://example.com/c%27est%20valide")!,
-            HTTPURL(string: "http://example.com/c%27est%20valide")
-        )
-        XCTAssertEqual(
-            HTTPURL(string: "http://example.com/c'est%20valide")!,
-            HTTPURL(string: "http://example.com/c%27est%20valide")
-        )
-
-        // Authority must be equal.
-        XCTAssertEqual(
-            HTTPURL(string: "http://example.com/foo")!,
-            HTTPURL(string: "http://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            HTTPURL(string: "http://example.com:80/foo")!,
-            HTTPURL(string: "http://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            HTTPURL(string: "http://example.com:80/foo")!,
-            HTTPURL(string: "http://example.com:443/foo")
-        )
-        XCTAssertNotEqual(
-            HTTPURL(string: "http://example.com:80/foo")!,
-            HTTPURL(string: "http://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            HTTPURL(string: "http://domain.com/foo")!,
-            HTTPURL(string: "http://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            HTTPURL(string: "http://user:password@example.com/foo")!,
-            HTTPURL(string: "http://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            HTTPURL(string: "http://user:password@example.com/foo")!,
-            HTTPURL(string: "http://other:password@example.com/foo")
-        )
-
-        // Order of query parameters is important.
-        XCTAssertNotEqual(
-            HTTPURL(string: "http://example.com/foo/bar?b=b&a=a")!,
-            HTTPURL(string: "http://example.com/foo/bar?a=a&b=b")
-        )
-
-        // Content of parameters is important.
-        XCTAssertEqual(
-            HTTPURL(string: "http://example.com/foo/bar?a=a&b=b")!,
-            HTTPURL(string: "http://example.com/foo/bar?a=a&b=b")
-        )
-        XCTAssertNotEqual(
-            HTTPURL(string: "http://example.com/foo/bar?b=b")!,
-            HTTPURL(string: "http://example.com/foo/bar?a=a")
-        )
-
-        // Scheme is case insensitive.
-        XCTAssertEqual(
-            HTTPURL(string: "HTTP://example.com/foo")!,
-            HTTPURL(string: "http://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            HTTPURL(string: "https://example.com/foo")!,
-            HTTPURL(string: "http://example.com/foo")
-        )
-
-        // Fragment is relevant.
-        XCTAssertEqual(
-            HTTPURL(string: "http://example.com/foo#fragment")!,
-            HTTPURL(string: "http://example.com/foo#fragment")
-        )
-        XCTAssertNotEqual(
-            HTTPURL(string: "http://example.com/foo#other")!,
-            HTTPURL(string: "http://example.com/foo#fragment")
+            HTTPURL(string: "http://domain.com")!,
+            HTTPURL(string: "http://domain.com#fragment")!
         )
     }
 

--- a/Tests/SharedTests/Toolkit/URL/Absolute URL/UnknownAbsoluteURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/Absolute URL/UnknownAbsoluteURLTests.swift
@@ -10,86 +10,13 @@ import XCTest
 
 class UnknownAbsoluteURLTests: XCTestCase {
     func testEquality() {
-        // Paths must be equal.
         XCTAssertEqual(
-            UnknownAbsoluteURL(string: "opds://example.com/foo/bar")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo/bar")
+            UnknownAbsoluteURL(string: "opds://domain.com")!,
+            UnknownAbsoluteURL(string: "opds://domain.com")!
         )
         XCTAssertNotEqual(
-            UnknownAbsoluteURL(string: "opds://example.com/foo/baz")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo/bar")
-        )
-
-        // Paths is compared percent and entity-decoded.
-        XCTAssertEqual(
-            UnknownAbsoluteURL(string: "opds://example.com/c%27est%20valide")!,
-            UnknownAbsoluteURL(string: "opds://example.com/c%27est%20valide")
-        )
-        XCTAssertEqual(
-            UnknownAbsoluteURL(string: "opds://example.com/c'est%20valide")!,
-            UnknownAbsoluteURL(string: "opds://example.com/c%27est%20valide")
-        )
-
-        // Authority must be equal.
-        XCTAssertEqual(
-            UnknownAbsoluteURL(string: "opds://example.com/foo")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            UnknownAbsoluteURL(string: "opds://example.com:80/foo")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            UnknownAbsoluteURL(string: "opds://example.com:80/foo")!,
-            UnknownAbsoluteURL(string: "opds://example.com:443/foo")
-        )
-        XCTAssertNotEqual(
-            UnknownAbsoluteURL(string: "opds://example.com:80/foo")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            UnknownAbsoluteURL(string: "opds://domain.com/foo")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            UnknownAbsoluteURL(string: "opds://user:password@example.com/foo")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo")
-        )
-        XCTAssertNotEqual(
-            UnknownAbsoluteURL(string: "opds://user:password@example.com/foo")!,
-            UnknownAbsoluteURL(string: "opds://other:password@example.com/foo")
-        )
-
-        // Order of query parameters is important.
-        XCTAssertNotEqual(
-            UnknownAbsoluteURL(string: "opds://example.com/foo/bar?b=b&a=a")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo/bar?a=a&b=b")
-        )
-
-        // Content of parameters is important.
-        XCTAssertEqual(
-            UnknownAbsoluteURL(string: "opds://example.com/foo/bar?a=a&b=b")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo/bar?a=a&b=b")
-        )
-        XCTAssertNotEqual(
-            UnknownAbsoluteURL(string: "opds://example.com/foo/bar?b=b")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo/bar?a=a")
-        )
-
-        // Scheme is case insensitive.
-        XCTAssertEqual(
-            UnknownAbsoluteURL(string: "OPDS://example.com/foo")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo")
-        )
-
-        // Fragment is relevant.
-        XCTAssertEqual(
-            UnknownAbsoluteURL(string: "opds://example.com/foo#fragment")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo#fragment")
-        )
-        XCTAssertNotEqual(
-            UnknownAbsoluteURL(string: "opds://example.com/foo#other")!,
-            UnknownAbsoluteURL(string: "opds://example.com/foo#fragment")
+            UnknownAbsoluteURL(string: "opds://domain.com")!,
+            UnknownAbsoluteURL(string: "opds://domain.com#fragment")!
         )
     }
 

--- a/Tests/SharedTests/Toolkit/URL/AnyURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/AnyURLTests.swift
@@ -147,4 +147,53 @@ class AnyURLTests: XCTestCase {
         XCTAssertEqual(base.relativize(AnyURL(string: "/foo/quz/baz")!)!.string, "quz/baz")
         XCTAssertNil(base.relativize(AnyURL(string: "/quz/baz")!))
     }
+    
+    func testNormalized() {
+        // Scheme is lower case.
+        XCTAssertEqual(
+            AnyURL(string: "HTTP://example.com")!.normalized.string,
+            "http://example.com"
+        )
+
+        // Path is percent-decoded.
+        XCTAssertEqual(
+            AnyURL(string: "HTTP://example.com/c%27est%20valide")!.normalized.string,
+            "http://example.com/c'est%20valide"
+        )
+        XCTAssertEqual(
+            AnyURL(string: "c%27est%20valide")!.normalized.string,
+            "c'est%20valide"
+        )
+
+        // Relative paths are resolved.
+        XCTAssertEqual(
+            AnyURL(string: "http://example.com/foo/./bar/../baz")!.normalized.string,
+            "http://example.com/foo/baz"
+        )
+        XCTAssertEqual(
+            AnyURL(string: "foo/./bar/../baz")!.normalized.string,
+            "foo/baz"
+        )
+        XCTAssertEqual(
+            AnyURL(string: "foo/./bar/../../../../../baz")!.normalized.string,
+            "baz"
+        )
+        
+        // Trailing slash is kept.
+        XCTAssertEqual(
+            AnyURL(string: "http://example.com/foo/")!.normalized.string,
+            "http://example.com/foo/"
+        )
+        XCTAssertEqual(
+            AnyURL(string: "foo/")!.normalized.string,
+            "foo/"
+        )
+
+        // The other components are left as-is.
+        XCTAssertEqual(
+            AnyURL(string: "http://user:password@example.com:443/foo?b=b&a=a#fragment")!.normalized.string,
+            "http://user:password@example.com:443/foo?b=b&a=a#fragment"
+        )
+
+    }
 }

--- a/Tests/SharedTests/Toolkit/URL/AnyURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/AnyURLTests.swift
@@ -147,7 +147,7 @@ class AnyURLTests: XCTestCase {
         XCTAssertEqual(base.relativize(AnyURL(string: "/foo/quz/baz")!)!.string, "quz/baz")
         XCTAssertNil(base.relativize(AnyURL(string: "/quz/baz")!))
     }
-    
+
     func testNormalized() {
         // Scheme is lower case.
         XCTAssertEqual(
@@ -178,7 +178,7 @@ class AnyURLTests: XCTestCase {
             AnyURL(string: "foo/./bar/../../../baz")!.normalized.string,
             "../baz"
         )
-        
+
         // Trailing slash is kept.
         XCTAssertEqual(
             AnyURL(string: "http://example.com/foo/")!.normalized.string,

--- a/Tests/SharedTests/Toolkit/URL/AnyURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/AnyURLTests.swift
@@ -175,8 +175,8 @@ class AnyURLTests: XCTestCase {
             "foo/baz"
         )
         XCTAssertEqual(
-            AnyURL(string: "foo/./bar/../../../../../baz")!.normalized.string,
-            "baz"
+            AnyURL(string: "foo/./bar/../../../baz")!.normalized.string,
+            "../baz"
         )
         
         // Trailing slash is kept.
@@ -194,6 +194,5 @@ class AnyURLTests: XCTestCase {
             AnyURL(string: "http://user:password@example.com:443/foo?b=b&a=a#fragment")!.normalized.string,
             "http://user:password@example.com:443/foo?b=b&a=a#fragment"
         )
-
     }
 }

--- a/Tests/SharedTests/Toolkit/URL/RelativeURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/RelativeURLTests.swift
@@ -12,25 +12,18 @@ import XCTest
 
 class RelativeURLTests: XCTestCase {
     func testEquality() {
-        // Paths must be equal.
-        XCTAssertEqual(RelativeURL(string: "foo/bar")!, RelativeURL(string: "foo/bar"))
-        XCTAssertNotEqual(RelativeURL(string: "foo/bar")!, RelativeURL(string: "foo/bar/"))
-        XCTAssertNotEqual(RelativeURL(string: "foo/baz")!, RelativeURL(string: "foo/bar"))
-
-        // Paths is compared percent and entity-decoded.
-        XCTAssertEqual(RelativeURL(string: "c%27est%20valide")!, RelativeURL(string: "c%27est%20valide"))
-        XCTAssertEqual(RelativeURL(string: "c'est%20valide")!, RelativeURL(string: "c%27est%20valide"))
-
-        // Order of query parameters is important.
-        XCTAssertNotEqual(RelativeURL(string: "foo/bar?b=b&a=a")!, RelativeURL(string: "foo/bar?a=a&b=b"))
-
-        // Content of parameters is important.
-        XCTAssertEqual(RelativeURL(string: "foo/bar?a=a&b=b")!, RelativeURL(string: "foo/bar?a=a&b=b"))
-        XCTAssertNotEqual(RelativeURL(string: "foo/bar?b=b")!, RelativeURL(string: "foo/bar?a=a"))
-
-        // Fragment is relevant.
-        XCTAssertEqual(RelativeURL(string: "foo/bar#fragment")!, RelativeURL(string: "foo/bar#fragment"))
-        XCTAssertNotEqual(RelativeURL(string: "foo/bar#other")!, RelativeURL(string: "foo/bar#fragment"))
+        XCTAssertEqual(
+            RelativeURL(string: "dir/file")!,
+            RelativeURL(string: "dir/file")!
+        )
+        XCTAssertNotEqual(
+            RelativeURL(string: "dir/file/")!,
+            RelativeURL(string: "dir/file")!
+        )
+        XCTAssertNotEqual(
+            RelativeURL(string: "dir")!,
+            RelativeURL(string: "dir/file")!
+        )
     }
 
     // MARK: - URLProtocol

--- a/Tests/StreamerTests/Extensions.swift
+++ b/Tests/StreamerTests/Extensions.swift
@@ -12,3 +12,10 @@ extension ArchiveFetcher {
         try self.init(archive: DefaultArchiveFactory().open(file: file, password: password).get())
     }
 }
+
+extension Locator {
+    init(href: String, mediaType: MediaType, title: String? = nil, locations: Locations = .init(), text: Text = .init()) {
+        self.init(href: AnyURL(string: href)!, mediaType: mediaType, title: title, locations: locations, text: text)
+    }
+}
+

--- a/Tests/StreamerTests/Extensions.swift
+++ b/Tests/StreamerTests/Extensions.swift
@@ -18,4 +18,3 @@ extension Locator {
         self.init(href: AnyURL(string: href)!, mediaType: mediaType, title: title, locations: locations, text: text)
     }
 }
-

--- a/Tests/StreamerTests/Parser/Audio/AudioParserTests.swift
+++ b/Tests/StreamerTests/Parser/Audio/AudioParserTests.swift
@@ -62,7 +62,7 @@ class AudioParserTests: XCTestCase {
 
     func testHasNoCover() throws {
         let publication = try XCTUnwrap(parser.parse(asset: zabAsset, fetcher: zabFetcher, warnings: nil)?.build())
-        XCTAssertNil(publication.link(withRel: .cover))
+        XCTAssertNil(publication.linkWithRel(.cover))
     }
 
     func testComputeTitleFromArchiveRootDirectory() throws {

--- a/Tests/StreamerTests/Parser/Audio/Services/AudioLocatorServiceTests.swift
+++ b/Tests/StreamerTests/Parser/Audio/Services/AudioLocatorServiceTests.swift
@@ -74,7 +74,7 @@ class AudioLocatorServiceTests: XCTestCase {
             service.locate(
                 Locator(
                     href: "wrong",
-                    type: "wrong-type",
+                    mediaType: MediaType("text/plain")!,
                     title: "Title",
                     locations: .init(
                         fragments: ["ignored"],

--- a/Tests/StreamerTests/Parser/Audio/Services/AudioLocatorServiceTests.swift
+++ b/Tests/StreamerTests/Parser/Audio/Services/AudioLocatorServiceTests.swift
@@ -16,7 +16,7 @@ class AudioLocatorServiceTests: XCTestCase {
             Link(href: "l2"),
         ])
 
-        let locator = Locator(href: "l1", type: "audio/mpeg", locations: .init(totalProgression: 0.53))
+        let locator = Locator(href: "l1", mediaType: .mp3, locations: .init(totalProgression: 0.53))
         XCTAssertEqual(service.locate(locator), locator)
     }
 
@@ -26,19 +26,19 @@ class AudioLocatorServiceTests: XCTestCase {
             Link(href: "l2"),
         ])
 
-        let locator = Locator(href: "l3", type: "audio/mpeg", locations: .init(totalProgression: 0.53))
+        let locator = Locator(href: "l3", mediaType: .mp3, locations: .init(totalProgression: 0.53))
         XCTAssertNil(service.locate(locator))
     }
 
     func testLocateLocatorUsesTotalProgression() {
         let service = makeService(readingOrder: [
-            Link(href: "l1", type: "audio/mpeg", duration: 100),
-            Link(href: "l2", type: "audio/mpeg", duration: 100),
+            Link(href: "l1", mediaType: .mp3, duration: 100),
+            Link(href: "l2", mediaType: .mp3, duration: 100),
         ])
 
         XCTAssertEqual(
-            service.locate(Locator(href: "wrong", type: "audio/mpeg", locations: .init(totalProgression: 0.49))),
-            Locator(href: "l1", type: "audio/mpeg", locations: .init(
+            service.locate(Locator(href: "wrong", mediaType: .mp3, locations: .init(totalProgression: 0.49))),
+            Locator(href: "l1", mediaType: .mp3, locations: .init(
                 fragments: ["t=98"],
                 progression: 98 / 100.0,
                 totalProgression: 0.49
@@ -46,8 +46,8 @@ class AudioLocatorServiceTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            service.locate(Locator(href: "wrong", type: "audio/mpeg", locations: .init(totalProgression: 0.5))),
-            Locator(href: "l2", type: "audio/mpeg", locations: .init(
+            service.locate(Locator(href: "wrong", mediaType: .mp3, locations: .init(totalProgression: 0.5))),
+            Locator(href: "l2", mediaType: .mp3, locations: .init(
                 fragments: ["t=0"],
                 progression: 0,
                 totalProgression: 0.5
@@ -55,8 +55,8 @@ class AudioLocatorServiceTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            service.locate(Locator(href: "wrong", type: "audio/mpeg", locations: .init(totalProgression: 0.51))),
-            Locator(href: "l2", type: "audio/mpeg", locations: .init(
+            service.locate(Locator(href: "wrong", mediaType: .mp3, locations: .init(totalProgression: 0.51))),
+            Locator(href: "l2", mediaType: .mp3, locations: .init(
                 fragments: ["t=2"],
                 progression: 0.02,
                 totalProgression: 0.51
@@ -66,8 +66,8 @@ class AudioLocatorServiceTests: XCTestCase {
 
     func testLocateLocatorUsingTotalProgressionKeepsTitleAndText() {
         let service = makeService(readingOrder: [
-            Link(href: "l1", type: "audio/mpeg", duration: 100),
-            Link(href: "l2", type: "audio/mpeg", duration: 100),
+            Link(href: "l1", mediaType: .mp3, duration: 100),
+            Link(href: "l2", mediaType: .mp3, duration: 100),
         ])
 
         XCTAssertEqual(
@@ -88,7 +88,7 @@ class AudioLocatorServiceTests: XCTestCase {
             ),
             Locator(
                 href: "l1",
-                type: "audio/mpeg",
+                mediaType: .mp3,
                 title: "Title",
                 locations: .init(
                     fragments: ["t=80"],
@@ -102,13 +102,13 @@ class AudioLocatorServiceTests: XCTestCase {
 
     func testLocateProgression() {
         let service = makeService(readingOrder: [
-            Link(href: "l1", type: "audio/mpeg", duration: 100),
-            Link(href: "l2", type: "audio/mpeg", duration: 100),
+            Link(href: "l1", mediaType: .mp3, duration: 100),
+            Link(href: "l2", mediaType: .mp3, duration: 100),
         ])
 
         XCTAssertEqual(
             service.locate(progression: 0),
-            Locator(href: "l1", type: "audio/mpeg", locations: .init(
+            Locator(href: "l1", mediaType: .mp3, locations: .init(
                 fragments: ["t=0"],
                 progression: 0,
                 totalProgression: 0
@@ -117,7 +117,7 @@ class AudioLocatorServiceTests: XCTestCase {
 
         XCTAssertEqual(
             service.locate(progression: 0.49),
-            Locator(href: "l1", type: "audio/mpeg", locations: .init(
+            Locator(href: "l1", mediaType: .mp3, locations: .init(
                 fragments: ["t=98"],
                 progression: 98 / 100.0,
                 totalProgression: 0.49
@@ -126,7 +126,7 @@ class AudioLocatorServiceTests: XCTestCase {
 
         XCTAssertEqual(
             service.locate(progression: 0.5),
-            Locator(href: "l2", type: "audio/mpeg", locations: .init(
+            Locator(href: "l2", mediaType: .mp3, locations: .init(
                 fragments: ["t=0"],
                 progression: 0,
                 totalProgression: 0.5
@@ -135,7 +135,7 @@ class AudioLocatorServiceTests: XCTestCase {
 
         XCTAssertEqual(
             service.locate(progression: 0.51),
-            Locator(href: "l2", type: "audio/mpeg", locations: .init(
+            Locator(href: "l2", mediaType: .mp3, locations: .init(
                 fragments: ["t=2"],
                 progression: 0.02,
                 totalProgression: 0.51
@@ -144,7 +144,7 @@ class AudioLocatorServiceTests: XCTestCase {
 
         XCTAssertEqual(
             service.locate(progression: 1),
-            Locator(href: "l2", type: "audio/mpeg", locations: .init(
+            Locator(href: "l2", mediaType: .mp3, locations: .init(
                 fragments: ["t=100"],
                 progression: 1,
                 totalProgression: 1
@@ -154,8 +154,8 @@ class AudioLocatorServiceTests: XCTestCase {
 
     func testLocateInvalidProgression() {
         let service = makeService(readingOrder: [
-            Link(href: "l1", type: "audio/mpeg", duration: 100),
-            Link(href: "l2", type: "audio/mpeg", duration: 100),
+            Link(href: "l1", mediaType: .mp3, duration: 100),
+            Link(href: "l2", mediaType: .mp3, duration: 100),
         ])
 
         XCTAssertNil(service.locate(progression: -0.5))

--- a/Tests/StreamerTests/Parser/EPUB/OPFParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/OPFParserTests.swift
@@ -54,17 +54,17 @@ class OPFParserTests: XCTestCase {
 
         XCTAssertEqual(sut.links, [])
         XCTAssertEqual(sut.readingOrder, [
-            link(id: "titlepage", href: "titlepage.xhtml", type: "application/xhtml+xml"),
-            link(id: "chapter01", href: "EPUB/chapter01.xhtml", type: "application/xhtml+xml"),
+            link(id: "titlepage", href: "titlepage.xhtml", mediaType: .xhtml),
+            link(id: "chapter01", href: "EPUB/chapter01.xhtml", mediaType: .xhtml),
         ])
         XCTAssertEqual(sut.resources, [
             link(id: "font0", href: "EPUB/fonts/MinionPro.otf", type: "application/vnd.ms-opentype"),
-            link(id: "nav", href: "EPUB/nav.xhtml", type: "application/xhtml+xml", rels: [.contents]),
-            link(id: "css", href: "style.css", type: "text/css"),
-            link(id: "chapter02", href: "EPUB/chapter02.xhtml", type: "application/xhtml+xml"),
+            link(id: "nav", href: "EPUB/nav.xhtml", mediaType: .xhtml, rels: [.contents]),
+            link(id: "css", href: "style.css", mediaType: .css),
+            link(id: "chapter02", href: "EPUB/chapter02.xhtml", mediaType: .xhtml),
             link(id: "chapter01_smil", href: "EPUB/chapter01.smil", type: "application/smil+xml"),
             link(id: "chapter02_smil", href: "EPUB/chapter02.smil", type: "application/smil+xml"),
-            link(id: "img01a", href: "EPUB/images/alice01a.png", type: "image/png", rels: [.cover]),
+            link(id: "img01a", href: "EPUB/images/alice01a.png", mediaType: .png, rels: [.cover]),
             link(id: "img02a", href: "EPUB/images/alice02a.gif", type: "image/gif"),
             link(id: "nomediatype", href: "EPUB/nomediatype.txt"),
         ])

--- a/Tests/StreamerTests/Parser/EPUB/OPFParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/OPFParserTests.swift
@@ -58,14 +58,14 @@ class OPFParserTests: XCTestCase {
             link(id: "chapter01", href: "EPUB/chapter01.xhtml", mediaType: .xhtml),
         ])
         XCTAssertEqual(sut.resources, [
-            link(id: "font0", href: "EPUB/fonts/MinionPro.otf", type: "application/vnd.ms-opentype"),
+            link(id: "font0", href: "EPUB/fonts/MinionPro.otf", mediaType: MediaType("application/vnd.ms-opentype")!),
             link(id: "nav", href: "EPUB/nav.xhtml", mediaType: .xhtml, rels: [.contents]),
             link(id: "css", href: "style.css", mediaType: .css),
             link(id: "chapter02", href: "EPUB/chapter02.xhtml", mediaType: .xhtml),
-            link(id: "chapter01_smil", href: "EPUB/chapter01.smil", type: "application/smil+xml"),
-            link(id: "chapter02_smil", href: "EPUB/chapter02.smil", type: "application/smil+xml"),
+            link(id: "chapter01_smil", href: "EPUB/chapter01.smil", mediaType: .smil),
+            link(id: "chapter02_smil", href: "EPUB/chapter02.smil", mediaType: .smil),
             link(id: "img01a", href: "EPUB/images/alice01a.png", mediaType: .png, rels: [.cover]),
-            link(id: "img02a", href: "EPUB/images/alice02a.gif", type: "image/gif"),
+            link(id: "img02a", href: "EPUB/images/alice02a.gif", mediaType: .gif),
             link(id: "nomediatype", href: "EPUB/nomediatype.txt"),
         ])
     }
@@ -125,7 +125,7 @@ class OPFParserTests: XCTestCase {
         let sut = try parseManifest("cover-epub2", at: "EPUB/content.opf").manifest
 
         XCTAssertEqual(sut.resources, [
-            link(id: "my-cover", href: "EPUB/cover.jpg", type: "image/jpeg", rels: [.cover]),
+            link(id: "my-cover", href: "EPUB/cover.jpg", mediaType: .jpeg, rels: [.cover]),
         ])
     }
 
@@ -133,7 +133,7 @@ class OPFParserTests: XCTestCase {
         let sut = try parseManifest("cover-epub3", at: "EPUB/content.opf").manifest
 
         XCTAssertEqual(sut.resources, [
-            link(id: "my-cover", href: "EPUB/cover.jpg", type: "image/jpeg", rels: [.cover]),
+            link(id: "my-cover", href: "EPUB/cover.jpg", mediaType: .jpeg, rels: [.cover]),
         ])
     }
 
@@ -154,11 +154,11 @@ class OPFParserTests: XCTestCase {
         ), parts.version)
     }
 
-    func link(id: String? = nil, href: String, type: String? = nil, templated: Bool = false, title: String? = nil, rels: [LinkRelation] = [], properties: Properties = .init(), children: [Link] = []) -> Link {
+    func link(id: String? = nil, href: String, mediaType: MediaType? = nil, templated: Bool = false, title: String? = nil, rels: [LinkRelation] = [], properties: Properties = .init(), children: [Link] = []) -> Link {
         var properties = properties.otherProperties
         if let id = id {
             properties["id"] = id
         }
-        return Link(href: href, type: type, templated: templated, title: title, rels: rels, properties: Properties(properties), children: children)
+        return Link(href: href, mediaType: mediaType, templated: templated, title: title, rels: rels, properties: Properties(properties), children: children)
     }
 }

--- a/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
@@ -15,12 +15,12 @@ class EPUBPositionsServiceTests: XCTestCase {
     }
 
     func testFromReadingOrderWithOneResource() {
-        let service = makeService(readingOrder: [(1, Link(href: "res", type: "application/xml"))])
+        let service = makeService(readingOrder: [(1, Link(href: "res", mediaType: .xml))])
 
         XCTAssertEqual(service.positionsByReadingOrder, [[
             Locator(
                 href: "res",
-                type: "application/xml",
+                mediaType: .xml,
                 locations: Locator.Locations(
                     progression: 0,
                     totalProgression: 0,
@@ -33,14 +33,14 @@ class EPUBPositionsServiceTests: XCTestCase {
     func testFromReadingOrderWithFewResources() {
         let service = makeService(readingOrder: [
             (1, Link(href: "res")),
-            (2, Link(href: "chap1", type: "application/xml")),
-            (2, Link(href: "chap2", type: "text/html", title: "Chapter 2")),
+            (2, Link(href: "chap1", mediaType: .xml)),
+            (2, Link(href: "chap2", mediaType: .html, title: "Chapter 2")),
         ])
 
         XCTAssertEqual(service.positionsByReadingOrder, [
             [Locator(
                 href: "res",
-                type: "text/html",
+                mediaType: .html,
                 locations: Locator.Locations(
                     progression: 0.0,
                     totalProgression: 0.0,
@@ -49,7 +49,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             )],
             [Locator(
                 href: "chap1",
-                type: "application/xml",
+                mediaType: .xml,
                 locations: Locator.Locations(
                     progression: 0.0,
                     totalProgression: 1.0 / 3.0,
@@ -58,7 +58,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             )],
             [Locator(
                 href: "chap2",
-                type: "text/html",
+                mediaType: .html,
                 title: "Chapter 2",
                 locations: Locator.Locations(
                     progression: 0.0,
@@ -78,7 +78,7 @@ class EPUBPositionsServiceTests: XCTestCase {
         XCTAssertEqual(service.positionsByReadingOrder, [
             [Locator(
                 href: "chap1",
-                type: "text/html",
+                mediaType: .html,
                 locations: Locator.Locations(
                     progression: 0.0,
                     totalProgression: 0.0,
@@ -87,7 +87,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             )],
             [Locator(
                 href: "chap2",
-                type: "text/html",
+                mediaType: .html,
                 locations: Locator.Locations(
                     progression: 0.0,
                     totalProgression: 0.5,
@@ -102,15 +102,15 @@ class EPUBPositionsServiceTests: XCTestCase {
             layout: .fixed,
             readingOrder: [
                 (10000, Link(href: "res")),
-                (20000, Link(href: "chap1", type: "application/xml")),
-                (40000, Link(href: "chap2", type: "text/html", title: "Chapter 2")),
+                (20000, Link(href: "chap1", mediaType: .xml)),
+                (40000, Link(href: "chap2", mediaType: .html, title: "Chapter 2")),
             ]
         )
 
         XCTAssertEqual(service.positionsByReadingOrder, [
             [Locator(
                 href: "res",
-                type: "text/html",
+                mediaType: .html,
                 locations: Locator.Locations(
                     progression: 0.0,
                     totalProgression: 0.0,
@@ -119,7 +119,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             )],
             [Locator(
                 href: "chap1",
-                type: "application/xml",
+                mediaType: .xml,
                 locations: Locator.Locations(
                     progression: 0.0,
                     totalProgression: 1.0 / 3.0,
@@ -128,7 +128,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             )],
             [Locator(
                 href: "chap2",
-                type: "text/html",
+                mediaType: .html,
                 title: "Chapter 2",
                 locations: Locator.Locations(
                     progression: 0.0,
@@ -144,8 +144,8 @@ class EPUBPositionsServiceTests: XCTestCase {
             layout: .reflowable,
             readingOrder: [
                 (0, Link(href: "chap1")),
-                (49, Link(href: "chap2", type: "application/xml")),
-                (50, Link(href: "chap3", type: "text/html", title: "Chapter 3")),
+                (49, Link(href: "chap2", mediaType: .xml)),
+                (50, Link(href: "chap3", mediaType: .html, title: "Chapter 3")),
                 (51, Link(href: "chap4")),
                 (120, Link(href: "chap5")),
             ],
@@ -156,7 +156,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap1",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 0.0,
@@ -167,7 +167,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap2",
-                    type: "application/xml",
+                    mediaType: .xml,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 1.0 / 8.0,
@@ -178,7 +178,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap3",
-                    type: "text/html",
+                    mediaType: .html,
                     title: "Chapter 3",
                     locations: Locator.Locations(
                         progression: 0.0,
@@ -190,7 +190,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap4",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 3.0 / 8.0,
@@ -199,7 +199,7 @@ class EPUBPositionsServiceTests: XCTestCase {
                 ),
                 Locator(
                     href: "chap4",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.5,
                         totalProgression: 4.0 / 8.0,
@@ -210,7 +210,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap5",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 5.0 / 8.0,
@@ -219,7 +219,7 @@ class EPUBPositionsServiceTests: XCTestCase {
                 ),
                 Locator(
                     href: "chap5",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 1.0 / 3.0,
                         totalProgression: 6.0 / 8.0,
@@ -228,7 +228,7 @@ class EPUBPositionsServiceTests: XCTestCase {
                 ),
                 Locator(
                     href: "chap5",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 2.0 / 3.0,
                         totalProgression: 7.0 / 8.0,
@@ -252,7 +252,7 @@ class EPUBPositionsServiceTests: XCTestCase {
         XCTAssertEqual(service.positionsByReadingOrder, [[
             Locator(
                 href: "chap1",
-                type: "text/html",
+                mediaType: .html,
                 locations: Locator.Locations(
                     progression: 0.0,
                     totalProgression: 0.0,
@@ -261,7 +261,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             ),
             Locator(
                 href: "chap1",
-                type: "text/html",
+                mediaType: .html,
                 locations: Locator.Locations(
                     progression: 0.5,
                     totalProgression: 0.5,
@@ -286,7 +286,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap1",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 0.0,
@@ -297,7 +297,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap2",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 1.0 / 4.0,
@@ -306,7 +306,7 @@ class EPUBPositionsServiceTests: XCTestCase {
                 ),
                 Locator(
                     href: "chap2",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.5,
                         totalProgression: 2.0 / 4.0,
@@ -317,7 +317,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap3",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 3.0 / 4.0,
@@ -342,7 +342,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap1",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 0.0,
@@ -353,7 +353,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap2",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 1.0 / 3.0,
@@ -362,7 +362,7 @@ class EPUBPositionsServiceTests: XCTestCase {
                 ),
                 Locator(
                     href: "chap2",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.5,
                         totalProgression: 2.0 / 3.0,
@@ -387,7 +387,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap1",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 0.0,
@@ -398,7 +398,7 @@ class EPUBPositionsServiceTests: XCTestCase {
             [
                 Locator(
                     href: "chap2",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.0,
                         totalProgression: 1.0 / 3.0,
@@ -407,7 +407,7 @@ class EPUBPositionsServiceTests: XCTestCase {
                 ),
                 Locator(
                     href: "chap2",
-                    type: "text/html",
+                    mediaType: .html,
                     locations: Locator.Locations(
                         progression: 0.5,
                         totalProgression: 2.0 / 3.0,

--- a/Tests/StreamerTests/Parser/Image/ImageParserTests.swift
+++ b/Tests/StreamerTests/Parser/Image/ImageParserTests.swift
@@ -79,7 +79,7 @@ class ImageParserTests: XCTestCase {
         XCTAssertEqual(publication.positions, [
             Locator(
                 href: "Cory%20Doctorow's%20Futuristic%20Tales%20of%20the%20Here%20and%20Now/a-fc.jpg",
-                type: "image/jpeg",
+                mediaType: .jpeg,
                 locations: .init(
                     totalProgression: 0,
                     position: 1
@@ -87,7 +87,7 @@ class ImageParserTests: XCTestCase {
             ),
             Locator(
                 href: "Cory%20Doctorow's%20Futuristic%20Tales%20of%20the%20Here%20and%20Now/x-002.jpg",
-                type: "image/jpeg",
+                mediaType: .jpeg,
                 locations: .init(
                     totalProgression: 1 / 5.0,
                     position: 2
@@ -95,7 +95,7 @@ class ImageParserTests: XCTestCase {
             ),
             Locator(
                 href: "Cory%20Doctorow's%20Futuristic%20Tales%20of%20the%20Here%20and%20Now/x-003.jpg",
-                type: "image/jpeg",
+                mediaType: .jpeg,
                 locations: .init(
                     totalProgression: 2 / 5.0,
                     position: 3
@@ -103,7 +103,7 @@ class ImageParserTests: XCTestCase {
             ),
             Locator(
                 href: "Cory%20Doctorow's%20Futuristic%20Tales%20of%20the%20Here%20and%20Now/x-153.jpg",
-                type: "image/jpeg",
+                mediaType: .jpeg,
                 locations: .init(
                     totalProgression: 3 / 5.0,
                     position: 4
@@ -111,7 +111,7 @@ class ImageParserTests: XCTestCase {
             ),
             Locator(
                 href: "Cory%20Doctorow's%20Futuristic%20Tales%20of%20the%20Here%20and%20Now/z-bc.jpg",
-                type: "image/jpeg",
+                mediaType: .jpeg,
                 locations: .init(
                     totalProgression: 4 / 5.0,
                     position: 5

--- a/Tests/StreamerTests/Parser/Image/ImageParserTests.swift
+++ b/Tests/StreamerTests/Parser/Image/ImageParserTests.swift
@@ -64,7 +64,7 @@ class ImageParserTests: XCTestCase {
 
     func testFirstReadingOrderItemIsCover() throws {
         let publication = try XCTUnwrap(parser.parse(asset: cbzAsset, fetcher: cbzFetcher, warnings: nil)?.build())
-        let cover = try XCTUnwrap(publication.link(withRel: .cover))
+        let cover = try XCTUnwrap(publication.linkWithRel(.cover))
         XCTAssertEqual(publication.readingOrder.first, cover)
     }
 


### PR DESCRIPTION
## Normalize URLs on-the-fly when comparing

Normalize URLs when comparing them following these rules:

* Scheme is lower case.
* Paths must only percent-encode required characters.
* Relative paths (e.g. `..`) are resolved.

The reason for this change is that some EPUBs encode unreserved characters which breaks locating a Link from an HREF.

For example both of these are valid relative URLs which point to the same resource:

* `Text/Ces_choses_qu'on_laisse.xhtml`
* `Text/Ces_choses_qu%27on_laisse.xhtml`

## URL and Media type in Link and Locator objects

Locator and Link objects now use `AnyURL` and `MediaType` instead of strings.