### PR TITLE
Fix first spread of FXL EPUBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * Optimized scrolling to an EPUB text-based locator if it contains a CSS selector.
+* The first resource of a fixed-layout EPUB is now displayed on its own when spreads are enabled and the author has not set a `page-spread-*` property. This is the default behavior in major reading apps like Apple Books.
 
 
 ## [3.0.0-alpha.1]

--- a/Sources/Navigator/Preferences/Types.swift
+++ b/Sources/Navigator/Preferences/Types.swift
@@ -52,13 +52,13 @@ public enum ReadingProgression: String, Codable, Hashable {
         }
     }
 
-    /// Returns the leading Page for the reading progression.
-    var leadingPage: Presentation.Page {
+    /// Returns the starting page for the reading progression.
+    var startingPage: Presentation.Page {
         switch self {
         case .ltr:
-            return .left
-        case .rtl:
             return .right
+        case .rtl:
+            return .left
         }
     }
 }


### PR DESCRIPTION
### Fixed

#### Navigator

* The first resource of a fixed-layout EPUB is now displayed on its own when spreads are enabled and the author has not set a `page-spread-*` property. This is the default behavior in major reading apps like Apple Books.