### PR TITLE
Fix stack overflow with TTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+#### Navigator
+
+* [#459](https://github.com/readium/swift-toolkit/issues/459) Fixed the stack overflow issue that occurred when running the text-to-speech on an EPUB file with many empty resources.
+
 
 ## [3.0.0-alpha.2]
 

--- a/Sources/Navigator/TTS/PublicationSpeechSynthesizer.swift
+++ b/Sources/Navigator/TTS/PublicationSpeechSynthesizer.swift
@@ -339,15 +339,14 @@ public class PublicationSpeechSynthesizer: Loggable {
     /// Loads the utterances for the next publication `ContentElement` item in the given `direction`.
     private func loadNextUtterances(_ direction: Direction) async -> Bool {
         do {
-            guard let content = try await publicationIterator?.next(direction) else {
-                return false
-            }
+            var nextUtterances: [Utterance] = []
+            while nextUtterances.isEmpty {
+                guard let content = try await publicationIterator?.next(direction) else {
+                    return false
+                }
 
-            let nextUtterances = try tokenize(content)
-                .flatMap { utterances(for: $0) }
-
-            if nextUtterances.isEmpty {
-                return await loadNextUtterances(direction)
+                nextUtterances = try tokenize(content)
+                    .flatMap { utterances(for: $0) }
             }
 
             utterances = CursorList(


### PR DESCRIPTION

### Fixed

#### Navigator

* [#459](https://github.com/readium/swift-toolkit/issues/459) Fixed the stack overflow issue that occurred when running the text-to-speech on an EPUB file with many empty resources.

---

* Fixes #459 