### PR TITLE
Fix Fuzi with Xcode 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+* [#489](https://github.com/readium/swift-toolkit/issues/489) Fix crash related to Fuzi when compiling with Xcode 16 in release mode.
+
 
 ## [2.7.3]
+
+### Fixed
 
 * [#483](https://github.com/readium/swift-toolkit/issues/483) Fix build on Xcode 16.
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,7 +1,7 @@
-github "cezheng/Fuzi" ~> 3.1.3
 github "dexman/Minizip" ~> 1.4.0
 github "krzyzanowskim/CryptoSwift" == 1.5.1 # From 1.6.0, the build fails in GitHub actions
 github "ra1028/DifferenceKit" ~> 1.3.0
+github "readium/Fuzi" ~> 3.1.4
 github "readium/GCDWebServer" ~> 4.0.0
 github "scinfu/SwiftSoup" == 2.5.3 # 2.6.0 requires Xcode 14
 github "stephencelis/SQLite.swift" == 0.13.3 # 0.14 introduces a breaking change

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "ReadiumAdapterGCDWebServer", targets: ["ReadiumAdapterGCDWebServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/cezheng/Fuzi.git", from: "3.1.3"),
+        .package(url: "https://github.com/readium/Fuzi.git", from: "3.1.4"),
         // From 1.6.0, the build fails in GitHub actions with Carthage
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", "1.5.1" ..< "1.6.0"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.2"),

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ pod 'R2Navigator', podspec: 'https://raw.githubusercontent.com/readium/swift-too
 pod 'ReadiumOPDS', podspec: 'https://raw.githubusercontent.com/readium/swift-toolkit/2.7.3/Support/CocoaPods/ReadiumOPDS.podspec'
 pod 'ReadiumLCP', podspec: 'https://raw.githubusercontent.com/readium/swift-toolkit/2.7.3/Support/CocoaPods/ReadiumLCP.podspec'
 pod 'ReadiumInternal', podspec: 'https://raw.githubusercontent.com/readium/swift-toolkit/2.7.3/Support/CocoaPods/ReadiumInternal.podspec'
+pod 'Fuzi', podspec: 'https://raw.githubusercontent.com/readium/Fuzi/refs/heads/master/Fuzi.podspec'
 
 # Required if you use R2Streamer.
 pod 'ReadiumGCDWebServer', podspec: 'https://raw.githubusercontent.com/readium/GCDWebServer/4.0.0/GCDWebServer.podspec'

--- a/TestApp/Integrations/CocoaPods/Podfile
+++ b/TestApp/Integrations/CocoaPods/Podfile
@@ -10,6 +10,7 @@ target 'TestApp' do
   pod 'ReadiumAdapterGCDWebServer', podspec: 'https://raw.githubusercontent.com/readium/swift-toolkit/VERSION/Support/CocoaPods/ReadiumAdapterGCDWebServer.podspec'
   pod 'ReadiumOPDS', podspec: 'https://raw.githubusercontent.com/readium/swift-toolkit/VERSION/Support/CocoaPods/ReadiumOPDS.podspec'
   pod 'ReadiumInternal', podspec: 'https://raw.githubusercontent.com/readium/swift-toolkit/VERSION/Support/CocoaPods/ReadiumInternal.podspec'
+  pod 'Fuzi', podspec: 'https://raw.githubusercontent.com/readium/Fuzi/refs/heads/master/Fuzi.podspec'
 
   # Required for R2Streamer and ReadiumAdapterGCDWebServer.
   pod 'ReadiumGCDWebServer', podspec: 'https://raw.githubusercontent.com/readium/GCDWebServer/master/GCDWebServer.podspec'

--- a/TestApp/Integrations/CocoaPods/Podfile+lcp
+++ b/TestApp/Integrations/CocoaPods/Podfile+lcp
@@ -11,6 +11,7 @@ target 'TestApp' do
   pod 'ReadiumOPDS', podspec: 'https://raw.githubusercontent.com/readium/swift-toolkit/VERSION/Support/CocoaPods/ReadiumOPDS.podspec'
   pod 'ReadiumLCP', podspec: 'https://raw.githubusercontent.com/readium/swift-toolkit/VERSION/Support/CocoaPods/ReadiumLCP.podspec'
   pod 'ReadiumInternal', podspec: 'https://raw.githubusercontent.com/readium/swift-toolkit/VERSION/Support/CocoaPods/ReadiumInternal.podspec'
+  pod 'Fuzi', podspec: 'https://raw.githubusercontent.com/readium/Fuzi/refs/heads/master/Fuzi.podspec'
   pod 'R2LCPClient', podspec: 'LCP_URL'
 
   # Required for R2Streamer and ReadiumAdapterGCDWebServer.


### PR DESCRIPTION

### Fixed

* [#489](https://github.com/readium/swift-toolkit/issues/489) Fix crash related to Fuzi when compiling with Xcode 16 in release mode.
