### PR TITLE
Fix EPUB deobfuscation of ranges

### DIFF
--- a/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
+++ b/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
@@ -72,20 +72,24 @@ final class EPUBDeobfuscator {
         }
 
         func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
-            await resource.stream(
+            var readPosition = range?.lowerBound ?? 0
+            let obfuscatedLength = algorithm.obfuscatedLength
+
+            return await resource.stream(
                 range: range,
                 consume: { data in
                     var data = data
 
-                    let range = range ?? 0 ..< UInt64(data.count)
-                    if range.lowerBound < self.algorithm.obfuscatedLength {
-                        let toDeobfuscate = max(range.lowerBound, 0) ..< min(range.upperBound, UInt64(self.algorithm.obfuscatedLength))
-
-                        for i in toDeobfuscate {
-                            let i = Int(i)
+                    if readPosition < obfuscatedLength {
+                        for i in 0 ..< data.count {
+                            if readPosition + UInt64(i) >= obfuscatedLength {
+                                break
+                            }
                             data[i] = data[i] ^ self.key[i % self.key.count]
                         }
                     }
+
+                    readPosition += UInt64(data.count)
 
                     consume(data)
                 }


### PR DESCRIPTION
Fix deobfuscation of EPUB resources, when they are consumed as chunks.

This issue surfaced after [transitioning to `ZIPFoundation`](https://github.com/readium/swift-toolkit/pull/518).