### PR TITLE
Don't crash the app if the LCP database cannot be opened

### DIFF
--- a/Sources/Adapters/LCPSQLite/Database.swift
+++ b/Sources/Adapters/LCPSQLite/Database.swift
@@ -9,22 +9,24 @@ import SQLite
 
 final class Database {
     /// Shared instance.
-    static let shared = Database()
+    static let shared: Swift.Result<Database, Error> = {
+        do {
+            return try .success(Database())
+        } catch {
+            return .failure(error)
+        }
+    }()
 
     let connection: Connection
 
-    private init() {
-        do {
-            var url = try FileManager.default.url(
-                for: .libraryDirectory,
-                in: .userDomainMask,
-                appropriateFor: nil, create: true
-            )
-            url.appendPathComponent("lcpdatabase.sqlite")
-            connection = try Connection(url.absoluteString)
-        } catch {
-            fatalError("Error initializing db.")
-        }
+    private init() throws {
+        var url = try FileManager.default.url(
+            for: .libraryDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil, create: true
+        )
+        url.appendPathComponent("lcpdatabase.sqlite")
+        connection = try Connection(url.absoluteString)
     }
 }
 

--- a/Sources/Adapters/LCPSQLite/SQLiteLCPLicenseRepository.swift
+++ b/Sources/Adapters/LCPSQLite/SQLiteLCPLicenseRepository.swift
@@ -17,17 +17,17 @@ public class LCPSQLiteLicenseRepository: LCPLicenseRepository {
 
     private let db: Connection
 
-    public init() {
-        db = Database.shared.connection
+    public init() throws {
+        db = try Database.shared.get().connection
 
-        _ = try? db.run(licenses.create(temporary: false, ifNotExists: true) { t in
+        try db.run(licenses.create(temporary: false, ifNotExists: true) { t in
             t.column(id, unique: true)
             t.column(printsLeft)
             t.column(copiesLeft)
         })
 
         if db.userVersion == 0 {
-            _ = try? db.run(licenses.addColumn(registered, defaultValue: false))
+            try db.run(licenses.addColumn(registered, defaultValue: false))
             db.userVersion = 1
         }
         if db.userVersion == 1 {

--- a/Sources/Adapters/LCPSQLite/SQLiteLCPPassphraseRepository.swift
+++ b/Sources/Adapters/LCPSQLite/SQLiteLCPPassphraseRepository.swift
@@ -18,19 +18,15 @@ public class LCPSQLitePassphraseRepository: LCPPassphraseRepository, Loggable {
 
     private let db: Connection
 
-    public init() {
-        db = Database.shared.connection
+    public init() throws {
+        db = try Database.shared.get().connection
 
-        do {
-            try db.run(transactions.create(temporary: false, ifNotExists: true) { t in
-                t.column(licenseId)
-                t.column(provider)
-                t.column(userId)
-                t.column(passphrase)
-            })
-        } catch {
-            log(.error, error)
-        }
+        try db.run(transactions.create(temporary: false, ifNotExists: true) { t in
+            t.column(licenseId)
+            t.column(provider)
+            t.column(userId)
+            t.column(passphrase)
+        })
     }
 
     public func passphrase(for licenseID: LicenseDocument.ID) async throws -> LCPPassphraseHash? {

--- a/TestApp/Sources/App/Readium.swift
+++ b/TestApp/Sources/App/Readium.swift
@@ -45,8 +45,8 @@ final class Readium {
 
         lazy var lcpService = LCPService(
             client: LCPClient(),
-            licenseRepository: LCPSQLiteLicenseRepository(),
-            passphraseRepository: LCPSQLitePassphraseRepository(),
+            licenseRepository: try! LCPSQLiteLicenseRepository(),
+            passphraseRepository: try! LCPSQLitePassphraseRepository(),
             assetRetriever: assetRetriever,
             httpClient: httpClient
         )


### PR DESCRIPTION
Throws an error instead of crashing if the LCP SQLite repositories adapter cannot open the database. This allows the app to attempt recovery from the error or, at the very least, gather more information about its source.

Note that the Test App still crashes, for simplicity.