### PR TITLE
Remove the "Copy Link with Highlight" and "Writing Tools" EPUB editing actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * Fixed a crash using `HTTPClient.download()` when the device storage is full.
 
+#### Navigator
+
+* [#509](https://github.com/readium/swift-toolkit/issues/509) Removed the "Copy Link with Highlight" and "Writing Tools" EPUB editing actions on newer devices.
+
 #### OPDS
 
 * Fixed a data race in the OPDS 1 parser.

--- a/Sources/Navigator/Toolkit/WebView.swift
+++ b/Sources/Navigator/Toolkit/WebView.swift
@@ -20,9 +20,11 @@ final class WebView: WKWebView {
 
         // Disable the Apple Intelligence Writing tools in the web views.
         // See https://github.com/readium/swift-toolkit/issues/509#issuecomment-2577780749
-        if #available(iOS 18.0, *) {
-            config.writingToolsBehavior = .none
-        }
+        #if compiler(>=6.0)
+            if #available(iOS 18.0, *) {
+                config.writingToolsBehavior = .none
+            }
+        #endif
 
         super.init(frame: .zero, configuration: config)
 

--- a/Sources/Navigator/Toolkit/WebView.swift
+++ b/Sources/Navigator/Toolkit/WebView.swift
@@ -17,6 +17,13 @@ final class WebView: WKWebView {
 
         let config = WKWebViewConfiguration()
         config.mediaTypesRequiringUserActionForPlayback = .all
+
+        // Disable the Apple Intelligence Writing tools in the web views.
+        // See https://github.com/readium/swift-toolkit/issues/509#issuecomment-2577780749
+        if #available(iOS 18.0, *) {
+            config.writingToolsBehavior = .none
+        }
+
         super.init(frame: .zero, configuration: config)
 
         #if DEBUG && swift(>=5.8)
@@ -36,6 +43,15 @@ final class WebView: WKWebView {
         // Before iOS 12, we also need to disable user interaction to get rid of the selection overlays.
         isUserInteractionEnabled = false
         isUserInteractionEnabled = true
+    }
+
+    override func buildMenu(with builder: any UIMenuBuilder) {
+        editingActions.buildMenu(with: builder)
+
+        // Don't call super as it is the only way to remove the
+        // "Copy Link with Highlight" menu item.
+        // See https://github.com/readium/swift-toolkit/issues/509
+//        super.buildMenu(with: builder)
     }
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {


### PR DESCRIPTION
### Fixed

#### Navigator

* [#509](https://github.com/readium/swift-toolkit/issues/509) Removed the "Copy Link with Highlight" and "Writing Tools" EPUB editing actions on newer devices.

---

* Fixes #509 