### PR TITLE
Fix concurrency warnings

### DIFF
--- a/Sources/Navigator/Audiobook/AudioNavigator.swift
+++ b/Sources/Navigator/Audiobook/AudioNavigator.swift
@@ -419,15 +419,9 @@ public final class AudioNavigator: Navigator, Configurable, AudioSessionUser, Lo
             // Seeks to time
             let time = locator.locations.time?.begin ?? ((resourceDuration ?? 0) * (locator.locations.progression ?? 0))
 
-            await withCheckedContinuation { continuation in
-                player.seek(to: CMTime(seconds: time, preferredTimescale: 1000)) { [weak self] finished in
-                    if let self = self, finished {
-                        Task { @MainActor in
-                            self.delegate?.navigator(self, didJumpTo: locator)
-                        }
-                    }
-                    continuation.resume()
-                }
+            let finished = await player.seek(to: CMTime(seconds: time, preferredTimescale: 1000))
+            if finished {
+                await delegate?.navigator(self, didJumpTo: locator)
             }
 
             return true

--- a/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
+++ b/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
@@ -12,7 +12,7 @@ import ReadiumShared
 /// Serves `Publication`'s `Resource`s as an `AVURLAsset`.
 ///
 /// Useful for local resources or when you need to customize the way HTTP requests are sent.
-final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate, Loggable {
+final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate, Loggable, @unchecked Sendable {
     public enum AssetError: Error {
         /// Can't produce an URL to create an AVAsset for the given HREF.
         case invalidHREF(String)
@@ -51,6 +51,8 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate, Log
     private var resources: [AnyURL: (Link, Resource)] = [:]
 
     private func resource<T: URLConvertible>(forHREF href: T) -> (Link, Resource)? {
+        dispatchPrecondition(condition: .onQueue(queue))
+
         let href = href.anyURL
         if let res = resources[equivalent: href] {
             return res
@@ -75,6 +77,8 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate, Log
 
     /// Adds a new loading request.
     private func registerRequest<T: URLConvertible>(_ request: AVAssetResourceLoadingRequest, task: Task<Void, Never>, for href: T) {
+        dispatchPrecondition(condition: .onQueue(queue))
+
         let href = href.anyURL
         var reqs: [CancellableRequest] = requests[href] ?? []
         reqs.append((request, task))
@@ -83,6 +87,8 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate, Log
 
     /// Terminates and removes the given loading request, cancelling it if necessary.
     private func finishRequest(_ request: AVAssetResourceLoadingRequest) {
+        dispatchPrecondition(condition: .onQueue(queue))
+
         guard
             let href = request.request.url?.audioHREF,
             var reqs = requests[href],


### PR DESCRIPTION
Fix a couple of concurrency warnings in the audio navigator, on Xcode 16.

`PublicationMediaLoader` is `Sendable` as all its internal APIs are restricted on a serial queue.