### PR TITLE
Fix regression with LCP passphrases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+#### LCP
+
+* Fixed a regression that caused some LCP passphrases to no longer match the protected publication.
+
 
 ## [3.0.0-beta.2]
 

--- a/Sources/Adapters/LCPSQLite/SQLiteLCPPassphraseRepository.swift
+++ b/Sources/Adapters/LCPSQLite/SQLiteLCPPassphraseRepository.swift
@@ -41,10 +41,19 @@ public class LCPSQLitePassphraseRepository: LCPPassphraseRepository, Loggable {
 
     public func passphrasesMatching(userID: User.ID?, provider: LicenseDocument.Provider) async throws -> [LCPPassphraseHash] {
         try logAndRethrow {
-            try db.prepare(transactions.select(passphrase)
-                .filter(self.userId == userID && self.provider == provider)
-            )
-            .compactMap { try $0.get(passphrase) }
+            var passphrases =
+                try db.prepare(transactions.select(passphrase)
+                        .filter(self.userId == userID && self.provider == provider)
+                    )
+                    .compactMap { try $0.get(passphrase) }
+
+            // The legacy SQLite database did not save all the new
+            // (passphrase, userID, provider) tuples. So we need to fall back
+            // on checking all the saved passphrases for a match.
+            passphrases += try db.prepare(transactions.select(passphrase))
+                .compactMap { try $0.get(passphrase) }
+
+            return passphrases
         }
     }
 


### PR DESCRIPTION
### Fixed

#### LCP

* Fixed a regression that caused some LCP passphrases to no longer match the protected publication.

---

The LCP module used to match any passphrase in the SQLite database, ignoring the provider and user ID information. Since #438, the matching explicitly require a provider and user ID match which might fail for older licenses. This PR reverts to matching all the passphrases in the database.