### PR TITLE
Fix race condition in the EPUB navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * Fixed a regression that caused some LCP passphrases to no longer match the protected publication.
 
+#### Navigator
+
+* Fixed race condition when calling `submitPreferences()` before the EPUB navigator is fully initialized.
+
 
 ## [3.0.0-beta.2]
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -849,7 +849,7 @@ open class EPUBNavigatorViewController: UIViewController,
     /// Applies user settings that require native configuration instead of
     /// CSS properties.
     private func applySettings() {
-        guard isViewLoaded else {
+        guard state != .initializing, isViewLoaded else {
             return
         }
 


### PR DESCRIPTION
### Fixed

#### Navigator

* Fixed race condition when calling `submitPreferences()` before the EPUB navigator is fully initialized.