### PR TITLE
Fix normalization of some URLs

### DIFF
--- a/Sources/Adapters/GCDWebServer/ResourceResponse.swift
+++ b/Sources/Adapters/GCDWebServer/ResourceResponse.swift
@@ -19,7 +19,7 @@ enum WebServerResponseError: Error {
 
 /// The object containing the response's ressource data.
 /// If the ressource to be served is too big, multiple responses will be created.
-class ResourceResponse: ReadiumGCDWebServerFileResponse, Loggable {
+class ResourceResponse: ReadiumGCDWebServerResponse, Loggable {
     private let bufferSize = 32 * 1024
 
     private var resource: Resource

--- a/Sources/LCP/Content Protection/LCPDecryptor.swift
+++ b/Sources/LCP/Content Protection/LCPDecryptor.swift
@@ -34,7 +34,7 @@ final class LCPDecryptor {
 
     func decrypt(at href: AnyURL, resource: Resource) -> Resource {
         let href = href.normalized
-        
+
         // Checks if the resource is encrypted and whether the encryption
         // schemes of the resource and the DRM license are the same.
         guard let encryption = encryptionData[href], encryption.scheme == lcpScheme else {

--- a/Sources/LCP/Content Protection/LCPDecryptor.swift
+++ b/Sources/LCP/Content Protection/LCPDecryptor.swift
@@ -27,10 +27,14 @@ final class LCPDecryptor {
 
     init(license: LCPLicense?, encryptionData: [AnyURL: ReadiumShared.Encryption]) {
         self.license = license
-        self.encryptionData = encryptionData
+        self.encryptionData = encryptionData.reduce(into: [:]) { result, item in
+            result[item.key.normalized] = item.value
+        }
     }
 
     func decrypt(at href: AnyURL, resource: Resource) -> Resource {
+        let href = href.normalized
+        
         // Checks if the resource is encrypted and whether the encryption
         // schemes of the resource and the DRM license are the same.
         guard let encryption = encryptionData[href], encryption.scheme == lcpScheme else {

--- a/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
+++ b/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
@@ -53,7 +53,7 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate, Log
     private func resource<T: URLConvertible>(forHREF href: T) -> (Link, Resource)? {
         dispatchPrecondition(condition: .onQueue(queue))
 
-        let href = href.anyURL
+        let href = href.anyURL.normalized
         if let res = resources[equivalent: href] {
             return res
         }
@@ -79,7 +79,7 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate, Log
     private func registerRequest<T: URLConvertible>(_ request: AVAssetResourceLoadingRequest, task: Task<Void, Never>, for href: T) {
         dispatchPrecondition(condition: .onQueue(queue))
 
-        let href = href.anyURL
+        let href = href.anyURL.normalized
         var reqs: [CancellableRequest] = requests[href] ?? []
         reqs.append((request, task))
         requests[href] = reqs
@@ -196,7 +196,7 @@ extension URL {
         // * readium:relative/file.mp3
         // * readiumfile:///directory/local-file.mp3
         // * readiumhttp(s)://domain.com/external-file.mp3
-        return AnyURL(string: url.string.removingPrefix(schemePrefix).removingPrefix(":"))
+        return AnyURL(string: url.string.removingPrefix(schemePrefix).removingPrefix(":"))?.normalized
     }
 }
 

--- a/Sources/Shared/Toolkit/File/DirectoryContainer.swift
+++ b/Sources/Shared/Toolkit/File/DirectoryContainer.swift
@@ -18,7 +18,7 @@ public struct DirectoryContainer: Container, Loggable {
     /// `entries`.
     public init(directory: FileURL, entries: Set<RelativeURL>) {
         directoryURL = directory
-        self.entries = Set(entries.map(\.anyURL))
+        self.entries = Set(entries.map(\.anyURL.normalized))
     }
 
     /// Creates a ``DirectoryContainer`` at `directory` serving all its children

--- a/Sources/Shared/Toolkit/ZIP/ZIPFoundation.swift
+++ b/Sources/Shared/Toolkit/ZIP/ZIPFoundation.swift
@@ -154,7 +154,7 @@ final class ZIPFoundationContainer: Container, Loggable {
             for try await entry in archive {
                 guard
                     entry.type == .file,
-                    let url = RelativeURL(path: entry.path),
+                    let url = RelativeURL(path: entry.path)?.normalized,
                     !url.path.isEmpty
                 else {
                     continue
@@ -179,6 +179,10 @@ final class ZIPFoundationContainer: Container, Loggable {
         archiveFactory: ZIPFoundationArchiveFactory,
         entries: [RelativeURL: Entry]
     ) {
+        let entries = entries.reduce(into: [:]) { result, item in
+            result[item.key.normalized] = item.value
+        }
+        
         self.archiveFactory = archiveFactory
         entriesByPath = entries
         self.entries = Set(entries.keys.map(\.anyURL))
@@ -186,7 +190,7 @@ final class ZIPFoundationContainer: Container, Loggable {
 
     subscript(url: any URLConvertible) -> (any Resource)? {
         guard
-            let url = url.relativeURL,
+            let url = url.relativeURL?.normalized,
             let entry = entriesByPath[url]
         else {
             return nil

--- a/Sources/Shared/Toolkit/ZIP/ZIPFoundation.swift
+++ b/Sources/Shared/Toolkit/ZIP/ZIPFoundation.swift
@@ -182,7 +182,7 @@ final class ZIPFoundationContainer: Container, Loggable {
         let entries = entries.reduce(into: [:]) { result, item in
             result[item.key.normalized] = item.value
         }
-        
+
         self.archiveFactory = archiveFactory
         entriesByPath = entries
         self.entries = Set(entries.keys.map(\.anyURL))

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -91,7 +91,7 @@ public final class AudioParser: PublicationParser {
                 container.entries
                     .compactMap { url -> (AnyURL, Format)? in
                         guard
-                            let format = formats[url],
+                            let format = formats[equivalent: url],
                             format.conformsToAny(audioSpecifications)
                         else {
                             return nil

--- a/Sources/Streamer/Parser/Image/ImageParser.swift
+++ b/Sources/Streamer/Parser/Image/ImageParser.swift
@@ -86,7 +86,7 @@ public final class ImageParser: PublicationParser {
                 container.entries
                     .compactMap { url -> (AnyURL, Format)? in
                         guard
-                            let format = formats[url],
+                            let format = formats[equivalent: url],
                             format.conformsToAny(bitmapSpecifications)
                         else {
                             return nil

--- a/Tests/SharedTests/ProxyContainer.swift
+++ b/Tests/SharedTests/ProxyContainer.swift
@@ -11,7 +11,7 @@ final class ProxyContainer: Container {
     private let retrieve: (AnyURL) -> Resource?
 
     init(entries: Set<AnyURL> = [], _ retrieve: @escaping (AnyURL) -> Resource?) {
-        self.entries = entries
+        self.entries = Set(entries.map(\.normalized))
         self.retrieve = retrieve
     }
 
@@ -19,6 +19,6 @@ final class ProxyContainer: Container {
     let entries: Set<AnyURL>
 
     subscript(url: any URLConvertible) -> (any Resource)? {
-        retrieve(url.anyURL)
+        retrieve(url.anyURL.normalized)
     }
 }


### PR DESCRIPTION
* Fixed the normalization of some URLs in various components.
* Addressed a regression in the HTTP server introduced by removing the `close()` override. The `GCDWebServerFileResponse` was used incorrectly instead of `GCDWebServerResponse`.