### PR TITLE
Remove CI checks for Carthage integration on `develop`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -127,7 +127,7 @@ jobs:
   int-carthage:
     name: Integration (Carthage)
     runs-on: macos-14
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.ref == 'refs/heads/main' }}
     defaults:
       run:
         working-directory: TestApp


### PR DESCRIPTION
The CI check for the Carthage integration takes a long time (+15 minutes) and fails for PRs opened from an external fork. This will enable it only on the `main` branch.