### PR TITLE
Fix normalization of URLs in `MinizipContainer`

### DIFF
--- a/Sources/Shared/Publication/Link.swift
+++ b/Sources/Shared/Publication/Link.swift
@@ -167,7 +167,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
         if href.isEmpty {
             href = "#"
         }
-        return (AnyURL(string: href) ?? AnyURL(legacyHREF: href))!
+        return (AnyURL(string: href) ?? AnyURL(legacyHREF: href))!.normalized
     }
 
     /// Returns the URL represented by this link's HREF, resolved to the given
@@ -180,7 +180,7 @@ public struct Link: JSONEquatable, Hashable, Sendable {
         parameters: [String: LosslessStringConvertible] = [:]
     ) -> AnyURL {
         let url = url(parameters: parameters)
-        return baseURL?.anyURL.resolve(url) ?? url
+        return baseURL?.anyURL.resolve(url)?.normalized ?? url
     }
 
     // MARK: URI Template

--- a/Sources/Shared/Toolkit/ZIP/Minizip/MinizipContainer.swift
+++ b/Sources/Shared/Toolkit/ZIP/Minizip/MinizipContainer.swift
@@ -60,7 +60,7 @@ final class MinizipContainer: Container, Loggable {
 
     subscript(url: any URLConvertible) -> (any Resource)? {
         guard
-            let url = url.relativeURL,
+            let url = url.relativeURL?.normalized,
             let metadata = entriesMetadata[url]
         else {
             return nil


### PR DESCRIPTION
#546 was done before [bringing back the `MinizipContainer`](https://github.com/readium/swift-toolkit/pull/551).