### PR TITLE
Don't require a `self` link when parsing a RWPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+#### Streamer
+
+* A `self` link is not required anymore when parsing a RWPM.
+
 
 ## [3.1.0]
 

--- a/Sources/Streamer/Parser/Readium/ReadiumWebPubParser.swift
+++ b/Sources/Streamer/Parser/Readium/ReadiumWebPubParser.swift
@@ -55,8 +55,9 @@ public class ReadiumWebPubParser: PublicationParser, Loggable {
 
         return await resource.readAsRWPM(warnings: warnings)
             .flatMap { manifest in
-                guard let baseURL = manifest.baseURL else {
-                    return .failure(.decoding("No valid self link found in the manifest"))
+                let baseURL = manifest.baseURL
+                if baseURL == nil {
+                    warnings?.log(RWPMWarning(message: "No valid self link found in the manifest", severity: .moderate))
                 }
 
                 return .success(CompositeContainer(
@@ -164,4 +165,12 @@ private extension Streamable {
             }
         }
     }
+}
+
+/// Warning raised when parsing a RWPM.
+public struct RWPMWarning: Warning {
+    public let message: String
+    public let severity: WarningSeverityLevel
+
+    public var tag: String { "rwpm" }
 }


### PR DESCRIPTION

### Changed

#### Streamer

* A `self` link is not required anymore when parsing a RWPM.

---

This aligns with the behavior of the Kotlin toolkit. While a `self` link is required by the specification, there are some RWPM in the wild with no `self` link and absolute HREFs in the `readingOrder` and `resources`.