### PR TITLE
Add support for TDM Reservation Protocol metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Added
 
+#### Shared
+
+* Support for [W3C's Text & data mining Reservation Protocol](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/) in our metadata models.
+
 #### LCP
 
 * Support for streaming an LCP-protected publication from its License Document (LCPL). [Take a look at the LCP guide for more information](docs/Guides/Readium%20LCP.md#streaming-an-lcp-protected-package).

--- a/Sources/Shared/Publication/Metadata.swift
+++ b/Sources/Shared/Publication/Metadata.swift
@@ -49,6 +49,11 @@ public struct Metadata: Hashable, Loggable, WarningLogger, Sendable {
     public var numberOfPages: Int?
     public var belongsTo: [String: [Collection]]
 
+    /// Publications can indicate whether they allow third parties to use their
+    /// content for text and data mining purposes using the [TDM Rep protocol](https://www.w3.org/community/tdmrep/),
+    /// as defined in a [W3C Community Group Report](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/).
+    public var tdm: TDM?
+
     public var readingProgression: ReadingProgression
 
     /// Additional properties for extensions.
@@ -92,6 +97,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger, Sendable {
         belongsTo: [String: [Collection]] = [:],
         belongsToCollections: [Collection] = [],
         belongsToSeries: [Collection] = [],
+        tdm: TDM? = nil,
         otherMetadata: JSONDictionary.Wrapped = [:]
     ) {
         self.identifier = identifier
@@ -132,6 +138,8 @@ public struct Metadata: Hashable, Loggable, WarningLogger, Sendable {
             belongsTo["series"] = belongsToSeries
         }
         self.belongsTo = belongsTo
+
+        self.tdm = tdm
 
         otherMetadataJSON = JSONDictionary(otherMetadata) ?? JSONDictionary()
     }
@@ -179,6 +187,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger, Sendable {
         belongsTo = (json.pop("belongsTo") as? JSONDictionary.Wrapped)?
             .compactMapValues { item in [Collection](json: item, warnings: warnings) }
             ?? [:]
+        tdm = try? TDM(json: json.pop("tdm"), warnings: warnings)
         otherMetadataJSON = json
     }
 
@@ -213,6 +222,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger, Sendable {
             "duration": encodeIfNotNil(duration),
             "numberOfPages": encodeIfNotNil(numberOfPages),
             "belongsTo": encodeIfNotEmpty(belongsTo.mapValues { $0.json }),
+            "tdm": encodeIfNotEmpty(tdm?.json),
         ], additional: otherMetadata)
     }
 
@@ -261,6 +271,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger, Sendable {
         belongsTo: [String: [Collection]]? = nil,
         belongsToCollections: [Collection]? = nil,
         belongsToSeries: [Collection]? = nil,
+        tdm: TDM? = nil,
         otherMetadata: JSONDictionary.Wrapped? = nil
     ) -> Metadata {
         Metadata(
@@ -295,6 +306,7 @@ public struct Metadata: Hashable, Loggable, WarningLogger, Sendable {
             belongsTo: belongsTo ?? self.belongsTo,
             belongsToCollections: belongsToCollections ?? self.belongsToCollections,
             belongsToSeries: belongsToSeries ?? self.belongsToSeries,
+            tdm: tdm ?? self.tdm,
             otherMetadata: otherMetadata ?? self.otherMetadata
         )
     }

--- a/Sources/Shared/Publication/TDM.swift
+++ b/Sources/Shared/Publication/TDM.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright 2025 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+import ReadiumInternal
+
+/// Publications can indicate whether they allow third parties to use their
+/// content for text and data mining purposes using the [TDM Rep protocol](https://www.w3.org/community/tdmrep/),
+/// as defined in a [W3C Community Group Report](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/).
+///
+/// https://github.com/readium/webpub-manifest/blob/master/schema/metadata.schema.json
+public struct TDM: Hashable, Sendable {
+    public struct Reservation: RawRepresentable, Hashable, Sendable {
+        public let rawValue: String
+
+        public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+        }
+
+        /// All TDM rights are reserved. If a TDM Policy is set, TDM Agents MAY
+        /// use it to get information on how they can acquire from the
+        /// rightsholder an authorization to mine the content.
+        public static let all = Reservation(rawValue: "all")
+
+        /// TDM rights are not reserved. TDM agents can mine the content for TDM
+        /// purposes without having to contact the rightsholder.
+        public static let none = Reservation(rawValue: "none")
+    }
+
+    public var reservation: Reservation
+    
+    /// URL pointing to a TDM Policy set be the rightsholder.
+    public var policy: HTTPURL?
+
+    public init(reservation: Reservation, policy: HTTPURL? = nil) {
+        self.reservation = reservation
+        self.policy = policy
+    }
+
+    public init?(json: Any?, warnings: WarningLogger? = nil) throws {
+        guard
+            let json = json as? [String: Any],
+            let reservation = (json["reservation"] as? String).flatMap(Reservation.init(rawValue:))
+        else {
+            warnings?.log("Invalid TDM object", model: Self.self, source: json, severity: .minor)
+            throw JSONError.parsing(Self.self)
+        }
+
+        self.init(
+            reservation: reservation,
+            policy: (json["policy"] as? String).flatMap { HTTPURL(string: $0) }
+        )
+    }
+
+    public var json: [String: Any] {
+        makeJSON([
+            "reservation": reservation.rawValue,
+            "policy": encodeIfNotNil(policy?.string),
+        ])
+    }
+}

--- a/Sources/Shared/Publication/TDM.swift
+++ b/Sources/Shared/Publication/TDM.swift
@@ -31,7 +31,7 @@ public struct TDM: Hashable, Sendable {
     }
 
     public var reservation: Reservation
-    
+
     /// URL pointing to a TDM Policy set be the rightsholder.
     public var policy: HTTPURL?
 

--- a/Sources/Shared/Toolkit/Data/Container/Container.swift
+++ b/Sources/Shared/Toolkit/Data/Container/Container.swift
@@ -8,7 +8,16 @@ import Foundation
 
 /// A container provides access to a list of `Resource` entries.
 public protocol Container: Closeable {
-    /// Direct source to this container, when available.
+    /// URL locating this container, when available.
+    ///
+    /// This can be used to optimize access to a container's content for the
+    /// caller. For example if the container is available on the local file
+    /// system, a caller might prefer using a file handle instead of the
+    /// ``Container`` API.
+    ///
+    /// Note that this must represent the same content available in
+    /// ``Container``. If you transform the resources content on the fly (e.g.
+    /// with ``TransformingContainer``), then the `sourceURL` becomes nil.
     var sourceURL: AbsoluteURL? { get }
 
     /// List of all the container entries.

--- a/Sources/Shared/Toolkit/Data/Resource/Resource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/Resource.swift
@@ -8,7 +8,19 @@ import Foundation
 
 /// Acts as a proxy to an actual resource by handling read access.
 public protocol Resource: Streamable {
-    /// URL locating this resource, if any.
+    /// URL locating this resource, when available.
+    ///
+    /// This can be used to optimize access to a resource's content for the
+    /// caller. For example if the resource is available on the local file
+    /// system, a caller might prefer using a file handle instead of the
+    /// ``Resource`` API.
+    ///
+    /// Note that this must represent the same content available in
+    /// ``Resource``. If you transform the resources content on the fly (e.g.
+    /// with ``TransformingResource``), then the `sourceURL` becomes nil.
+    ///
+    /// A ``Resource`` located in a ZIP archive will have a nil `sourceURL`, as
+    /// there is no direct access to the ZIP entry using an absolute URL.
     var sourceURL: AbsoluteURL? { get }
 
     /// Properties associated to the resource.

--- a/Sources/Streamer/Parser/EPUB/OPFMeta.swift
+++ b/Sources/Streamer/Parser/EPUB/OPFMeta.swift
@@ -13,10 +13,17 @@ import ReadiumShared
 enum OPFVocabulary: String {
     // Fallback prefixes for metadata's properties and links' rels.
     case defaultMetadata, defaultLinkRel
-    // Reserved prefixes (https://idpf.github.io/epub-prefixes/packages/).
+
+    // Reserved prefixes
+    // https://idpf.github.io/epub-prefixes/packages/
     case a11y, dcterms, epubsc, marc, media, onix, rendition, schema, xsd
+
     // Additional prefixes used in the streamer.
     case calibre
+
+    // New TDM Reservation Protocol
+    // https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/
+    case tdm
 
     var uri: String {
         switch self {
@@ -45,6 +52,8 @@ enum OPFVocabulary: String {
         case .calibre:
             // https://github.com/kovidgoyal/calibre/blob/3f903cbdd165e0d1c5c25eecb6eef2a998342230/src/calibre/ebooks/metadata/opf3.py#L170
             return "https://calibre-ebook.com"
+        case .tdm:
+            return "http://www.w3.org/ns/tdmrep#"
         }
     }
 

--- a/Support/Carthage/.xcodegen
+++ b/Support/Carthage/.xcodegen
@@ -659,6 +659,7 @@
 ../../Sources/Shared/Publication/Services/Table Of Contents
 ../../Sources/Shared/Publication/Services/Table Of Contents/TableOfContentsService.swift
 ../../Sources/Shared/Publication/Subject.swift
+../../Sources/Shared/Publication/TDM.swift
 ../../Sources/Shared/Publication/User Settings
 ../../Sources/Shared/Publication/User Settings/UserProperties.swift
 ../../Sources/Shared/Publication/User Settings/UserSettings.swift

--- a/Support/Carthage/Readium.xcodeproj/project.pbxproj
+++ b/Support/Carthage/Readium.xcodeproj/project.pbxproj
@@ -327,6 +327,7 @@
 		D1248D9E9EE269C3245927F7 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD54FD376456C1925316BC /* Cancellable.swift */; };
 		D25058A427D47ABEA88A3F4B /* PublicationSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DE4955327D8C2DE6F866D3 /* PublicationSpeechSynthesizer.swift */; };
 		D29E1DBC5BD1B82C996427C4 /* Closeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02A9225D636D845BF24F6AC /* Closeable.swift */; };
+		D3058C80ABFBAED1CAA1B0CC /* TDM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28792F801221D49F61B92CF8 /* TDM.swift */; };
 		D4BBC0AD7652265497B5CD1C /* URLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10894CC9684584098A22D8FA /* URLExtensions.swift */; };
 		D525E9E2AFA0ED63151A4FBC /* Assets in Resources */ = {isa = PBXBuildFile; fileRef = DBCE9786DD346E6BDB2E50FF /* Assets */; };
 		D589F337B244F5B58E85AEFB /* AudioSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9D0ACCBA7B6E4473A95D5E /* AudioSettings.swift */; };
@@ -542,6 +543,7 @@
 		258351CE21165EDED7F87878 /* URLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocol.swift; sourceTree = "<group>"; };
 		2732AFC91AB15FA09C60207A /* Locator+Audio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locator+Audio.swift"; sourceTree = "<group>"; };
 		2828D89EBB52CCA782ED1146 /* ReadiumFuzi.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ReadiumFuzi.xcframework; path = ../../Carthage/Build/ReadiumFuzi.xcframework; sourceTree = "<group>"; };
+		28792F801221D49F61B92CF8 /* TDM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TDM.swift; sourceTree = "<group>"; };
 		294E01A2E6FF25539EBC1082 /* Properties+Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Properties+Archive.swift"; sourceTree = "<group>"; };
 		29AD63CD2A41586290547212 /* NavigationDocumentParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDocumentParser.swift; sourceTree = "<group>"; };
 		2AF56CF04F94B7BE45631897 /* LCPContentProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPContentProtection.swift; sourceTree = "<group>"; };
@@ -2005,6 +2007,7 @@
 				3B0A149FC97C747F55F6463C /* PublicationCollection.swift */,
 				74F646B746EB27124F9456F8 /* ReadingProgression.swift */,
 				98CD4C99103DC795E44F56AE /* Subject.swift */,
+				28792F801221D49F61B92CF8 /* TDM.swift */,
 				87352D29A81641A4B9054319 /* Asset */,
 				055166DFDEE6C6A17D04D42D /* Extensions */,
 				C1002695D860AE505D689C26 /* Media Overlays */,
@@ -2686,6 +2689,7 @@
 				4DB4C10CB9AB5D38C56C1609 /* StringEncoding.swift in Sources */,
 				E6AC10CCF9711168BE2BE85C /* StringSearchService.swift in Sources */,
 				3E9F244ACDA938D330B9EAEA /* Subject.swift in Sources */,
+				D3058C80ABFBAED1CAA1B0CC /* TDM.swift in Sources */,
 				CB95F5EAA4D0DB5177FED4F7 /* TableOfContentsService.swift in Sources */,
 				4E84353322A4CDBBCAD6C070 /* TailCachingResource.swift in Sources */,
 				96048047B4205636ABB66DC9 /* TextTokenizer.swift in Sources */,

--- a/Tests/SharedTests/Publication/MetadataTests.swift
+++ b/Tests/SharedTests/Publication/MetadataTests.swift
@@ -42,6 +42,7 @@ class MetadataTests: XCTestCase {
         ],
         belongsToCollections: [Contributor(name: "Collection")],
         belongsToSeries: [Contributor(name: "Series")],
+        tdm: TDM(reservation: .all, policy: HTTPURL(string: "https://tdm.com")!),
         otherMetadata: [
             "other-metadata1": "value",
             "other-metadata2": [42],
@@ -104,6 +105,10 @@ class MetadataTests: XCTestCase {
                     "collection": "Collection",
                     "series": "Series",
                     "schema:Periodical": "Periodical",
+                ],
+                "tdm": [
+                    "reservation": "all",
+                    "policy": "https://tdm.com",
                 ],
                 "other-metadata1": "value",
                 "other-metadata2": [42],
@@ -214,6 +219,10 @@ class MetadataTests: XCTestCase {
                     "collection": [["name": "Collection"]],
                     "series": [["name": "Series"]],
                     "schema:Periodical": [["name": "Periodical"]],
+                ],
+                "tdm": [
+                    "reservation": "all",
+                    "policy": "https://tdm.com",
                 ],
                 "other-metadata1": "value",
                 "other-metadata2": [42],

--- a/Tests/SharedTests/Publication/TDMTests.swift
+++ b/Tests/SharedTests/Publication/TDMTests.swift
@@ -1,0 +1,56 @@
+//
+//  Copyright 2025 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumShared
+import XCTest
+
+class TDMTests: XCTestCase {
+    func testParseMinimalJSON() {
+        XCTAssertEqual(
+            try? TDM(json: ["reservation": "none"]),
+            TDM(reservation: .none)
+        )
+    }
+
+    func testParseFullJSON() {
+        XCTAssertEqual(
+            try? TDM(json: [
+                "reservation": "all",
+                "policy": "https://policy",
+            ] as [String: Any]),
+            TDM(
+                reservation: .all,
+                policy: HTTPURL(string: "https://policy")
+            )
+        )
+    }
+
+    func testParseJSONRequiresReservation() {
+        XCTAssertThrowsError(try TDM(json: [
+            "policy": "https://policy",
+        ]))
+    }
+
+    func testGetMinimalJSON() {
+        AssertJSONEqual(
+            TDM(reservation: .none).json,
+            ["reservation": "none"]
+        )
+    }
+
+    func testGetFullJSON() {
+        AssertJSONEqual(
+            TDM(
+                reservation: .all,
+                policy: HTTPURL(string: "https://policy")
+            ).json,
+            [
+                "reservation": "all",
+                "policy": "https://policy",
+            ] as [String: Any]
+        )
+    }
+}

--- a/Tests/StreamerTests/Fixtures/OPF/tdm-epub2.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/tdm-epub2.opf
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="2.0" xml:lang="en">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Alice's Adventures in Wonderland</dc:title>
+
+    <meta name="tdm:reservation" content="1" />
+    <meta name="tdm:policy" content="https://provider.com/policies/policy.json" />
+  </metadata>
+  <manifest>
+    <item id="titlepage" href="titlepage.xhtml"/>
+  </manifest>
+  <spine>
+    <itemref idref="titlepage"/>
+  </spine>
+</package>

--- a/Tests/StreamerTests/Fixtures/OPF/tdm-epub3.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/tdm-epub3.opf
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" prefix="tdm: http://www.w3.org/ns/tdmrep#" unique-identifier="pub-id" version="3.0" xml:lang="en">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+    <dc:title>Alice's Adventures in Wonderland</dc:title>
+
+    <meta property="tdm:reservation">1</meta>
+    <meta property="tdm:policy">https://provider.com/policies/policy.json</meta>
+  </metadata>
+  <manifest>
+    <item id="titlepage" href="titlepage.xhtml"/>
+  </manifest>
+  <spine>
+    <itemref idref="titlepage"/>
+  </spine>
+</package>

--- a/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
@@ -353,6 +353,28 @@ class EPUBMetadataParserTests: XCTestCase {
         XCTAssertEqual(Array(sut.otherMetadata.keys), ["presentation"])
     }
 
+    func testParseEPUB2TDM() throws {
+        let sut = try parseMetadata("tdm-epub2")
+        XCTAssertEqual(
+            sut.tdm,
+            TDM(
+                reservation: .all,
+                policy: HTTPURL(string: "https://provider.com/policies/policy.json")!
+            )
+        )
+    }
+
+    func testParseEPUB3TDM() throws {
+        let sut = try parseMetadata("tdm-epub3")
+        XCTAssertEqual(
+            sut.tdm,
+            TDM(
+                reservation: .all,
+                policy: HTTPURL(string: "https://provider.com/policies/policy.json")!
+            )
+        )
+    }
+
     // MARK: - Toolkit
 
     func parseMetadata(_ name: String, displayOptions: String? = nil) throws -> Metadata {


### PR DESCRIPTION
### Added

#### Shared

* Support for [W3C's Text & data mining Reservation Protocol](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/) in our metadata models.