### PR TITLE
Various accessibility metadata changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 * Support for [W3C's Text & data mining Reservation Protocol](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/) in our metadata models.
 * Support for [accessibility exemption metadata]https://readium.org/webpub-manifest/contexts/default/#exemption), which allows content creators to identify publications that do not meet conformance requirements but fall under exemptions in a given juridiction.
+* Support for [EPUB Accessibility 1.1](https://www.w3.org/TR/epub-a11y-11/) conformance profiles.
 
 #### LCP
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 * The `absoluteURL` and `relativeURL` extensions on `URLConvertible` were removed as they conflict with the native `URL.absoluteURL`.
     * If you were using them, you can for example still use `anyURL.absoluteURL` instead.
+* [go-toolkit#92](https://github.com/readium/go-toolkit/issues/92) The accessibility feature `printPageNumbers` is deprecated in favor of `pageNavigation`.
 
 #### Streamer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Shared
 
 * Support for [W3C's Text & data mining Reservation Protocol](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/) in our metadata models.
+* Support for [accessibility exemption metadata]https://readium.org/webpub-manifest/contexts/default/#exemption), which allows content creators to identify publications that do not meet conformance requirements but fall under exemptions in a given juridiction.
 
 #### LCP
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Shared
 
 * Support for [W3C's Text & data mining Reservation Protocol](https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/) in our metadata models.
-* Support for [accessibility exemption metadata]https://readium.org/webpub-manifest/contexts/default/#exemption), which allows content creators to identify publications that do not meet conformance requirements but fall under exemptions in a given juridiction.
+* Support for [accessibility exemption metadata](https://readium.org/webpub-manifest/contexts/default/#exemption), which allows content creators to identify publications that do not meet conformance requirements but fall under exemptions in a given juridiction.
 * Support for [EPUB Accessibility 1.1](https://www.w3.org/TR/epub-a11y-11/) conformance profiles.
 
 #### LCP

--- a/Sources/Shared/Publication/Accessibility.swift
+++ b/Sources/Shared/Publication/Accessibility.swift
@@ -176,9 +176,16 @@ public struct Accessibility: Hashable, Sendable {
 
         /// The work includes an index to the content.
         public static let index = Feature("index")
+        
+        /// The resource includes a means of navigating to static page break
+        /// locations.
+        ///
+        /// The most common way of providing page navigation in digital
+        /// publications is through a page list.
+        public static let pageNavigation = Feature("pageNavigation")
 
-        /// The work includes equivalent print page numbers. This setting is most commonly used with ebooks for which
-        /// there is a print equivalent.
+        // https://github.com/readium/go-toolkit/issues/92
+        @available(*, deprecated, renamed: "pageNavigation")
         public static let printPageNumbers = Feature("printPageNumbers")
 
         /// The reading order of the content is clearly defined in the markup (e.g., figures, sidebars and other

--- a/Sources/Shared/Publication/Accessibility.swift
+++ b/Sources/Shared/Publication/Accessibility.swift
@@ -199,6 +199,16 @@ public struct Accessibility: Hashable, Sendable {
         /// The work includes an index to the content.
         public static let index = Feature("index")
 
+        /// The resource includes static page markers, such as those identified
+        /// by the doc-pagebreak role (DPUB-ARIA-1.0).
+        ///
+        /// This value is most commonly used with ebooks for which there is a
+        /// statically paginated equivalent, such as a print edition, but it is
+        /// not required that the page markers correspond to another work. The
+        /// markers may exist solely to facilitate navigation in purely digital
+        /// works.
+        public static let pageBreakMarkers = Feature("pageBreakMarkers")
+
         /// The resource includes a means of navigating to static page break
         /// locations.
         ///

--- a/Sources/Shared/Publication/Accessibility.swift
+++ b/Sources/Shared/Publication/Accessibility.swift
@@ -48,6 +48,10 @@ public struct Accessibility: Hashable, Sendable {
     /// https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityHazard
     public var hazards: [Hazard]
 
+    /// Justifications for non-conformance based on exemptions in a given
+    /// jurisdiction.
+    public var exemptions: [Exemption]
+
     /// Accessibility profile.
     public struct Profile: Hashable, Sendable {
         public let uri: String
@@ -176,7 +180,7 @@ public struct Accessibility: Hashable, Sendable {
 
         /// The work includes an index to the content.
         public static let index = Feature("index")
-        
+
         /// The resource includes a means of navigating to static page break
         /// locations.
         ///
@@ -348,6 +352,49 @@ public struct Accessibility: Hashable, Sendable {
         public static let none = Hazard("none")
     }
 
+    /// ``Exemption`` allows content creators to identify publications that do
+    /// not meet conformance requirements but fall under exemptions in a given
+    /// juridiction.
+    ///
+    /// While this list is currently limited to exemptions covered by the
+    /// European Accessibility Act, it will be extended to cover additional
+    /// exemptions in the future.
+    public struct Exemption: Hashable, Sendable {
+        public let id: String
+
+        public init(_ id: String) {
+            self.id = id
+        }
+
+        /// Article 14, paragraph 1 of the European Accessibility Act states
+        /// that its accessibility requirements shall apply only to the extent
+        /// that compliance: … (b) does not result in the imposition of a
+        /// disproportionate burden on the economic operators concerned
+        /// https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019L0882#d1e2148-70-1
+        public static let eaaDisproportionateBurden = Exemption("eaa-disproportionate-burden")
+
+        /// Article 14, paragraph 1 of the European Accessibility Act states
+        /// that its accessibility requirements shall apply only to the extent
+        /// that compliance: (a) does not require a significant change in a
+        /// product or service that results in the fundamental alteration of its
+        /// basic nature
+        /// https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019L0882#d1e2148-70-1
+        public static let eaaFundamentalAlteration = Exemption("eaa-fundamental-alteration")
+
+        /// The European Accessibility Act defines a microenterprise as: an
+        /// enterprise which employs fewer than 10 persons and which has an
+        /// annual turnover not exceeding EUR 2 million or an annual balance
+        /// sheet total not exceeding EUR 2 million.
+        ///
+        /// It further states in Article 4, paragraph 5: Microenterprises
+        /// providing services shall be exempt from complying with the
+        /// accessibility requirements referred to in paragraph 3 of this
+        /// Article and any obligations relating to the compliance with those
+        /// requirements.
+        /// https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019L0882#d1e1798-70-1
+        public static let eaaMicroenterprise = Exemption("eaa-microenterprise")
+    }
+
     public init(
         conformsTo: [Profile] = [],
         certification: Certification? = nil,
@@ -355,7 +402,8 @@ public struct Accessibility: Hashable, Sendable {
         accessModes: [AccessMode] = [],
         accessModesSufficient: [[PrimaryAccessMode]] = [],
         features: [Feature] = [],
-        hazards: [Hazard] = []
+        hazards: [Hazard] = [],
+        exemptions: [Exemption] = []
     ) {
         self.conformsTo = conformsTo
         self.certification = certification
@@ -364,6 +412,7 @@ public struct Accessibility: Hashable, Sendable {
         self.accessModesSufficient = accessModesSufficient
         self.features = features
         self.hazards = hazards
+        self.exemptions = exemptions
     }
 
     public init?(json: Any?, warnings: WarningLogger? = nil) throws {
@@ -401,7 +450,8 @@ public struct Accessibility: Hashable, Sendable {
                 }
                 .filter { !$0.isEmpty },
             features: parseArray(jsonObject["feature"]).map(Feature.init),
-            hazards: parseArray(jsonObject["hazard"]).map(Hazard.init)
+            hazards: parseArray(jsonObject["hazard"]).map(Hazard.init),
+            exemptions: parseArray(jsonObject["exemption"]).map(Exemption.init)
         )
     }
 
@@ -420,6 +470,7 @@ public struct Accessibility: Hashable, Sendable {
             "accessModeSufficient": encodeIfNotEmpty(accessModesSufficient.map { $0.map(\.rawValue) }),
             "feature": encodeIfNotEmpty(features.map(\.id)),
             "hazard": encodeIfNotEmpty(hazards.map(\.id)),
+            "exemption": encodeIfNotEmpty(exemptions.map(\.id)),
         ])
     }
 }

--- a/Sources/Shared/Publication/Accessibility.swift
+++ b/Sources/Shared/Publication/Accessibility.swift
@@ -66,6 +66,24 @@ public struct Accessibility: Hashable, Sendable {
         public static let epubA11y10WCAG20AA = Profile("http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa")
         /// EPUB Accessibility 1.0 - WCAG 2.0 Level AAA
         public static let epubA11y10WCAG20AAA = Profile("http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa")
+        /// EPUB Accessibility 1.1 - WCAG 2.0 Level A
+        public static let epubA11y11WCAG20A = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.0-a")
+        /// EPUB Accessibility 1.1 - WCAG 2.0 Level AA
+        public static let epubA11y11WCAG20AA = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.0-aa")
+        /// EPUB Accessibility 1.1 - WCAG 2.0 Level AAA
+        public static let epubA11y11WCAG20AAA = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.0-aaa")
+        /// EPUB Accessibility 1.1 - WCAG 2.1 Level A
+        public static let epubA11y11WCAG21A = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.1-a")
+        /// EPUB Accessibility 1.1 - WCAG 2.1 Level AA
+        public static let epubA11y11WCAG21AA = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.1-aa")
+        /// EPUB Accessibility 1.1 - WCAG 2.1 Level AAA
+        public static let epubA11y11WCAG21AAA = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.1-aaa")
+        /// EPUB Accessibility 1.1 - WCAG 2.2 Level A
+        public static let epubA11y11WCAG22A = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.2-a")
+        /// EPUB Accessibility 1.1 - WCAG 2.2 Level AA
+        public static let epubA11y11WCAG22AA = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.2-aa")
+        /// EPUB Accessibility 1.1 - WCAG 2.2 Level AAA
+        public static let epubA11y11WCAG22AAA = Profile("https://www.w3.org/TR/epub-a11y-11#wcag-2.2-aaa")
     }
 
     public struct Certification: Hashable, Sendable {

--- a/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
@@ -205,26 +205,51 @@ final class EPUBMetadataParser: Loggable {
 
     private func accessibilityProfile(from value: String) -> Accessibility.Profile? {
         switch value {
-        case "EPUB Accessibility 1.1 - WCAG 2.0 Level A",
-             "http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-a",
+        case "http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-a",
              "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a",
              "https://idpf.org/epub/a11y/accessibility-20170105.html#wcag-a",
              "https://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a":
             return .epubA11y10WCAG20A
 
-        case "EPUB Accessibility 1.1 - WCAG 2.0 Level AA",
-             "http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa",
+        case "http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa",
              "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa",
              "https://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa",
              "https://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa":
             return .epubA11y10WCAG20AA
 
-        case "EPUB Accessibility 1.1 - WCAG 2.0 Level AAA",
-             "http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa",
+        case "http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa",
              "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa",
              "https://idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa",
              "https://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa":
             return .epubA11y10WCAG20AAA
+
+        case "EPUB Accessibility 1.1 - WCAG 2.0 Level A":
+            return .epubA11y11WCAG20A
+
+        case "EPUB Accessibility 1.1 - WCAG 2.0 Level AA":
+            return .epubA11y11WCAG20AA
+
+        case "EPUB Accessibility 1.1 - WCAG 2.0 Level AAA":
+            return .epubA11y11WCAG20AAA
+
+        case "EPUB Accessibility 1.1 - WCAG 2.1 Level A":
+            return .epubA11y11WCAG21A
+
+        case "EPUB Accessibility 1.1 - WCAG 2.1 Level AA":
+            return .epubA11y11WCAG21AA
+
+        case "EPUB Accessibility 1.1 - WCAG 2.1 Level AAA":
+            return .epubA11y11WCAG21AAA
+
+        case "EPUB Accessibility 1.1 - WCAG 2.2 Level A":
+            return .epubA11y11WCAG22A
+
+        case "EPUB Accessibility 1.1 - WCAG 2.2 Level AA":
+            return .epubA11y11WCAG22AA
+
+        case "EPUB Accessibility 1.1 - WCAG 2.2 Level AAA":
+            return .epubA11y11WCAG22AAA
+
         default:
             return nil
         }

--- a/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
@@ -190,7 +190,8 @@ final class EPUBMetadataParser: Loggable {
             accessModes: accessibilityAccessModes(),
             accessModesSufficient: accessibilityAccessModesSufficient(),
             features: accessibilityFeatures(),
-            hazards: accessibilityHazards()
+            hazards: accessibilityHazards(),
+            exemptions: accessibilityExemptions()
         )
 
         return accessibility.takeIf { $0 != Accessibility() }
@@ -275,6 +276,11 @@ final class EPUBMetadataParser: Loggable {
     private func accessibilityHazards() -> [Accessibility.Hazard] {
         metas["accessibilityHazard", in: .schema]
             .map { Accessibility.Hazard($0.content) }
+    }
+
+    private func accessibilityExemptions() -> [Accessibility.Exemption] {
+        metas["exemption", in: .a11y]
+            .map { Accessibility.Exemption($0.content) }
     }
 
     /// https://www.w3.org/community/reports/tdmrep/CG-FINAL-tdmrep-20240510/#sec-epub3

--- a/Sources/Streamer/Parser/EPUB/OPFMeta.swift
+++ b/Sources/Streamer/Parser/EPUB/OPFMeta.swift
@@ -303,7 +303,7 @@ struct OPFMetaList {
     /// List of properties that should not be added to `otherMetadata` because they are already
     /// consumed by the RWPM model.
     private let rwpmProperties: [OPFVocabulary: [String]] = [
-        .a11y: ["certifiedBy", "certifierCredential", "certifierReport"],
+        .a11y: ["certifiedBy", "certifierCredential", "certifierReport", "exemption"],
         .defaultMetadata: ["cover"],
         .dcterms: [
             "contributor", "creator", "date", "description", "identifier",

--- a/Tests/SharedTests/Publication/AccessibilityTests.swift
+++ b/Tests/SharedTests/Publication/AccessibilityTests.swift
@@ -33,6 +33,7 @@ class AccessibilityTests: XCTestCase {
                 "accessModeSufficient": [["visual", "tactile"]],
                 "feature": ["readingOrder", "alternativeText"],
                 "hazard": ["flashing", "motionSimulation"],
+                "exemption": ["eaa-fundamental-alteration", "eaa-microenterprise"],
             ] as [String: Any]),
             Accessibility(
                 conformsTo: [
@@ -48,7 +49,8 @@ class AccessibilityTests: XCTestCase {
                 accessModes: [.auditory, .chartOnVisual],
                 accessModesSufficient: [[.visual, .tactile]],
                 features: [.readingOrder, .alternativeText],
-                hazards: [.flashing, .motionSimulation]
+                hazards: [.flashing, .motionSimulation],
+                exemptions: [.eaaFundamentalAlteration, .eaaMicroenterprise]
             )
         )
     }
@@ -164,6 +166,25 @@ class AccessibilityTests: XCTestCase {
         )
     }
 
+    func testParseExemptions() {
+        XCTAssertEqual(
+            try? Accessibility(json: [
+                "exemption": ["eaa-microenterprise"],
+            ]),
+            Accessibility(
+                exemptions: [.eaaMicroenterprise]
+            )
+        )
+        XCTAssertEqual(
+            try? Accessibility(json: [
+                "exemption": ["eaa-disproportionate-burden", "eaa-microenterprise"],
+            ]),
+            Accessibility(
+                exemptions: [.eaaDisproportionateBurden, .eaaMicroenterprise]
+            )
+        )
+    }
+
     func testGetMinimalJSON() {
         AssertJSONEqual(
             Accessibility().json,
@@ -186,7 +207,8 @@ class AccessibilityTests: XCTestCase {
             accessModes: [.auditory, .chartOnVisual],
             accessModesSufficient: [[.auditory], [.visual, .tactile], [.visual]],
             features: [.readingOrder, .alternativeText],
-            hazards: [.flashing, .motionSimulation]
+            hazards: [.flashing, .motionSimulation],
+            exemptions: [.eaaDisproportionateBurden, .eaaMicroenterprise]
         ).json
         AssertJSONEqual(
             expected,
@@ -202,6 +224,7 @@ class AccessibilityTests: XCTestCase {
                 "accessModeSufficient": [["auditory"], ["visual", "tactile"], ["visual"]],
                 "feature": ["readingOrder", "alternativeText"],
                 "hazard": ["flashing", "motionSimulation"],
+                "exemption": ["eaa-disproportionate-burden", "eaa-microenterprise"],
             ] as [String: Any]
         )
     }

--- a/Tests/StreamerTests/Fixtures/OPF/accessibility-epub2.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/accessibility-epub2.opf
@@ -5,6 +5,8 @@
 
     <dc:conformsTo>any profile</dc:conformsTo>
     <dc:conformsTo>http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</dc:conformsTo>
+    <dc:conformsTo>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</dc:conformsTo>
+    <dc:conformsTo>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</dc:conformsTo>
     <meta name="schema:accessibilitySummary" content="The publication contains structural and page navigation."/>
 
     <meta name="schema:accessMode" content="textual"/>

--- a/Tests/StreamerTests/Fixtures/OPF/accessibility-epub2.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/accessibility-epub2.opf
@@ -20,6 +20,10 @@
     <meta name="a11y:certifiedBy" content="Accessibility Testers Group"/>
     <meta name="a11y:certifierCredential" content="DAISY OK"/>
     <meta name="a11y:certifierReport" content="https://example.com/a11y-report/"/>
+    
+    <meta name="a11y:exemption" content="eaa-microenterprise"/>
+    <meta name="a11y:exemption" content="eaa-fundamental-alteration"/>
+    <meta name="a11y:exemption" content="eaa-disproportionate-burden"/>
   </metadata>
   <manifest>
     <item id="titlepage" href="titlepage.xhtml"/>

--- a/Tests/StreamerTests/Fixtures/OPF/accessibility-epub3.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/accessibility-epub3.opf
@@ -23,7 +23,10 @@
     <meta property="a11y:certifierCredential" refines="#certifier">DAISY OK</meta>
     <link rel="a11y:certifierReport" refines="#certifier2" href="https://example.com/fakereport"/>
     <link rel="a11y:certifierReport" refines="#certifier" href="https://example.com/a11y-report/"/>
-
+    
+    <meta property="a11y:exemption">eaa-microenterprise</meta>
+    <meta property="a11y:exemption">eaa-fundamental-alteration</meta>
+    <meta property="a11y:exemption">eaa-disproportionate-burden</meta>
   </metadata>
   <manifest>
     <item id="titlepage" href="titlepage.xhtml"/>

--- a/Tests/StreamerTests/Fixtures/OPF/accessibility-epub3.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/accessibility-epub3.opf
@@ -5,6 +5,8 @@
 
     <dc:conformsTo>any profile</dc:conformsTo>
     <dc:conformsTo>http://idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</dc:conformsTo>
+    <dc:conformsTo>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</dc:conformsTo>
+    <dc:conformsTo>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</dc:conformsTo>
     <meta property="schema:accessibilitySummary">The publication contains structural and page navigation.</meta>
 
     <meta property="schema:accessMode">textual</meta>

--- a/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
@@ -316,7 +316,7 @@ class EPUBMetadataParserTests: XCTestCase {
         XCTAssertEqual(
             sut.accessibility,
             Accessibility(
-                conformsTo: [.epubA11y10WCAG20A],
+                conformsTo: [.epubA11y10WCAG20A, .epubA11y11WCAG20AAA, .epubA11y11WCAG21AA],
                 certification: Accessibility.Certification(
                     certifiedBy: "Accessibility Testers Group",
                     credential: "DAISY OK",
@@ -339,7 +339,7 @@ class EPUBMetadataParserTests: XCTestCase {
         XCTAssertEqual(
             sut.accessibility,
             Accessibility(
-                conformsTo: [.epubA11y10WCAG20A],
+                conformsTo: [.epubA11y10WCAG20A, .epubA11y11WCAG20AAA, .epubA11y11WCAG21AA],
                 certification: Accessibility.Certification(
                     certifiedBy: "Accessibility Testers Group",
                     credential: "DAISY OK",

--- a/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
@@ -326,9 +326,11 @@ class EPUBMetadataParserTests: XCTestCase {
                 accessModes: [.textual, .visual],
                 accessModesSufficient: [[.textual], [.textual, .visual]],
                 features: [.structuralNavigation, .alternativeText],
-                hazards: [.motionSimulation, .noSoundHazard]
+                hazards: [.motionSimulation, .noSoundHazard],
+                exemptions: [.eaaMicroenterprise, .eaaFundamentalAlteration, .eaaDisproportionateBurden]
             )
         )
+        // Checks that the a11y metadata are not added to otherMetadata.
         XCTAssertEqual(Array(sut.otherMetadata.keys), ["presentation"])
     }
 
@@ -347,9 +349,11 @@ class EPUBMetadataParserTests: XCTestCase {
                 accessModes: [.textual, .visual],
                 accessModesSufficient: [[.textual], [.textual, .visual]],
                 features: [.structuralNavigation, .alternativeText],
-                hazards: [.motionSimulation, .noSoundHazard]
+                hazards: [.motionSimulation, .noSoundHazard],
+                exemptions: [.eaaMicroenterprise, .eaaFundamentalAlteration, .eaaDisproportionateBurden]
             )
         )
+        // Checks that the a11y metadata are not added to otherMetadata.
         XCTAssertEqual(Array(sut.otherMetadata.keys), ["presentation"])
     }
 


### PR DESCRIPTION
### Added

#### Shared

* Support for [accessibility exemption metadata](https://readium.org/webpub-manifest/contexts/default/#exemption), which allows content creators to identify publications that do not meet conformance requirements but fall under exemptions in a given juridiction.
* Support for [EPUB Accessibility 1.1](https://www.w3.org/TR/epub-a11y-11/) conformance profiles.

### Changed

#### Shared

* [go-toolkit#92](https://github.com/readium/go-toolkit/issues/92) The accessibility feature `printPageNumbers` is deprecated in favor of `pageNavigation`.