### PR TITLE
Fix applying the EPUB background on initialization

### DIFF
--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -882,7 +882,7 @@ open class EPUBNavigatorViewController: UIViewController,
     /// Applies user settings that require native configuration instead of
     /// CSS properties.
     private func applySettings() {
-        guard state != .initializing, isViewLoaded else {
+        guard isViewLoaded else {
             return
         }
 


### PR DESCRIPTION
Fixed applying the default EPUB background color on navigator initialization, if no preferences are submitted.