### PR TITLE
Add new `LinkRelation` for the `readingOrder` and EPUB `landmarks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * Implementation of the [W3C Accessibility Metadata Display Guide](https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/guidelines/) specification to facilitate displaying accessibility metadata to users. [See the dedicated user guide](docs/Guides/Accessibility.md).
 * Support for starting from a progression in the HTML content iterator.
+* New link `rels` in the `readingOrder` and EPUB `landmarks` to mark:
+    * `cover`: the title page
+    * `contents`: the table of contents
+    * `start`: the first actual chapter
 
 #### Navigator
 

--- a/Sources/LCP/Content Protection/EncryptionParser.swift
+++ b/Sources/LCP/Content Protection/EncryptionParser.swift
@@ -51,11 +51,7 @@ private func parseEPUBEncryptionData(in container: Container) async -> ReadResul
             do {
                 let doc = try await DefaultXMLDocumentFactory().open(
                     data: data,
-                    namespaces: [
-                        (prefix: "enc", uri: "http://www.w3.org/2001/04/xmlenc#"),
-                        (prefix: "ds", uri: "http://www.w3.org/2000/09/xmldsig#"),
-                        (prefix: "comp", uri: "http://www.idpf.org/2016/encryption#compression"),
-                    ]
+                    namespaces: [.enc, .ds, .comp]
                 )
                 return .success(doc)
             } catch {

--- a/Sources/OPDS/OPDS1Parser.swift
+++ b/Sources/OPDS/OPDS1Parser.swift
@@ -80,9 +80,9 @@ public class OPDS1Parser: Loggable {
     /// - parameter document: The XMLDocument data
     /// - Returns: The resulting Feed
     private static func parse(document: ReadiumFuzi.XMLDocument, feedURL: URL) throws -> Feed {
-        document.definePrefix("thr", forNamespace: "http://purl.org/syndication/thread/1.0")
-        document.definePrefix("dcterms", forNamespace: "http://purl.org/dc/terms/")
-        document.definePrefix("opds", forNamespace: "http://opds-spec.org/2010/catalog")
+        document.defineNamespace(.thr)
+        document.defineNamespace(.dcterms)
+        document.defineNamespace(.opds)
 
         guard let root = document.root else {
             throw OPDS1ParserError.rootNotFound

--- a/Sources/OPDS/XMLNamespace.swift
+++ b/Sources/OPDS/XMLNamespace.swift
@@ -1,0 +1,15 @@
+//
+//  Copyright 2025 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import ReadiumFuzi
+import ReadiumShared
+
+// FIXME: Extension used until we migrate from ReadiumFuzi to our shared XMLParser API, in the OPDS parser.
+extension ReadiumFuzi.XMLDocument {
+    func defineNamespace(_ namespace: XMLNamespace) {
+        definePrefix(namespace.prefix, forNamespace: namespace.uri)
+    }
+}

--- a/Sources/Shared/Publication/LinkRelation.swift
+++ b/Sources/Shared/Publication/LinkRelation.swift
@@ -49,6 +49,8 @@ public struct LinkRelation: Sendable {
     public static let search = LinkRelation("search")
     /// Conveys an identifier for the link's context.
     public static let `self` = LinkRelation("self")
+    /// Refers to the start of the actual content in a publication.
+    public static let start = LinkRelation("start")
 
     // IANA – https://www.iana.org/assignments/link-relations/link-relations.xhtml
 

--- a/Sources/Shared/Toolkit/Data/Resource/ResourceContentExtractor.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/ResourceContentExtractor.swift
@@ -70,10 +70,7 @@ class _HTMLResourceContentExtractor: _ResourceContentExtractor {
     // This is much more efficient than using SwiftSoup, but will fail when encountering
     // invalid HTML documents.
     private func parse(xml: String) async -> String? {
-        guard let document = try? await xmlFactory.open(string: xml, namespaces: [
-            XMLNamespace(prefix: "xhtml", uri: "http://www.w3.org/1999/xhtml"),
-        ])
-        else {
+        guard let document = try? await xmlFactory.open(string: xml, namespaces: [.xhtml]) else {
             return nil
         }
 

--- a/Sources/Shared/Toolkit/Format/Sniffers/EPUBFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/EPUBFormatSniffer.swift
@@ -72,11 +72,7 @@ public struct EPUBFormatSniffer: FormatSniffer {
                     return format
                 }
 
-                let namespaces: [XMLNamespace] = [
-                    (prefix: "enc", uri: "http://www.w3.org/2001/04/xmlenc#"),
-                    (prefix: "sig", uri: "http://www.w3.org/2000/09/xmldsig#"),
-                    (prefix: "adept", uri: "http://ns.adobe.com/adept"),
-                ]
+                let namespaces: [XMLNamespace] = [.enc, .sig, .adept]
 
                 if
                     document

--- a/Sources/Shared/Toolkit/Format/Sniffers/HTMLFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/HTMLFormatSniffer.swift
@@ -47,10 +47,7 @@ public struct HTMLFormatSniffer: FormatSniffer {
             return nil
         }
 
-        if element.first("xhtml:body|xhtml2:body", with: [
-            (prefix: "xhtml", uri: "http://www.w3.org/1999/xhtml"),
-            (prefix: "xhtml2", uri: "http://www.w3.org/2002/06/xhtml2"),
-        ]) != nil {
+        if element.first("xhtml:body|xhtml2:body", with: [.xhtml, .xhtml2]) != nil {
             return xhtml
         } else {
             return html

--- a/Sources/Shared/Toolkit/Format/Sniffers/OPDSFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/OPDSFormatSniffer.swift
@@ -36,7 +36,7 @@ public class OPDSFormatSniffer: FormatSniffer {
                     guard let document = $0 else {
                         return nil
                     }
-                    let namespaces = [(prefix: "atom", uri: "http://www.w3.org/2005/Atom")]
+                    let namespaces = [XMLNamespace.atom]
                     if document.first("/atom:feed", with: namespaces) != nil {
                         return opds1Catalog
                     } else if document.first("/atom:entry", with: namespaces) != nil {

--- a/Sources/Shared/Toolkit/XML/XML.swift
+++ b/Sources/Shared/Toolkit/XML/XML.swift
@@ -6,7 +6,30 @@
 
 import Foundation
 
-public typealias XMLNamespace = (prefix: String, uri: String)
+public struct XMLNamespace {
+    public let prefix: String
+    public let uri: String
+
+    public static let adept = XMLNamespace(prefix: "adept", uri: "http://ns.adobe.com/adept")
+    public static let atom = XMLNamespace(prefix: "atom", uri: "http://www.w3.org/2005/Atom")
+    public static let cn = XMLNamespace(prefix: "cn", uri: "urn:oasis:names:tc:opendocument:xmlns:container")
+    public static let comp = XMLNamespace(prefix: "comp", uri: "http://www.idpf.org/2016/encryption#compression")
+    public static let dc = XMLNamespace(prefix: "dc", uri: "http://purl.org/dc/elements/1.1/")
+    public static let dcterms = XMLNamespace(prefix: "dcterms", uri: "http://purl.org/dc/terms/")
+    public static let ds = XMLNamespace(prefix: "ds", uri: "http://www.w3.org/2000/09/xmldsig#")
+    public static let enc = XMLNamespace(prefix: "enc", uri: "http://www.w3.org/2001/04/xmlenc#")
+    public static let epub = XMLNamespace(prefix: "epub", uri: "http://www.idpf.org/2007/ops")
+    public static let html = XMLNamespace(prefix: "html", uri: "http://www.w3.org/1999/xhtml")
+    public static let ncx = XMLNamespace(prefix: "ncx", uri: "http://www.daisy.org/z3986/2005/ncx/")
+    public static let opds = XMLNamespace(prefix: "opds", uri: "http://opds-spec.org/2010/catalog")
+    public static let opf = XMLNamespace(prefix: "opf", uri: "http://www.idpf.org/2007/opf")
+    public static let rendition = XMLNamespace(prefix: "rendition", uri: "http://www.idpf.org/2013/rendition")
+    public static let sig = XMLNamespace(prefix: "sig", uri: "http://www.w3.org/2000/09/xmldsig#")
+    public static let smil = XMLNamespace(prefix: "smil", uri: "http://www.w3.org/ns/SMIL")
+    public static let thr = XMLNamespace(prefix: "thr", uri: "http://purl.org/syndication/thread/1.0")
+    public static let xhtml = XMLNamespace(prefix: "xhtml", uri: "http://www.w3.org/1999/xhtml")
+    public static let xhtml2 = XMLNamespace(prefix: "xhtml2", uri: "http://www.w3.org/2002/06/xhtml2")
+}
 
 public protocol XMLNode {
     /// Concatenated string content of all descendants.

--- a/Sources/Streamer/Parser/EPUB/EPUBContainerParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBContainerParser.swift
@@ -14,7 +14,7 @@ final class EPUBContainerParser: Loggable {
 
     init(data: Data) throws {
         document = try XMLDocument(data: data)
-        document.definePrefix("cn", forNamespace: "urn:oasis:names:tc:opendocument:xmlns:container")
+        document.defineNamespace(.cn)
     }
 
     convenience init(container: Container) async throws {

--- a/Sources/Streamer/Parser/EPUB/EPUBEncryptionParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBEncryptionParser.swift
@@ -28,9 +28,9 @@ final class EPUBEncryptionParser: Loggable {
 
     private lazy var document: ReadiumFuzi.XMLDocument? = {
         let document = try? ReadiumFuzi.XMLDocument(data: data)
-        document?.definePrefix("enc", forNamespace: "http://www.w3.org/2001/04/xmlenc#")
-        document?.definePrefix("ds", forNamespace: "http://www.w3.org/2000/09/xmldsig#")
-        document?.definePrefix("comp", forNamespace: "http://www.idpf.org/2016/encryption#compression")
+        document?.defineNamespace(.enc)
+        document?.defineNamespace(.ds)
+        document?.defineNamespace(.comp)
         return document
     }()
 

--- a/Sources/Streamer/Parser/EPUB/EPUBManifestParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBManifestParser.swift
@@ -1,0 +1,152 @@
+//
+//  Copyright 2025 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import ReadiumShared
+
+final class EPUBManifestParser {
+    private let container: Container
+    private let encryptions: [RelativeURL: Encryption]
+
+    init(container: Container, encryptions: [RelativeURL : Encryption]) {
+        self.container = container
+        self.encryptions = encryptions
+    }
+
+    func parseManifest() async throws -> Manifest {
+        let opfHREF = try await EPUBContainerParser(container: container).parseOPFHREF()
+        
+        // Extracts metadata and links from the OPF.
+        let components = try await OPFParser(container: container, opfHREF: opfHREF, encryptions: encryptions).parsePublication()
+        let metadata = components.metadata
+        let links = components.readingOrder + components.resources
+
+        var manifest = await Manifest(
+            metadata: metadata,
+            readingOrder: components.readingOrder,
+            resources: components.resources,
+            subcollections: parseCollections(in: container, links: links)
+        )
+        
+        return manifest
+    }
+
+    private func parseCollections(in container: Container, links: [Link]) async -> [String: [PublicationCollection]] {
+        var collections = await parseNavigationDocument(in: container, links: links)
+        if collections["toc"]?.first?.links.isEmpty != false {
+            // Falls back on the NCX tables.
+            await collections.merge(parseNCXDocument(in: container, links: links), uniquingKeysWith: { first, _ in first })
+        }
+        return collections
+    }
+
+    /// Attempt to fill the `Publication`'s `tableOfContent`, `landmarks`, `pageList` and `listOfX` links collections using the navigation document.
+    private func parseNavigationDocument(in container: Container, links: [Link]) async -> [String: [PublicationCollection]] {
+        // Get the link in the readingOrder pointing to the Navigation Document.
+        guard
+            let navLink = links.firstWithRel(.contents),
+            let navURI = RelativeURL(string: navLink.href),
+            let navDocumentData = try? await container.readData(at: navURI)
+        else {
+            return [:]
+        }
+
+        // Get the location of the navigation document in order to normalize href paths.
+        let navigationDocument = NavigationDocumentParser(data: navDocumentData, at: navURI)
+
+        var collections: [String: [PublicationCollection]] = [:]
+        func addCollection(_ type: NavigationDocumentParser.NavType, role: String) {
+            let links = navigationDocument.links(for: type)
+            if !links.isEmpty {
+                collections[role] = [PublicationCollection(links: links)]
+            }
+        }
+
+        addCollection(.tableOfContents, role: "toc")
+        addCollection(.pageList, role: "pageList")
+        addCollection(.landmarks, role: "landmarks")
+        addCollection(.listOfAudiofiles, role: "loa")
+        addCollection(.listOfIllustrations, role: "loi")
+        addCollection(.listOfTables, role: "lot")
+        addCollection(.listOfVideos, role: "lov")
+
+        return collections
+    }
+
+    /// Attempt to fill `Publication.tableOfContent`/`.pageList` using the NCX
+    /// document. Will only modify the Publication if it has not be filled
+    /// previously (using the Navigation Document).
+    private func parseNCXDocument(in container: Container, links: [Link]) async -> [String: [PublicationCollection]] {
+        // Get the link in the readingOrder pointing to the NCX document.
+        guard
+            let ncxLink = links.firstWithMediaType(.ncx),
+            let ncxURI = RelativeURL(string: ncxLink.href),
+            let ncxDocumentData = try? await container.readData(at: ncxURI)
+        else {
+            return [:]
+        }
+
+        let ncx = NCXParser(data: ncxDocumentData, at: ncxURI)
+
+        var collections: [String: [PublicationCollection]] = [:]
+        func addCollection(_ type: NCXParser.NavType, role: String) {
+            let links = ncx.links(for: type)
+            if !links.isEmpty {
+                collections[role] = [PublicationCollection(links: links)]
+            }
+        }
+
+        addCollection(.tableOfContents, role: "toc")
+        addCollection(.pageList, role: "pageList")
+
+        return collections
+    }
+
+    /// Parse the mediaOverlays informations contained in the ressources then
+    /// parse the associted SMIL files to populate the MediaOverlays objects
+    /// in each of the ReadingOrder's Links.
+    private func parseMediaOverlay(from container: Container, to publication: inout Publication) throws {
+        // FIXME: For now we don't fill the media-overlays anymore, since it was only half implemented and the API will change
+//        let mediaOverlays = publication.resources.filter(byType: .smil)
+//
+//        guard !mediaOverlays.isEmpty else {
+//            log(.info, "No media-overlays found in the Publication.")
+//            return
+//        }
+//        for mediaOverlayLink in mediaOverlays {
+//            let node = MediaOverlayNode()
+//
+//            guard let smilData = try? fetcher.data(at: mediaOverlayLink.href),
+//                let smilXml = try? XMLDocument(data: smilData) else
+//            {
+//                throw OPFParserError.invalidSmilResource
+//            }
+//
+//            smilXml.definePrefix("smil", forNamespace: "http://www.w3.org/ns/SMIL")
+//            smilXml.definePrefix("epub", forNamespace: "http://www.idpf.org/2007/ops")
+//            guard let body = smilXml.firstChild(xpath: "./smil:body") else {
+//                continue
+//            }
+//
+//            node.role.append("section")
+//            if let textRef = body.attr("textref") { // Prevent the crash on the japanese book
+//                node.text = HREF(textRef, relativeTo: mediaOverlayLink.href).string
+//            }
+//            // get body parameters <par>a
+//            let href = mediaOverlayLink.href
+//            SMILParser.parseParameters(in: body, withParent: node, base: href)
+//            SMILParser.parseSequences(in: body, withParent: node, publicationReadingOrder: &publication.readingOrder, base: href)
+        // "/??/xhtml/mo-002.xhtml#mo-1" => "/??/xhtml/mo-002.xhtml"
+
+//            guard let baseHref = node.text?.components(separatedBy: "#")[0],
+//                let link = publication.readingOrder.first(where: { baseHref.contains($0.href) }) else
+//            {
+//                continue
+//            }
+//            link.mediaOverlays.append(node)
+//            link.properties.mediaOverlay = EPUBConstant.mediaOverlayURL + link.href
+//        }
+    }
+}

--- a/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
@@ -19,10 +19,10 @@ final class EPUBMetadataParser: Loggable {
         self.displayOptions = displayOptions
         self.metas = metas
 
-        document.definePrefix("opf", forNamespace: "http://www.idpf.org/2007/opf")
-        document.definePrefix("dc", forNamespace: "http://purl.org/dc/elements/1.1/")
-        document.definePrefix("dcterms", forNamespace: "http://purl.org/dc/terms/")
-        document.definePrefix("rendition", forNamespace: "http://www.idpf.org/2013/rendition")
+        document.defineNamespace(.opf)
+        document.defineNamespace(.dc)
+        document.defineNamespace(.dcterms)
+        document.defineNamespace(.rendition)
     }
 
     private lazy var metadataElement: ReadiumFuzi.XMLElement? = document.firstChild(xpath: "/opf:package/opf:metadata")

--- a/Sources/Streamer/Parser/EPUB/EPUBParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBParser.swift
@@ -55,25 +55,19 @@ public final class EPUBParser: PublicationParser {
 
         do {
             let container = asset.container
-            let opfHREF = try await EPUBContainerParser(container: container).parseOPFHREF()
 
             // `Encryption` indexed by HREF.
             let encryptions = await (try? EPUBEncryptionParser(container: container))?.parseEncryptions() ?? [:]
+            
+            let manifest = try await EPUBManifestParser(
+                container: asset.container,
+                encryptions: encryptions
+            ).parseManifest()
 
-            // Extracts metadata and links from the OPF.
-            let components = try await OPFParser(container: container, opfHREF: opfHREF, encryptions: encryptions).parsePublication()
-            let metadata = components.metadata
-            let links = components.readingOrder + components.resources
-
-            let deobfuscator = EPUBDeobfuscator(publicationId: metadata.identifier ?? "", encryptions: encryptions)
-
-            return await .success(Publication.Builder(
-                manifest: Manifest(
-                    metadata: metadata,
-                    readingOrder: components.readingOrder,
-                    resources: components.resources,
-                    subcollections: parseCollections(in: container, links: links)
-                ),
+            let deobfuscator = EPUBDeobfuscator(publicationId: manifest.metadata.identifier ?? "", encryptions: encryptions)
+            
+            return .success(Publication.Builder(
+                manifest: manifest,
                 container: container.map { url, resource in
                     deobfuscator.deobfuscate(resource: resource, at: url)
                 },
@@ -90,124 +84,5 @@ public final class EPUBParser: PublicationParser {
         } catch {
             return .failure(.reading(.decoding(error)))
         }
-    }
-
-    private func parseCollections(in container: Container, links: [Link]) async -> [String: [PublicationCollection]] {
-        var collections = await parseNavigationDocument(in: container, links: links)
-        if collections["toc"]?.first?.links.isEmpty != false {
-            // Falls back on the NCX tables.
-            await collections.merge(parseNCXDocument(in: container, links: links), uniquingKeysWith: { first, _ in first })
-        }
-        return collections
-    }
-
-    // MARK: - Internal Methods.
-
-    /// Attempt to fill the `Publication`'s `tableOfContent`, `landmarks`, `pageList` and `listOfX` links collections using the navigation document.
-    private func parseNavigationDocument(in container: Container, links: [Link]) async -> [String: [PublicationCollection]] {
-        // Get the link in the readingOrder pointing to the Navigation Document.
-        guard
-            let navLink = links.firstWithRel(.contents),
-            let navURI = RelativeURL(string: navLink.href),
-            let navDocumentData = try? await container.readData(at: navURI)
-        else {
-            return [:]
-        }
-
-        // Get the location of the navigation document in order to normalize href paths.
-        let navigationDocument = NavigationDocumentParser(data: navDocumentData, at: navURI)
-
-        var collections: [String: [PublicationCollection]] = [:]
-        func addCollection(_ type: NavigationDocumentParser.NavType, role: String) {
-            let links = navigationDocument.links(for: type)
-            if !links.isEmpty {
-                collections[role] = [PublicationCollection(links: links)]
-            }
-        }
-
-        addCollection(.tableOfContents, role: "toc")
-        addCollection(.pageList, role: "pageList")
-        addCollection(.landmarks, role: "landmarks")
-        addCollection(.listOfAudiofiles, role: "loa")
-        addCollection(.listOfIllustrations, role: "loi")
-        addCollection(.listOfTables, role: "lot")
-        addCollection(.listOfVideos, role: "lov")
-
-        return collections
-    }
-
-    /// Attempt to fill `Publication.tableOfContent`/`.pageList` using the NCX
-    /// document. Will only modify the Publication if it has not be filled
-    /// previously (using the Navigation Document).
-    private func parseNCXDocument(in container: Container, links: [Link]) async -> [String: [PublicationCollection]] {
-        // Get the link in the readingOrder pointing to the NCX document.
-        guard
-            let ncxLink = links.firstWithMediaType(.ncx),
-            let ncxURI = RelativeURL(string: ncxLink.href),
-            let ncxDocumentData = try? await container.readData(at: ncxURI)
-        else {
-            return [:]
-        }
-
-        let ncx = NCXParser(data: ncxDocumentData, at: ncxURI)
-
-        var collections: [String: [PublicationCollection]] = [:]
-        func addCollection(_ type: NCXParser.NavType, role: String) {
-            let links = ncx.links(for: type)
-            if !links.isEmpty {
-                collections[role] = [PublicationCollection(links: links)]
-            }
-        }
-
-        addCollection(.tableOfContents, role: "toc")
-        addCollection(.pageList, role: "pageList")
-
-        return collections
-    }
-
-    /// Parse the mediaOverlays informations contained in the ressources then
-    /// parse the associted SMIL files to populate the MediaOverlays objects
-    /// in each of the ReadingOrder's Links.
-    private func parseMediaOverlay(from container: Container, to publication: inout Publication) throws {
-        // FIXME: For now we don't fill the media-overlays anymore, since it was only half implemented and the API will change
-//        let mediaOverlays = publication.resources.filter(byType: .smil)
-//
-//        guard !mediaOverlays.isEmpty else {
-//            log(.info, "No media-overlays found in the Publication.")
-//            return
-//        }
-//        for mediaOverlayLink in mediaOverlays {
-//            let node = MediaOverlayNode()
-//
-//            guard let smilData = try? fetcher.data(at: mediaOverlayLink.href),
-//                let smilXml = try? XMLDocument(data: smilData) else
-//            {
-//                throw OPFParserError.invalidSmilResource
-//            }
-//
-//            smilXml.definePrefix("smil", forNamespace: "http://www.w3.org/ns/SMIL")
-//            smilXml.definePrefix("epub", forNamespace: "http://www.idpf.org/2007/ops")
-//            guard let body = smilXml.firstChild(xpath: "./smil:body") else {
-//                continue
-//            }
-//
-//            node.role.append("section")
-//            if let textRef = body.attr("textref") { // Prevent the crash on the japanese book
-//                node.text = HREF(textRef, relativeTo: mediaOverlayLink.href).string
-//            }
-//            // get body parameters <par>a
-//            let href = mediaOverlayLink.href
-//            SMILParser.parseParameters(in: body, withParent: node, base: href)
-//            SMILParser.parseSequences(in: body, withParent: node, publicationReadingOrder: &publication.readingOrder, base: href)
-        // "/??/xhtml/mo-002.xhtml#mo-1" => "/??/xhtml/mo-002.xhtml"
-
-//            guard let baseHref = node.text?.components(separatedBy: "#")[0],
-//                let link = publication.readingOrder.first(where: { baseHref.contains($0.href) }) else
-//            {
-//                continue
-//            }
-//            link.mediaOverlays.append(node)
-//            link.properties.mediaOverlay = EPUBConstant.mediaOverlayURL + link.href
-//        }
     }
 }

--- a/Sources/Streamer/Parser/EPUB/EPUBParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBParser.swift
@@ -58,14 +58,14 @@ public final class EPUBParser: PublicationParser {
 
             // `Encryption` indexed by HREF.
             let encryptions = await (try? EPUBEncryptionParser(container: container))?.parseEncryptions() ?? [:]
-            
+
             let manifest = try await EPUBManifestParser(
                 container: asset.container,
                 encryptions: encryptions
             ).parseManifest()
 
             let deobfuscator = EPUBDeobfuscator(publicationId: manifest.metadata.identifier ?? "", encryptions: encryptions)
-            
+
             return .success(Publication.Builder(
                 manifest: manifest,
                 container: container.map { url, resource in

--- a/Sources/Streamer/Parser/EPUB/Extensions/LinkRelation+EPUB.swift
+++ b/Sources/Streamer/Parser/EPUB/Extensions/LinkRelation+EPUB.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright 2025 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import ReadiumShared
+
+extension LinkRelation {
+    init(epubType: String) {
+        self = switch epubType {
+        case "cover": .cover
+        case "toc": .contents
+        case "bodymatter": .start
+        default: LinkRelation("\(XMLNamespace.epub.uri)#\(epubType)")
+        }
+    }
+}

--- a/Sources/Streamer/Parser/EPUB/Extensions/LinkRelation+EPUB.swift
+++ b/Sources/Streamer/Parser/EPUB/Extensions/LinkRelation+EPUB.swift
@@ -7,12 +7,16 @@
 import ReadiumShared
 
 extension LinkRelation {
-    init(epubType: String) {
-        self = switch epubType {
-        case "cover": .cover
-        case "toc": .contents
-        case "bodymatter": .start
-        default: LinkRelation("\(XMLNamespace.epub.uri)#\(epubType)")
+    init?(epubType: String) {
+        switch epubType {
+        case "cover":
+            self = .cover
+        case "toc":
+            self = .contents
+        case "bodymatter":
+            self = .start
+        default:
+            return nil
         }
     }
 }

--- a/Sources/Streamer/Parser/EPUB/Extensions/LinkRelation+EPUB.swift
+++ b/Sources/Streamer/Parser/EPUB/Extensions/LinkRelation+EPUB.swift
@@ -8,15 +8,11 @@ import ReadiumShared
 
 extension LinkRelation {
     init?(epubType: String) {
-        switch epubType {
-        case "cover":
-            self = .cover
-        case "toc":
-            self = .contents
-        case "bodymatter":
-            self = .start
-        default:
-            return nil
+        self = switch epubType {
+        case "cover": .cover
+        case "toc": .contents
+        case "bodymatter": .start
+        default: LinkRelation("http://idpf.org/epub/vocab/structure/#\(epubType)")
         }
     }
 }

--- a/Sources/Streamer/Parser/EPUB/NCXParser.swift
+++ b/Sources/Streamer/Parser/EPUB/NCXParser.swift
@@ -31,7 +31,7 @@ final class NCXParser {
 
     private lazy var document: ReadiumFuzi.XMLDocument? = {
         let document = try? XMLDocument(data: data)
-        document?.definePrefix("ncx", forNamespace: "http://www.daisy.org/z3986/2005/ncx/")
+        document?.defineNamespace(.ncx)
         return document
     }()
 
@@ -65,6 +65,7 @@ final class NCXParser {
         NavigationDocumentParser.makeLink(
             title: element.firstChild(xpath: "ncx:navLabel/ncx:text")?.stringValue,
             href: element.firstChild(xpath: "ncx:content")?.attr("src").flatMap(RelativeURL.init(epubHREF:)),
+            rel: nil,
             children: links(in: element, nodeTagName: nodeTagName),
             baseURL: url
         )

--- a/Sources/Streamer/Parser/EPUB/NavigationDocumentParser.swift
+++ b/Sources/Streamer/Parser/EPUB/NavigationDocumentParser.swift
@@ -65,7 +65,7 @@ final class NavigationDocumentParser {
         return NavigationDocumentParser.makeLink(
             title: label.stringValue,
             href: label.attr("href").flatMap(RelativeURL.init(epubHREF:)),
-            rel: label.attr("type", namespace: .epub).map(LinkRelation.init(epubType:)),
+            rel: label.attr("type", namespace: .epub).flatMap(LinkRelation.init(epubType:)),
             children: links(in: li),
             baseURL: url
         )

--- a/Sources/Streamer/Parser/EPUB/NavigationDocumentParser.swift
+++ b/Sources/Streamer/Parser/EPUB/NavigationDocumentParser.swift
@@ -34,8 +34,7 @@ final class NavigationDocumentParser {
     private lazy var document: ReadiumFuzi.XMLDocument? = {
         // Warning: Somehow if we use HTMLDocument instead of XMLDocument, then the `epub` prefix doesn't work.
         let document = try? ReadiumFuzi.XMLDocument(data: data)
-        document?.definePrefix("html", forNamespace: "http://www.w3.org/1999/xhtml")
-        document?.definePrefix("epub", forNamespace: "http://www.idpf.org/2007/ops")
+        document?.defineNamespaces(.html, .epub)
         return document
     }()
 
@@ -66,13 +65,20 @@ final class NavigationDocumentParser {
         return NavigationDocumentParser.makeLink(
             title: label.stringValue,
             href: label.attr("href").flatMap(RelativeURL.init(epubHREF:)),
+            rel: label.attr("type", namespace: .epub).map(LinkRelation.init(epubType:)),
             children: links(in: li),
             baseURL: url
         )
     }
 
     /// Creates a new navigation `Link` object from a label, href and children, after validating the data.
-    static func makeLink(title: String?, href: RelativeURL?, children: [Link], baseURL: RelativeURL) -> Link? {
+    static func makeLink(
+        title: String?,
+        href: RelativeURL?,
+        rel: LinkRelation?,
+        children: [Link],
+        baseURL: RelativeURL
+    ) -> Link? {
         // Cleans up title label.
         // http://www.idpf.org/epub/301/spec/epub-contentdocs.html#confreq-nav-a-cnt
         let title = (title ?? "")
@@ -92,6 +98,11 @@ final class NavigationDocumentParser {
             return nil
         }
 
-        return Link(href: href?.string ?? "#", title: title, children: children)
+        return Link(
+            href: href?.string ?? "#",
+            title: title,
+            rel: rel,
+            children: children
+        )
     }
 }

--- a/Sources/Streamer/Parser/EPUB/OPFMeta.swift
+++ b/Sources/Streamer/Parser/EPUB/OPFMeta.swift
@@ -106,7 +106,7 @@ enum OPFVocabulary: String {
     /// > must use such local overrides when encountered.
     /// http://www.idpf.org/epub/301/spec/epub-publications.html#sec-metadata-reserved-vocabs
     static func prefixes(in document: ReadiumFuzi.XMLDocument) -> [String: String] {
-        document.definePrefix("opf", forNamespace: "http://www.idpf.org/2007/opf")
+        document.defineNamespace(.opf)
         guard let prefixAttribute = document.firstChild(xpath: "/opf:package")?.attr("prefix") else {
             return [:]
         }
@@ -159,8 +159,7 @@ struct OPFMetaList {
     init(document: ReadiumFuzi.XMLDocument) {
         self.document = document
         let prefixes = OPFVocabulary.prefixes(in: document)
-        document.definePrefix("opf", forNamespace: "http://www.idpf.org/2007/opf")
-        document.definePrefix("dc", forNamespace: "http://purl.org/dc/elements/1.1/")
+        document.defineNamespaces(.opf, .dc)
 
         // Parses `<meta>` and `<dc:x>` tags in order of appearance.
         let root = "/opf:package/opf:metadata"

--- a/Sources/Streamer/Parser/EPUB/OPFParser.swift
+++ b/Sources/Streamer/Parser/EPUB/OPFParser.swift
@@ -48,7 +48,7 @@ final class OPFParser: Loggable {
     init(baseURL: RelativeURL, data: Data, displayOptionsData: Data? = nil, encryptions: [RelativeURL: Encryption]) throws {
         self.baseURL = baseURL
         document = try ReadiumFuzi.XMLDocument(data: data)
-        document.definePrefix("opf", forNamespace: "http://www.idpf.org/2007/opf")
+        document.defineNamespace(.opf)
         displayOptions = (displayOptionsData.map { try? ReadiumFuzi.XMLDocument(data: $0) }) ?? nil
         metas = OPFMetaList(document: document)
         self.encryptions = encryptions

--- a/Sources/Streamer/Parser/EPUB/XMLNamespace.swift
+++ b/Sources/Streamer/Parser/EPUB/XMLNamespace.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright 2025 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import ReadiumFuzi
+import ReadiumShared
+
+// FIXME: Extension used until we migrate from ReadiumFuzi to our shared XMLParser API, in the streamer.
+extension ReadiumFuzi.XMLDocument {
+    func defineNamespace(_ namespace: XMLNamespace) {
+        definePrefix(namespace.prefix, forNamespace: namespace.uri)
+    }
+
+    func defineNamespaces(_ namespaces: XMLNamespace...) {
+        for namespace in namespaces {
+            defineNamespace(namespace)
+        }
+    }
+}
+
+extension ReadiumFuzi.XMLElement {
+    func attr(_ name: String, namespace: XMLNamespace?) -> String? {
+        attr(name, namespace: namespace?.uri)
+    }
+}

--- a/Support/Carthage/.xcodegen
+++ b/Support/Carthage/.xcodegen
@@ -440,9 +440,13 @@
 ../../Sources/Navigator/EPUB/Assets/Static/scripts
 ../../Sources/Navigator/EPUB/Assets/Static/scripts/.gitignore
 ../../Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed-wrapper-one.js
+../../Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed-wrapper-one.js.map
 ../../Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed-wrapper-two.js
+../../Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed-wrapper-two.js.map
 ../../Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed.js
+../../Sources/Navigator/EPUB/Assets/Static/scripts/readium-fixed.js.map
 ../../Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js
+../../Sources/Navigator/EPUB/Assets/Static/scripts/readium-reflowable.js.map
 ../../Sources/Navigator/EPUB/CSS
 ../../Sources/Navigator/EPUB/CSS/CSSLayout.swift
 ../../Sources/Navigator/EPUB/CSS/CSSProperties.swift
@@ -576,6 +580,7 @@
 ../../Sources/OPDS/OPDSParser.swift
 ../../Sources/OPDS/ParseData.swift
 ../../Sources/OPDS/URLHelper.swift
+../../Sources/OPDS/XMLNamespace.swift
 ../../Sources/Shared
 ../../Sources/Shared/Logger
 ../../Sources/Shared/Logger/Loggable.swift
@@ -811,9 +816,11 @@
 ../../Sources/Streamer/Parser/EPUB
 ../../Sources/Streamer/Parser/EPUB/EPUBContainerParser.swift
 ../../Sources/Streamer/Parser/EPUB/EPUBEncryptionParser.swift
+../../Sources/Streamer/Parser/EPUB/EPUBManifestParser.swift
 ../../Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
 ../../Sources/Streamer/Parser/EPUB/EPUBParser.swift
 ../../Sources/Streamer/Parser/EPUB/Extensions
+../../Sources/Streamer/Parser/EPUB/Extensions/LinkRelation+EPUB.swift
 ../../Sources/Streamer/Parser/EPUB/Extensions/Presentation+EPUB.swift
 ../../Sources/Streamer/Parser/EPUB/NavigationDocumentParser.swift
 ../../Sources/Streamer/Parser/EPUB/NCXParser.swift
@@ -823,6 +830,7 @@
 ../../Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
 ../../Sources/Streamer/Parser/EPUB/Services
 ../../Sources/Streamer/Parser/EPUB/Services/EPUBPositionsService.swift
+../../Sources/Streamer/Parser/EPUB/XMLNamespace.swift
 ../../Sources/Streamer/Parser/Image
 ../../Sources/Streamer/Parser/Image/ImageParser.swift
 ../../Sources/Streamer/Parser/PDF

--- a/Support/Carthage/Readium.xcodeproj/project.pbxproj
+++ b/Support/Carthage/Readium.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		17108D46A0353A254DA193B0 /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D002FDDAD1A21AC5BB84CE /* Container.swift */; };
 		1752D756BED37325D6D4ED29 /* ReadiumInternal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42FD63C2720614E558522675 /* ReadiumInternal.framework */; };
 		18217BC157557A5DDA4BA119 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDB8B9906FC78C038203BDD /* User.swift */; };
+		1852D8C28060050B53CFABED /* XMLNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E494545D2CCE72A3FED240 /* XMLNamespace.swift */; };
 		188D742F80B70DE8A625AD21 /* Facet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387B19B66C4D91A295B5EFA6 /* Facet.swift */; };
 		1A4F41D5A7E48472DB9A181E /* ZIPFoundationArchiveOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50064FE9BBCEA4C00BA6BBEF /* ZIPFoundationArchiveOpener.swift */; };
 		1AEF63A8471C7676092842D2 /* FileExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D555435E2BADB2B877FD50C7 /* FileExtension.swift */; };
@@ -99,6 +100,7 @@
 		39326587EF76BFD5AD68AED2 /* ReadiumShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97BC822B36D72EF548162129 /* ReadiumShared.framework */; };
 		39B1DDE3571AB3F3CC6824F4 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA827FC94F5CB3F9032028F /* JSON.swift */; };
 		3AD9E86BB1621CF836919E33 /* ReadiumLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38984FD65CFF1D54FF7F794F /* ReadiumLocalizedString.swift */; };
+		3AF8DBD6431F7F5A156FFBCF /* EPUBManifestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C73E1510486CBF553651D60 /* EPUBManifestParser.swift */; };
 		3B138483530FDCC545A12D6F /* ZIPFoundationArchiveFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C1E0FDB5373E672D5FF80F /* ZIPFoundationArchiveFactory.swift */; };
 		3B5A8A76665391D2D32CB012 /* LCPAcquiredPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C61B620DE6C012805269111 /* LCPAcquiredPublication.swift */; };
 		3BB313823F043BA2C7D7D2F7 /* Locator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7D07E66B7E820D1A509A27 /* Locator.swift */; };
@@ -295,6 +297,7 @@
 		BD520A603D8351461485877F /* ComicFormatSniffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6271FA7F282364A4E68C4C /* ComicFormatSniffer.swift */; };
 		BE754F8C0536C8B7D28A294C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5507BD4012032A7567175B69 /* Localizable.strings */; };
 		BF0CC6F4EE0F18B52D2D8693 /* Properties+Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E175BF1A1F97687B4119BB1 /* Properties+Encryption.swift */; };
+		BFC777DBBFBDFDD54876BB59 /* LinkRelation+EPUB.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB91391C899304A1DC051C6E /* LinkRelation+EPUB.swift */; };
 		C0A492BDDCB4A472F408B3B4 /* ReadiumZIPFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69E17C4870C64264819EB227 /* ReadiumZIPFoundation.xcframework */; };
 		C122D3F719E77AEFA36E3034 /* RPFFormatSniffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACA9031C70DAB05CE0DD463 /* RPFFormatSniffer.swift */; };
 		C1A94B2A9C446CB03650DC47 /* NCXParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4363E8A92B1EA9AF2561DCE9 /* NCXParser.swift */; };
@@ -343,6 +346,7 @@
 		DDD0C8AC27EF8D1A893DF6CC /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529B55BE6996FCDC1082BF0A /* JSON.swift */; };
 		DEF1AA526DDAF2D5EA3A6594 /* FileURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA3AA272772FCF7D6268A74 /* FileURL.swift */; };
 		DEF375FF574461E670FF45B9 /* ProgressionStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED4C26FFA10656866E167F4 /* ProgressionStrategy.swift */; };
+		DEF5B692764428697150AA8A /* XMLNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364F18D0F750A1D98A381654 /* XMLNamespace.swift */; };
 		DFA6D21F48B69ED6839BC9AC /* EPUBSpread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D8CC7BC117BBFB206D01CC /* EPUBSpread.swift */; };
 		E03AE8289EEA87838334C3DB /* BorrowedResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38198AAB12E30A23B32C6EF1 /* BorrowedResource.swift */; };
 		E08CABFE57EC96D9F7062AF1 /* PDFKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAF1D0444B94E2CDD80087D /* PDFKit.swift */; };
@@ -553,6 +557,7 @@
 		34AB954525AC159166C96A36 /* HTMLResourceContentIterator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLResourceContentIterator.swift; sourceTree = "<group>"; };
 		34B5C938E4973406F110F2E6 /* OPDS1Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDS1Parser.swift; sourceTree = "<group>"; };
 		3510E7E84A5361BCECC90569 /* WarningLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningLogger.swift; sourceTree = "<group>"; };
+		364F18D0F750A1D98A381654 /* XMLNamespace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLNamespace.swift; sourceTree = "<group>"; };
 		37087C0D0B36FE7F20F1C891 /* ImageParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageParser.swift; sourceTree = "<group>"; };
 		37120DA973F5C438B59BC014 /* ReadiumLCP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReadiumLCP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		38198AAB12E30A23B32C6EF1 /* BorrowedResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorrowedResource.swift; sourceTree = "<group>"; };
@@ -593,6 +598,7 @@
 		4BCDF341872EEFB88B6674DE /* HTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPServer.swift; sourceTree = "<group>"; };
 		4BF38F71FDEC1920325B62D3 /* PublicationContentIterator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationContentIterator.swift; sourceTree = "<group>"; };
 		4BF3D04FB9D6A90EE77F1F02 /* ResourceProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceProperties.swift; sourceTree = "<group>"; };
+		4C73E1510486CBF553651D60 /* EPUBManifestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBManifestParser.swift; sourceTree = "<group>"; };
 		4E564AE6D5137499C81FEBE2 /* TargetAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetAction.swift; sourceTree = "<group>"; };
 		4FEE01FAD273864D0908C358 /* Measure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Measure.swift; sourceTree = "<group>"; };
 		50064FE9BBCEA4C00BA6BBEF /* ZIPFoundationArchiveOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPFoundationArchiveOpener.swift; sourceTree = "<group>"; };
@@ -783,6 +789,7 @@
 		D6BCDFDD5327AB802F0F6460 /* NowPlayingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingInfo.swift; sourceTree = "<group>"; };
 		D6C93236E313B55D8B835D9F /* EPUBPositionsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPositionsService.swift; sourceTree = "<group>"; };
 		D6D7EDF33594A73EADA04511 /* HTTPResourceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResourceFactory.swift; sourceTree = "<group>"; };
+		D6E494545D2CCE72A3FED240 /* XMLNamespace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLNamespace.swift; sourceTree = "<group>"; };
 		D828AE80E51FC75FAF6DD7DB /* URLConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLConvertible.swift; sourceTree = "<group>"; };
 		D83D2271E64F38A8A1CEF491 /* Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
 		D88E58FF0AC7D506273FD8D9 /* TTSEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSEngine.swift; sourceTree = "<group>"; };
@@ -843,6 +850,7 @@
 		F8A3CDE3EA555A97BBFE1EEF /* ZIPFoundationContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPFoundationContainer.swift; sourceTree = "<group>"; };
 		F8C32FDF5E2D35BE71E45ED0 /* AudioPreferencesEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPreferencesEditor.swift; sourceTree = "<group>"; };
 		F90C4D94134D9F741D38D8AA /* Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comparable.swift; sourceTree = "<group>"; };
+		FB91391C899304A1DC051C6E /* LinkRelation+EPUB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkRelation+EPUB.swift"; sourceTree = "<group>"; };
 		FC3996B9F88089C7F752C531 /* DefaultFormatSniffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFormatSniffer.swift; sourceTree = "<group>"; };
 		FC6271FA7F282364A4E68C4C /* ComicFormatSniffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComicFormatSniffer.swift; sourceTree = "<group>"; };
 		FC9D0ACCBA7B6E4473A95D5E /* AudioSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSettings.swift; sourceTree = "<group>"; };
@@ -939,6 +947,7 @@
 		00753735EE68A5BCEF35D787 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				FB91391C899304A1DC051C6E /* LinkRelation+EPUB.swift */,
 				42EFF9139B59D763CE254F92 /* Presentation+EPUB.swift */,
 			);
 			path = Extensions;
@@ -1422,12 +1431,14 @@
 			children = (
 				78033AFDF98C92351785D17F /* EPUBContainerParser.swift */,
 				893C5F4086D99997DAF9BEDC /* EPUBEncryptionParser.swift */,
+				4C73E1510486CBF553651D60 /* EPUBManifestParser.swift */,
 				76E46B10FD5B26A2F41718E0 /* EPUBMetadataParser.swift */,
 				03C234075C7F7573BA54B77D /* EPUBParser.swift */,
 				29AD63CD2A41586290547212 /* NavigationDocumentParser.swift */,
 				4363E8A92B1EA9AF2561DCE9 /* NCXParser.swift */,
 				0FC49AFB32B525AAC5BF7612 /* OPFMeta.swift */,
 				61575203A3BEB8E218CAFE38 /* OPFParser.swift */,
+				364F18D0F750A1D98A381654 /* XMLNamespace.swift */,
 				00753735EE68A5BCEF35D787 /* Extensions */,
 				5EC23231F487889071301718 /* Resource Transformers */,
 				36AE60D6C483E1F4BBE7AAE0 /* Services */,
@@ -1471,6 +1482,7 @@
 				07B5469E40752E598C070E5B /* OPDSParser.swift */,
 				B1085F2D690A73984E675D54 /* ParseData.swift */,
 				E19D31097B3A8050A46CDAA5 /* URLHelper.swift */,
+				D6E494545D2CCE72A3FED240 /* XMLNamespace.swift */,
 			);
 			name = OPDS;
 			path = ../../Sources/OPDS;
@@ -2438,12 +2450,14 @@
 				0569A7E5E5B31AF3B4C8C234 /* EPUBContainerParser.swift in Sources */,
 				20D530EDB2B26ADECB4DAE82 /* EPUBDeobfuscator.swift in Sources */,
 				5E85C11FCCA593DE3161407C /* EPUBEncryptionParser.swift in Sources */,
+				3AF8DBD6431F7F5A156FFBCF /* EPUBManifestParser.swift in Sources */,
 				7A7B204C7C289DBE91A14685 /* EPUBMetadataParser.swift in Sources */,
 				D65BEF9DAF1FEB1A5BEED700 /* EPUBParser.swift in Sources */,
 				914DEDFE5594761D3F180491 /* EPUBPositionsService.swift in Sources */,
 				EF15E9163EBC82672B22F6E0 /* ImageParser.swift in Sources */,
 				FCFFE5305127D9FC72549EAA /* LCPDFPositionsService.swift in Sources */,
 				0BFCDAEC82CFF09AFC53A5D0 /* LCPDFTableOfContentsService.swift in Sources */,
+				BFC777DBBFBDFDD54876BB59 /* LinkRelation+EPUB.swift in Sources */,
 				C1A94B2A9C446CB03650DC47 /* NCXParser.swift in Sources */,
 				01AD628D6DE82E1C1C4C281D /* NavigationDocumentParser.swift in Sources */,
 				2B8BC06B6B366E67C716DDA1 /* OPFMeta.swift in Sources */,
@@ -2455,6 +2469,7 @@
 				67F1C7C3D434D2AA542376E3 /* PublicationParser.swift in Sources */,
 				C9FBD23E459FB395377E149E /* ReadiumWebPubParser.swift in Sources */,
 				4AE70F783C07D9938B40E792 /* StringExtension.swift in Sources */,
+				DEF5B692764428697150AA8A /* XMLNamespace.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2552,6 +2567,7 @@
 				346C4DA09157847639648F56 /* OPDSParser.swift in Sources */,
 				C2A1FAC4ADA33EABA1E45EF8 /* ParseData.swift in Sources */,
 				F2BDD94FFFBD08526B56E337 /* URLHelper.swift in Sources */,
+				1852D8C28060050B53CFABED /* XMLNamespace.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/StreamerTests/Fixtures/Navigation Documents/full-metadata-nav.xhtml
+++ b/Tests/StreamerTests/Fixtures/Navigation Documents/full-metadata-nav.xhtml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head>
+  <meta charset="utf-8" />
+</head>
+<body>
+  <nav epub:type="landmarks">
+    <h2>Landmarks</h2>
+    <ol>
+      <li><a epub:type="cover" href="titlepage.xhtml">Cover</a></li>
+      <li><a epub:type="toc" href="toc.xhtml">Table of Contents</a></li>
+      <li><a epub:type="bodymatter" href="chapter01.xhtml">Begin Reading</a></li>
+    </ol>
+  </nav>
+</body>
+</html>

--- a/Tests/StreamerTests/Fixtures/Navigation Documents/nav-section.xhtml
+++ b/Tests/StreamerTests/Fixtures/Navigation Documents/nav-section.xhtml
@@ -18,8 +18,11 @@
     <nav epub:type="landmarks">
       <h2>Landmarks</h2>
       <ol>
+        <li><a epub:type="cover" href="cover.xhtml">Cover</a></li>
         <li><a epub:type="toc" href="#toc">Table of Contents</a></li>
         <li><a epub:type="bodymatter" href="ch1.xhtml">Begin Reading</a></li>
+        <li><a epub:type="index" href="index.xhtml">Index</a></li>
+        <li><a epub:type="glossary" href="glossary.xhtml">Glossary</a></li>
       </ol>
     </nav>
   </section>

--- a/Tests/StreamerTests/Fixtures/OPF/full-metadata.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/full-metadata.opf
@@ -48,12 +48,16 @@
     <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
     <item id="css" href="style.css" media-type="text/css"/>
     <item id="titlepage" href="titlepage.xhtml" media-type="application/xhtml+xml" />
+    <item id="toc" href="toc.xhtml" media-type="application/xhtml+xml" />
     <item id="chapter01" href="chapter01.xhtml" media-type="application/xhtml+xml"/>
+    <item id="chapter02" href="chapter02.xhtml" media-type="application/xhtml+xml"/>
     <item id="img01a" href="images/alice01a.gif" media-type="image/gif" properties="cover-image"/>
     <item id="img02a" href="images/alice02a.gif" media-type="image/gif"/>
   </manifest>
   <spine page-progression-direction="rtl">
     <itemref idref="titlepage"/>
+    <itemref idref="toc"/>
     <itemref idref="chapter01"/>
+    <itemref idref="chapter02"/>
   </spine>
 </package>

--- a/Tests/StreamerTests/Parser/EPUB/EPUBManifestParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/EPUBManifestParserTests.swift
@@ -1,0 +1,110 @@
+//
+//  Copyright 2025 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import ReadiumShared
+@testable import ReadiumStreamer
+import XCTest
+
+class EPUBManifestParserTests: XCTestCase {
+    let fixtures = Fixtures()
+
+    func testParseFullManifest() async throws {
+        let sut = EPUBManifestParser(
+            container: CompositeContainer(
+                FileContainer(files: [
+                    RelativeURL(path: "META-INF/container.xml")!: fixtures.url(for: "Container/container.xml"),
+                    RelativeURL(path: "EPUB/content.opf")!: fixtures.url(for: "OPF/full-metadata.opf")
+                ]),
+            ),
+            encryptions: [:]
+        )
+        
+        let manifest = try await sut.parseManifest()
+        
+        XCTAssertEqual(
+            manifest,
+            Manifest(
+                metadata: Metadata(
+                    identifier: "urn:uuid:7408D53A-5383-40AA-8078-5256C872AE41",
+                    conformsTo: [.epub],
+                    title: "Alice's Adventures in Wonderland",
+                    subtitle: "Alice returns to the magical world from her childhood adventure",
+                    accessibility: Accessibility(
+                        certification: Accessibility.Certification(
+                            certifiedBy: "EDRLab"
+                        )
+                    ),
+                    modified: "2012-04-02T12:47:00Z".dateFromISO8601,
+                    published: "1865-07-04".dateFromISO8601,
+                    languages: ["en-GB", "en"],
+                    subjects: [
+                        Subject(name: "fiction"),
+                        Subject(name: "classic", scheme: "thema", code: "DCA"),
+                    ],
+                    authors: [Contributor(name: "Lewis Carroll")],
+                    publishers: [Contributor(name: "D. Appleton and Co")],
+                    readingProgression: .rtl,
+                    description: "The book description.",
+                    numberOfPages: 42,
+                    otherMetadata: [
+                        "http://purl.org/dc/terms/source": [
+                            "Feedbooks",
+                            [
+                                "@value": "Web",
+                                "http://my.url/#scheme": "http",
+                            ],
+                            "Internet",
+                        ] as [Any],
+                        "http://purl.org/dc/terms/rights": "Public Domain",
+                        "http://idpf.org/epub/vocab/package/#type": "article",
+                        "http://my.url/#customProperty": [
+                            "@value": "Custom property",
+                            "http://my.url/#refine1": "Refine 1",
+                            "http://my.url/#refine2": "Refine 2",
+                        ],
+                        "http://purl.org/dc/terms/format": "application/epub+zip",
+                        "presentation": [
+                            "continuous": false,
+                            "spread": "both",
+                            "overflow": "scrolled",
+                            "orientation": "landscape",
+                            "layout": "fixed",
+                        ] as [String: Any],
+                    ]
+                ),
+                readingOrder: [
+                    link(id: "titlepage", href: "EPUB/titlepage.xhtml", mediaType: .xhtml),
+                    link(id: "chapter01", href: "EPUB/chapter01.xhtml", mediaType: .xhtml),
+                ],
+                resources: [
+                    link(id: "font0", href: "EPUB/fonts/MinionPro.otf", mediaType: MediaType("application/vnd.ms-opentype")!),
+                    link(id: "nav", href: "EPUB/nav.xhtml", mediaType: .xhtml, rels: [.contents]),
+                    link(id: "css", href: "EPUB/style.css", mediaType: .css),
+                    link(id: "img01a", href: "EPUB/images/alice01a.gif", mediaType: .gif, rels: [.cover]),
+                    link(id: "img02a", href: "EPUB/images/alice02a.gif", mediaType: .gif),
+                ]
+            )
+        )
+    }
+    
+    private func link(
+        id: String? = nil,
+        href: String,
+        mediaType: MediaType? = nil,
+        templated: Bool = false,
+        title: String? = nil,
+        rels: [LinkRelation] = [],
+        properties: Properties = .init(),
+        children: [Link] = []
+    ) -> Link {
+        var properties = properties.otherProperties
+        if let id = id {
+            properties["id"] = id
+        }
+        return Link(href: href, mediaType: mediaType, templated: templated, title: title, rels: rels, properties: Properties(properties), children: children)
+    }
+}
+

--- a/Tests/StreamerTests/Parser/EPUB/NavigationDocumentParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/NavigationDocumentParserTests.swift
@@ -63,8 +63,8 @@ class NavigationDocumentParserTests: XCTestCase {
             Link(href: "/base/cover.xhtml", title: "Cover", rel: .cover),
             Link(href: "/base/nav.xhtml#toc", title: "Table of Contents", rel: .contents),
             Link(href: "/base/ch1.xhtml", title: "Begin Reading", rel: .start),
-            Link(href: "/base/index.xhtml", title: "Index", rel: "http://www.idpf.org/2007/ops#index"),
-            Link(href: "/base/glossary.xhtml", title: "Glossary", rel: "http://www.idpf.org/2007/ops#glossary"),
+            Link(href: "/base/index.xhtml", title: "Index"),
+            Link(href: "/base/glossary.xhtml", title: "Glossary"),
         ])
     }
 

--- a/Tests/StreamerTests/Parser/EPUB/NavigationDocumentParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/NavigationDocumentParserTests.swift
@@ -63,8 +63,8 @@ class NavigationDocumentParserTests: XCTestCase {
             Link(href: "/base/cover.xhtml", title: "Cover", rel: .cover),
             Link(href: "/base/nav.xhtml#toc", title: "Table of Contents", rel: .contents),
             Link(href: "/base/ch1.xhtml", title: "Begin Reading", rel: .start),
-            Link(href: "/base/index.xhtml", title: "Index"),
-            Link(href: "/base/glossary.xhtml", title: "Glossary"),
+            Link(href: "/base/index.xhtml", title: "Index", rel: "http://idpf.org/epub/vocab/structure/#index"),
+            Link(href: "/base/glossary.xhtml", title: "Glossary", rel: "http://idpf.org/epub/vocab/structure/#glossary"),
         ])
     }
 

--- a/Tests/StreamerTests/Parser/EPUB/NavigationDocumentParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/NavigationDocumentParserTests.swift
@@ -33,8 +33,8 @@ class NavigationDocumentParserTests: XCTestCase {
         let sut = document.links(for: .landmarks)
 
         XCTAssertEqual(sut, [
-            Link(href: "/base/nav.xhtml#toc", title: "Table of Contents"),
-            Link(href: "/base/ch1.xhtml", title: "Begin Reading"),
+            Link(href: "/base/nav.xhtml#toc", title: "Table of Contents", rel: .contents),
+            Link(href: "/base/ch1.xhtml", title: "Begin Reading", rel: .start),
         ])
     }
 
@@ -60,8 +60,11 @@ class NavigationDocumentParserTests: XCTestCase {
         let sut = document.links(for: .landmarks)
 
         XCTAssertEqual(sut, [
-            Link(href: "/base/nav.xhtml#toc", title: "Table of Contents"),
-            Link(href: "/base/ch1.xhtml", title: "Begin Reading"),
+            Link(href: "/base/cover.xhtml", title: "Cover", rel: .cover),
+            Link(href: "/base/nav.xhtml#toc", title: "Table of Contents", rel: .contents),
+            Link(href: "/base/ch1.xhtml", title: "Begin Reading", rel: .start),
+            Link(href: "/base/index.xhtml", title: "Index", rel: "http://www.idpf.org/2007/ops#index"),
+            Link(href: "/base/glossary.xhtml", title: "Glossary", rel: "http://www.idpf.org/2007/ops#glossary"),
         ])
     }
 


### PR DESCRIPTION
### Added

#### Navigator

* New link `rels` in the `readingOrder` and EPUB `landmarks` to mark:
    * `cover`: the title page
    * `contents`: the table of contents
    * `start`: the first actual chapter
