### PR TITLE
Parse EPUB 2 guide as EPUB 3 landmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * A new `InputObserving` API has been added to enable more flexible gesture recognition and support for mouse pointers. [See the dedicated user guide](docs/Guides/Navigator/Input.md).
 
+#### Streamer
+
+* The EPUB 2 `<guide>` element is now parsed into the RWPM `landmarks` subcollection when no EPUB 3 `landmarks` navigation document is declared.
+
 ### Fixed
 
 #### Navigator

--- a/Sources/Internal/Extensions/String.swift
+++ b/Sources/Internal/Extensions/String.swift
@@ -91,4 +91,8 @@ public extension String {
         }
         return self
     }
+
+    func orNilIfBlank() -> String? {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
+    }
 }

--- a/Sources/Shared/Publication/Services/Content/Iterators/HTMLResourceContentIterator.swift
+++ b/Sources/Shared/Publication/Services/Content/Iterators/HTMLResourceContentIterator.swift
@@ -252,7 +252,7 @@ public class HTMLResourceContentIterator: ContentIterator {
                     flushText()
                     try node.srcRelativeToHREF(baseHREF).map { href in
                         var attributes: [ContentAttribute] = []
-                        if let alt = try node.attr("alt").takeUnlessBlank() {
+                        if let alt = try node.attr("alt").orNilIfBlank() {
                             attributes.append(ContentAttribute(key: .accessibilityLabel, value: alt))
                         }
 
@@ -277,7 +277,7 @@ public class HTMLResourceContentIterator: ContentIterator {
                                         try Link(
                                             href: href.string,
                                             mediaType: source.attr("type")
-                                                .takeUnlessBlank()
+                                                .orNilIfBlank()
                                                 .flatMap { MediaType($0) }
                                         )
                                     }
@@ -308,7 +308,7 @@ public class HTMLResourceContentIterator: ContentIterator {
 
         func tail(_ node: Node, _ depth: Int) throws {
             if let node = node as? TextNode {
-                guard let wholeText = node.getWholeText().takeUnlessBlank() else {
+                guard let wholeText = node.getWholeText().orNilIfBlank() else {
                     return
                 }
 
@@ -439,7 +439,7 @@ public class HTMLResourceContentIterator: ContentIterator {
 
 private extension Node {
     func srcRelativeToHREF(_ baseHREF: AnyURL?) throws -> AnyURL? {
-        try attr("src").takeUnlessBlank()
+        try attr("src").orNilIfBlank()
             .flatMap { AnyURL(string: $0) }
             .flatMap {
                 baseHREF?.resolve($0) ?? $0
@@ -447,15 +447,9 @@ private extension Node {
     }
 
     func language() throws -> String? {
-        try attr("xml:lang").takeUnlessBlank()
-            ?? attr("lang").takeUnlessBlank()
+        try attr("xml:lang").orNilIfBlank()
+            ?? attr("lang").orNilIfBlank()
             ?? parent()?.language()
-    }
-}
-
-private extension String {
-    func takeUnlessBlank() -> String? {
-        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
     }
 }
 
@@ -507,8 +501,8 @@ private extension Locator.Text {
         let trailingWhitespace = String(text[trailingWhitespaceIdx...])
 
         return Locator.Text(
-            after: trailingWhitespace.takeUnlessBlank(),
-            before: ((before ?? "") + leadingWhitespace).takeUnlessBlank(),
+            after: trailingWhitespace.orNilIfBlank(),
+            before: ((before ?? "") + leadingWhitespace).orNilIfBlank(),
             highlight: String(text[leadingWhitespaceIdx ..< trailingWhitespaceIdx])
         )
     }

--- a/Sources/Streamer/Parser/EPUB/Extensions/LinkRelation+EPUB.swift
+++ b/Sources/Streamer/Parser/EPUB/Extensions/LinkRelation+EPUB.swift
@@ -7,12 +7,23 @@
 import ReadiumShared
 
 extension LinkRelation {
-    init?(epubType: String) {
-        self = switch epubType {
+    init?(epubType type: String) {
+        self = switch type {
         case "cover": .cover
         case "toc": .contents
         case "bodymatter": .start
-        default: LinkRelation("http://idpf.org/epub/vocab/structure/#\(epubType)")
+        default: LinkRelation("http://idpf.org/epub/vocab/structure/#\(type)")
         }
+    }
+
+    init?(epub2Type type: String) {
+        let asEPUB3Type = switch type {
+        case "title-page": "titlepage"
+        case "text": "bodymatter"
+        case "acknowledgements": "acknowledgments"
+        case "notes": "endnotes"
+        default: type
+        }
+        self.init(epubType: asEPUB3Type)
     }
 }

--- a/Tests/StreamerTests/Fixtures/OPF/guide-epub2.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/guide-epub2.opf
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>Alice's Adventures in Wonderland</dc:title>
+    <meta name="cover" content="cover" />
+  </metadata>
+  <manifest>
+    <item id="cover" href="cover.jpg" media-type="image/jpeg" />
+    <item id="titlepage" href="titlepage.xhtml" media-type="application/xhtml+xml" />
+    <item id="beginpage" href="beginpage.xhtml" media-type="application/xhtml+xml" />
+  </manifest>
+  <spine>
+    <itemref idref="titlepage"/>
+    <itemref idref="beginpage"/>
+  </spine>
+  <guide>
+          <reference type="toc" title="Table of Contents"
+                   href="toc.xhtml" />
+          <reference type="loi" title="List Of Illustrations"
+                   href="toc.xhtml#figures" />
+          <reference type="text" title="Introduction"
+                   href="beginpage.xhtml" />
+  </guide>
+</package>

--- a/Tests/StreamerTests/Parser/EPUB/EPUBManifestParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/EPUBManifestParserTests.swift
@@ -107,6 +107,32 @@ class EPUBManifestParserTests: XCTestCase {
         )
     }
 
+    func testParseEPUB2GuideAsLandmarks() async throws {
+        let sut = parser(files: [
+            "META-INF/container.xml": "Container/container.xml",
+            "EPUB/content.opf": "OPF/guide-epub2.opf",
+        ])
+
+        let manifest = try await sut.parseManifest()
+
+        XCTAssertEqual(
+            manifest.subcollections["landmarks"],
+            [PublicationCollection(links: [
+                link(href: "EPUB/toc.xhtml", title: "Table of Contents", rels: [.contents]),
+                link(href: "EPUB/toc.xhtml#figures", title: "List Of Illustrations", rels: ["http://idpf.org/epub/vocab/structure/#loi"]),
+                link(href: "EPUB/beginpage.xhtml", title: "Introduction", rels: [.start]),
+            ])]
+        )
+
+        XCTAssertEqual(
+            manifest.readingOrder,
+            [
+                link(id: "titlepage", href: "EPUB/titlepage.xhtml", mediaType: .xhtml),
+                link(id: "beginpage", href: "EPUB/beginpage.xhtml", mediaType: .xhtml, rels: [.start]),
+            ]
+        )
+    }
+
     private func parser(files: [String: String]) -> EPUBManifestParser {
         EPUBManifestParser(
             container: FileContainer(files: files.reduce(into: [:]) { files, item in


### PR DESCRIPTION
### Added

#### Streamer

* The EPUB 2 `<guide>` element is now parsed into the RWPM `landmarks` subcollection when no EPUB 3 `landmarks` navigation document is declared.