### PR TITLE
Fix extracting the cover from the manifest

### DIFF
--- a/Sources/Shared/Publication/Services/Cover/CoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/CoverService.swift
@@ -69,10 +69,13 @@ public extension Publication {
     /// Extracts the first valid cover from the manifest links with `cover` relation.
     private func coverFromManifest() async -> ReadResult<UIImage?> {
         for link in linksWithRel(.cover) {
-            if let resource = get(link) {
-                return await resource.read()
-                    .map { UIImage(data: $0) }
+            guard let image = await get(link)?
+                .read().getOrNil()
+                .flatMap({ UIImage(data: $0) })
+            else {
+                continue
             }
+            return .success(image)
         }
         return .success(nil)
     }

--- a/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
@@ -53,6 +53,9 @@ class CoverServiceTests: XCTestCase {
                 metadata: Metadata(
                     title: "title"
                 ),
+                readingOrder: [
+                    Link(href: "titlepage.xhtml", rels: [.cover]),
+                ],
                 resources: [
                     Link(href: coverPath, rels: [.cover]),
                 ]


### PR DESCRIPTION
Fixes a regression introduced in #602. Now that we can have XHTML resources in the `readingOrder` with a `cover` rel, we need to take it into account when extracting a bitmap cover in the `CoverService` fallback.