### PR TITLE
Add a SwiftUI LCP authentication dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * The EPUB 2 `<guide>` element is now parsed into the RWPM `landmarks` subcollection when no EPUB 3 `landmarks` navigation document is declared.
 
+#### LCP
+
+* A brand new LCP authentication dialog for SwiftUI applications. [See the accompanying user guide](docs/Guides/Readium%20LCP.md).
+
 ### Fixed
 
 #### Navigator

--- a/Sources/LCP/Authentications/LCPDialog.swift
+++ b/Sources/LCP/Authentications/LCPDialog.swift
@@ -1,0 +1,244 @@
+//
+//  Copyright 2025 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import SwiftUI
+
+/// A SwiftUI dialog used to prompt the user for its LCP passphrase.
+///
+/// You can use ``LCPDialog`` with an ``LCPObservableAuthentication`` to
+/// implement the whole LCP authentication flow in SwiftUI.
+///
+/// ```
+/// import ReadiumLCP
+///
+/// @main
+/// struct MyApp: App {
+///     private let lcpService: LCPService
+///     private let publicationOpener: PublicationOpener
+///
+///     @StateObject private var lcpAuthentication: LCPObservableAuthentication
+///
+///     init() {
+///         let lcpAuthentication = LCPObservableAuthentication()
+///         _lcpAuthentication = StateObject(wrappedValue: lcpAuthentication)
+///
+///         lcpService = LCPService(...)
+///
+///         publicationOpener = PublicationOpener(
+///            ...,
+///            contentProtections: [
+///                lcpService.contentProtection(with: lcpAuthentication)
+///            ]
+///         )
+///     }
+///
+///    var body: some Scene {
+///        WindowGroup {
+///            ContentView()
+///                .sheet(item: $lcpAuthentication.request) {
+///                    LCPDialog(request: $0)
+///                }
+///            }
+///        }
+///    }
+/// }
+/// ```
+@available(iOS 16.0, *)
+public struct LCPDialog: View {
+    public enum ErrorMessage {
+        case incorrectPassphrase
+
+        var string: String {
+            switch self {
+            case .incorrectPassphrase:
+                ReadiumLCPLocalizedString("dialog.error.incorrectPassphrase")
+            }
+        }
+    }
+
+    public var id: LCPDialog { self }
+
+    private let hint: String?
+    private let errorMessage: ErrorMessage?
+    private let onSubmit: (String) -> Void
+    private let onForgotPassphrase: (() -> Void)?
+
+    private let openButtonId = "open"
+
+    public init(
+        hint: String?,
+        errorMessage: ErrorMessage?,
+        onSubmit: @escaping (String) -> Void,
+        onForgotPassphrase: (() -> Void)?
+    ) {
+        self.hint = hint
+        self.errorMessage = errorMessage
+        self.onSubmit = onSubmit
+        self.onForgotPassphrase = onForgotPassphrase
+    }
+
+    public init(
+        request: LCPObservableAuthentication.Request
+    ) {
+        self.init(
+            hint: request.license.hint.orNilIfBlank(),
+            errorMessage: request.reason == .invalidPassphrase ? .incorrectPassphrase : nil,
+            onSubmit: { passphrase in
+                request.submit(passphrase)
+            },
+            onForgotPassphrase: request.license.hintLink?.url().map { url in
+                { UIApplication.shared.open(url.url) }
+            }
+        )
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var isFieldFocused
+    @State private var passphrase: String = ""
+
+    public var body: some View {
+        NavigationStack {
+            ScrollViewReader { scrollProxy in
+                Form {
+                    header
+                    input
+                    buttons
+                }
+                .onAppear {
+                    isFieldFocused = true
+                }
+                .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+                    // Wait for the @StateFocus animation to settle before
+                    // scrolling, otherwise it won't work.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        withAnimation {
+                            scrollProxy.scrollTo(openButtonId, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .navigationTitle(ReadiumLCPLocalizedStringKey("dialog.title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(ReadiumLCPLocalizedStringKey("dialog.cancel"), role: .cancel) {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var header: some View {
+        Section {
+            HStack {
+                Spacer()
+                VStack(spacing: 20) {
+                    Image(systemName: "lock.document.fill")
+                        .foregroundStyle(.blue)
+                        .font(.system(size: 70))
+
+                    Text(ReadiumLCPLocalizedStringKey("dialog.header"))
+                        .multilineTextAlignment(.center)
+                        .padding(.bottom, 16)
+                }
+                Spacer()
+            }
+
+            DisclosureGroup(ReadiumLCPLocalizedStringKey("dialog.details.title")) {
+                VStack(spacing: 16) {
+                    Text(ReadiumLCPLocalizedStringKey("dialog.details.body"))
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Text("[\(ReadiumLCPLocalizedString("dialog.details.more"))](https://www.edrlab.org/readium-lcp/)")
+
+                    Text(ReadiumLCPLocalizedStringKey("dialog.forgotYourPassphrase.help"))
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .alignmentGuide(.listRowSeparatorLeading) { _ in
+            0
+        }
+        .font(.callout)
+    }
+
+    @ViewBuilder private var input: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                TextField(text: $passphrase) {
+                    Text(ReadiumLCPLocalizedStringKey("dialog.passphrase.placeholder"))
+                }
+                .textInputAutocapitalization(.never)
+                .focused($isFieldFocused)
+                .submitLabel(.continue)
+                .onSubmit {
+                    submit()
+                }
+
+                if let errorMessage = errorMessage {
+                    HStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.circle")
+                        Text(errorMessage.string)
+                    }
+                    .foregroundStyle(.red)
+                    .font(.callout)
+                }
+            }
+        } footer: {
+            if let hint = hint {
+                Text(ReadiumLCPLocalizedStringKey("dialog.hint", hint))
+            }
+        }
+        .listRowSeparator(.hidden)
+    }
+
+    @ViewBuilder private var buttons: some View {
+        Section {
+            Button(ReadiumLCPLocalizedStringKey("dialog.continue")) {
+                submit()
+            }
+            .bold()
+            .id(openButtonId)
+            .disabled(passphrase.isEmpty)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+
+        if let onForgotPassphrase = onForgotPassphrase {
+            Section {
+                Button(ReadiumLCPLocalizedStringKey("dialog.forgotYourPassphrase"), role: .destructive) {
+                    onForgotPassphrase()
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+    }
+
+    private func submit() {
+        guard !passphrase.isEmpty else {
+            return
+        }
+
+        onSubmit(passphrase)
+        dismiss()
+    }
+}
+
+#Preview {
+    if #available(iOS 18.0, *) {
+        Spacer().sheet(isPresented: .constant(true)) {
+            LCPDialog(
+                hint: "Visit your library to know your password",
+                errorMessage: .incorrectPassphrase,
+                onSubmit: { _ in },
+                onForgotPassphrase: {}
+            )
+        }
+    }
+}

--- a/Sources/LCP/Authentications/LCPObservableAuthentication.swift
+++ b/Sources/LCP/Authentications/LCPObservableAuthentication.swift
@@ -1,0 +1,96 @@
+//
+//  Copyright 2025 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import SwiftUI
+
+/// An ``LCPAuthenticating`` implementation which can be used to observe
+/// authentication requests.
+///
+/// Pair an ``LCPObservableAuthentication``  with an ``LCPDialog`` to implement
+/// the LCP authentication in SwiftUI.
+@MainActor
+public final class LCPObservableAuthentication: LCPAuthenticating, ObservableObject {
+    /// Represents an on-going LCP authentication request.
+    ///
+    /// You must call the `submit()` or `cancel()` API to conclude the request.
+    @MainActor
+    public final class Request: Identifiable {
+        /// LCP License requested to be unlocked.
+        public let license: LCPAuthenticatedLicense
+
+        /// Reason for this authentication request.
+        public let reason: LCPAuthenticationReason
+
+        /// Sender given to the component requesting the authentication.
+        ///
+        /// For example, this is the `sender` you provided to the
+        /// `PublicationOpener.open()` API.
+        ///
+        /// Readium does not use this internally. You can pass any object to
+        /// help you determine how to present the LCP authentication dialog.
+        public let sender: Any?
+
+        private var continuation: CheckedContinuation<String?, Never>?
+
+        init(
+            license: LCPAuthenticatedLicense,
+            reason: LCPAuthenticationReason,
+            sender: Any?,
+            continuation: CheckedContinuation<String?, Never>
+        ) {
+            self.license = license
+            self.reason = reason
+            self.sender = sender
+            self.continuation = continuation
+        }
+
+        /// Terminates this authentication request by providing the given
+        /// `passphrase`.
+        public func submit(_ passphrase: String) {
+            continuation?.resume(returning: passphrase)
+            continuation = nil
+        }
+
+        /// Terminates this authentication request by cancelling it.
+        public func cancel() {
+            continuation?.resume(returning: nil)
+            continuation = nil
+        }
+    }
+
+    /// The current authentication request.
+    ///
+    /// Setting it to `nil` automatically cancels the previous request.
+    @Published public var request: Request? {
+        didSet { oldValue?.cancel() }
+    }
+
+    private var continuation: CheckedContinuation<String?, Never>?
+
+    public init() {}
+
+    public func retrievePassphrase(
+        for license: LCPAuthenticatedLicense,
+        reason: LCPAuthenticationReason,
+        allowUserInteraction: Bool,
+        sender: Any?
+    ) async -> String? {
+        guard allowUserInteraction else {
+            return nil
+        }
+
+        continuation?.resume(returning: nil)
+
+        return await withCheckedContinuation {
+            self.request = Request(
+                license: license,
+                reason: reason,
+                sender: sender,
+                continuation: $0
+            )
+        }
+    }
+}

--- a/Sources/LCP/License/Model/Components/Link.swift
+++ b/Sources/LCP/License/Model/Components/Link.swift
@@ -50,7 +50,7 @@ public struct Link {
 
     /// Gets the valid URL if possible, applying the given template context as query parameters if the link is templated.
     /// eg. http://url{?id,name} + [id: x, name: y] -> http://url?id=x&name=y
-    func url(parameters: [String: LosslessStringConvertible] = [:]) -> HTTPURL? {
+    public func url(parameters: [String: LosslessStringConvertible] = [:]) -> HTTPURL? {
         var href = href
 
         if templated {
@@ -60,12 +60,12 @@ public struct Link {
         return HTTPURL(string: href)
     }
 
-    var mediaType: MediaType? {
+    public var mediaType: MediaType? {
         type.flatMap { MediaType($0) }
     }
 
     /// List of URI template parameter keys, if the `Link` is templated.
-    var templateParameters: Set<String> {
+    public var templateParameters: Set<String> {
         guard templated else {
             return []
         }

--- a/Sources/LCP/Resources/en.lproj/Localizable.strings
+++ b/Sources/LCP/Resources/en.lproj/Localizable.strings
@@ -6,6 +6,21 @@
 
 /* LCP Dialog Authentication */
 
+"ReadiumLCP.dialog.title" = "Enter Password";
+"ReadiumLCP.dialog.cancel" = "Cancel";
+"ReadiumLCP.dialog.continue" = "Continue";
+"ReadiumLCP.dialog.forgotYourPassphrase" = "Forgot your password?";
+"ReadiumLCP.dialog.forgotYourPassphrase.help" = "Forgot your passphrase? Use the button below to request a new one from your library or bookstore.";
+"ReadiumLCP.dialog.hint" = "**Hint:** %@";
+"ReadiumLCP.dialog.header" = "This publication requires an LCP password to open, which is provided by your library or bookstore. Enter it once, and you're all set to read on this device.";
+"ReadiumLCP.dialog.details.title" = "What is LCP?";
+"ReadiumLCP.dialog.details.body" = "This publication is protected by LCP (Licensed Content Protection), a DRM technology that prevents unauthorized copying while keeping your reading experience simple. LCP is an open standard that balances user-friendliness with the needs of publishers.";
+"ReadiumLCP.dialog.details.more" = "Learn more…";
+"ReadiumLCP.dialog.passphrase.placeholder" = "Password";
+"ReadiumLCP.dialog.error.incorrectPassphrase" = "Incorrect password.";
+
+// MARK: - Legacy strings (LCPDialogViewController)
+
 /* Prompt messages when asking for the passphrase */
 "ReadiumLCP.dialog.prompt.message1" = "This publication is protected by Readium LCP.";
 "ReadiumLCP.dialog.prompt.message2" = "In order to open it, we need to know the passphrase required by:\n\n%@\n\nTo help you remember it, the following hint is available:";
@@ -21,8 +36,6 @@
 "ReadiumLCP.dialog.prompt.continue" = "Continue";
 /* Passphrase placeholder */
 "ReadiumLCP.dialog.prompt.passphrase" = "Passphrase";
-/* Cancel button */
-"ReadiumLCP.dialog.cancel" = "Cancel";
 
 /* Button to contact the support when entering the passphrase */
 "ReadiumLCP.dialog.support" = "Support";

--- a/Sources/LCP/Toolkit/ReadiumLCPLocalizedString.swift
+++ b/Sources/LCP/Toolkit/ReadiumLCPLocalizedString.swift
@@ -6,7 +6,12 @@
 
 import Foundation
 import ReadiumShared
+import SwiftUICore
 
 func ReadiumLCPLocalizedString(_ key: String, _ values: CVarArg...) -> String {
     ReadiumLocalizedString("ReadiumLCP.\(key)", in: Bundle.module, values)
+}
+
+func ReadiumLCPLocalizedStringKey(_ key: String, _ values: CVarArg...) -> LocalizedStringKey {
+    LocalizedStringKey(ReadiumLCPLocalizedString(key, values))
 }

--- a/Sources/LCP/Toolkit/ReadiumLCPLocalizedString.swift
+++ b/Sources/LCP/Toolkit/ReadiumLCPLocalizedString.swift
@@ -9,6 +9,10 @@ import ReadiumShared
 import SwiftUICore
 
 func ReadiumLCPLocalizedString(_ key: String, _ values: CVarArg...) -> String {
+    ReadiumLCPLocalizedString(key, values)
+}
+
+func ReadiumLCPLocalizedString(_ key: String, _ values: [CVarArg]) -> String {
     ReadiumLocalizedString("ReadiumLCP.\(key)", in: Bundle.module, values)
 }
 

--- a/Support/Carthage/.xcodegen
+++ b/Support/Carthage/.xcodegen
@@ -334,8 +334,10 @@
 ../../Sources/LCP/Authentications/Base.lproj
 ../../Sources/LCP/Authentications/Base.lproj/LCPDialogViewController.xib
 ../../Sources/LCP/Authentications/LCPAuthenticating.swift
+../../Sources/LCP/Authentications/LCPDialog.swift
 ../../Sources/LCP/Authentications/LCPDialogAuthentication.swift
 ../../Sources/LCP/Authentications/LCPDialogViewController.swift
+../../Sources/LCP/Authentications/LCPObservableAuthentication.swift
 ../../Sources/LCP/Authentications/LCPPassphraseAuthentication.swift
 ../../Sources/LCP/Content Protection
 ../../Sources/LCP/Content Protection/EncryptionParser.swift

--- a/Support/Carthage/Readium.xcodeproj/project.pbxproj
+++ b/Support/Carthage/Readium.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		69AA254E4A39D9B49FDFD648 /* UserKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC96A56AB406203898059B6C /* UserKey.swift */; };
 		69FDA9FBD2BA1775F73B3CE0 /* DefaultFormatSniffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3996B9F88089C7F752C531 /* DefaultFormatSniffer.swift */; };
 		6ADC5DF691179D611442787E /* ReadiumShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97BC822B36D72EF548162129 /* ReadiumShared.framework */; };
+		6B08C5FB1ABF696CDB6EDB03 /* LCPObservableAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791CEAC3DA5ED971DAE984CB /* LCPObservableAuthentication.swift */; };
 		6BE745329D68EE0533E42D14 /* DiffableDecoration+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01265194649A8E2A821CC2A4 /* DiffableDecoration+HTML.swift */; };
 		6C3C96A32EA2439AAEFD4967 /* ReadiumNavigatorLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBFAC2D57DE7EBB4E2F31BE /* ReadiumNavigatorLocalizedString.swift */; };
 		6D3BCAFF29D91DCA08809D71 /* CRLService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93B0556DAAAF429893B0692 /* CRLService.swift */; };
@@ -355,6 +356,7 @@
 		E39B7BCA5ACB6D33C47FCB38 /* MinizipArchiveOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CE7AFF3ECCD705A80685BB /* MinizipArchiveOpener.swift */; };
 		E408BBB74A13AFB83C953C67 /* Properties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76638D3D1220E4C2620B9A80 /* Properties.swift */; };
 		E42CCC4CB1D491564664B5B6 /* Configurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AD6A912937694B20AD54C9 /* Configurable.swift */; };
+		E45004E1BE7189DD9B5BC377 /* LCPDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02248F01B66C1151614EF15 /* LCPDialog.swift */; };
 		E58910A3992CC88DE5BC0AA0 /* AudioLocatorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB6D68278E0A593C810E2C0 /* AudioLocatorService.swift */; };
 		E5D440B49453AC615946E7FB /* PDFPositionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C2A38D366CE8560BCBAC8B /* PDFPositionsService.swift */; };
 		E6554CEB01222DA2255163D5 /* AVTTSEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15C9123EA383ED81DE0393A /* AVTTSEngine.swift */; };
@@ -659,6 +661,7 @@
 		789B56D6D8A6AA79CD3643F4 /* CachingResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingResource.swift; sourceTree = "<group>"; };
 		78E5D0B9449607B2906901C2 /* LanguageFormatSniffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFormatSniffer.swift; sourceTree = "<group>"; };
 		78FFDF8CF77437EDB41E4547 /* FailureResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailureResource.swift; sourceTree = "<group>"; };
+		791CEAC3DA5ED971DAE984CB /* LCPObservableAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPObservableAuthentication.swift; sourceTree = "<group>"; };
 		79CE7AFF3ECCD705A80685BB /* MinizipArchiveOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinizipArchiveOpener.swift; sourceTree = "<group>"; };
 		7BB152578CBA091A41A51B25 /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Language.swift; sourceTree = "<group>"; };
 		7BBD54FD376456C1925316BC /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
@@ -714,6 +717,7 @@
 		9ECD1D0BE2C4BB5B58E32BFD /* AudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSession.swift; sourceTree = "<group>"; };
 		9F8A0C50FD8E808C7A9F4D87 /* JSONFormatSniffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONFormatSniffer.swift; sourceTree = "<group>"; };
 		9FAAD26EE52713DB9F103610 /* Group.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Group.swift; sourceTree = "<group>"; };
+		A02248F01B66C1151614EF15 /* LCPDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPDialog.swift; sourceTree = "<group>"; };
 		A0A5959877EC9688CB0C370E /* Signature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signature.swift; sourceTree = "<group>"; };
 		A214B5DC13576FB36935B5EA /* LCPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPClient.swift; sourceTree = "<group>"; };
 		A266D398324C20079B0780BC /* LCPError+wrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LCPError+wrap.swift"; sourceTree = "<group>"; };
@@ -1558,9 +1562,11 @@
 			isa = PBXGroup;
 			children = (
 				2CB0BFECA8236412881393AA /* LCPAuthenticating.swift */,
+				A02248F01B66C1151614EF15 /* LCPDialog.swift */,
 				77392C999C0EFF83C8F2A47F /* LCPDialogAuthentication.swift */,
 				0BB64178365BFA9ED75C7078 /* LCPDialogViewController.swift */,
 				ED5C6546C24E5E619E4CC9D1 /* LCPDialogViewController.xib */,
+				791CEAC3DA5ED971DAE984CB /* LCPObservableAuthentication.swift */,
 				1D5053C2151DDDE4E8F06513 /* LCPPassphraseAuthentication.swift */,
 			);
 			path = Authentications;
@@ -2527,12 +2533,14 @@
 				A13490DA4406382752B8EA2B /* LCPClient.swift in Sources */,
 				4C6E7DF3D71660E723E148CF /* LCPContentProtection.swift in Sources */,
 				BB457884B7AFAEC3F52E8CE3 /* LCPDecryptor.swift in Sources */,
+				E45004E1BE7189DD9B5BC377 /* LCPDialog.swift in Sources */,
 				4C22206EA313899BBC6385C6 /* LCPDialogAuthentication.swift in Sources */,
 				B066F9DDCD00A8917478CB6C /* LCPDialogViewController.swift in Sources */,
 				25349166318EB00EE8A0765C /* LCPError+wrap.swift in Sources */,
 				98702AFB56F9C50F7246CDDA /* LCPError.swift in Sources */,
 				C4F0A98562FDDB478F7DD0A9 /* LCPLicense.swift in Sources */,
 				9A463F872E1B05B64E026EBB /* LCPLicenseRepository.swift in Sources */,
+				6B08C5FB1ABF696CDB6EDB03 /* LCPObservableAuthentication.swift in Sources */,
 				F90CF6CE1D4F5FA195E19D76 /* LCPPassphraseAuthentication.swift in Sources */,
 				349F6BB9FDD28532C2B030EC /* LCPPassphraseRepository.swift in Sources */,
 				2EEC1F0DF4BA4B8B1820FF9B /* LCPProgress.swift in Sources */,


### PR DESCRIPTION
### Added

#### LCP

* A brand new LCP authentication dialog for SwiftUI applications. 


<img width="361" alt="Screenshot 2025-06-10 at 14 22 05" src="https://github.com/user-attachments/assets/5fd6813c-26ae-428d-8fe9-ca6aad869b4e" />
<img width="359" alt="Screenshot 2025-06-10 at 14 22 14" src="https://github.com/user-attachments/assets/4149047c-5847-4b33-b115-293f1316d2fb" />



## Using the SwiftUI LCP Authentication dialog

If your application is built using SwiftUI, you cannot use `LCPAuthenticationDialog` because it requires a UIKit view controller as its host. Instead, use an `LCPObservableAuthentication` combined with our SwiftUI `LCPDialog` presented as a sheet.

```swift
@main
struct MyApp: App {
    private let lcpService: LCPService
    private let publicationOpener: PublicationOpener

    @StateObject private var lcpAuthentication: LCPObservableAuthentication

    init() {
        // Create an `LCPObservableAuthentication` which will be used
        // to initialize the `LCPContentProtection`.
        //
        // With SwiftUI, it must be stored in a `@StateObject` property
        // to observe the authentication requests.
        let lcpAuthentication = LCPObservableAuthentication()
        _lcpAuthentication = StateObject(wrappedValue: lcpAuthentication)

        lcpService = LCPService(...)

        publicationOpener = PublicationOpener(
            ...,
            contentProtections: [
                lcpService.contentProtection(with: lcpAuthentication)
            ]
        )
    }

    var body: some Scene {
        WindowGroup {
            ContentView()
                // You can present an `LCPDialog` when the `LCPObservableAuthentication`
                // `request` property is updated.
                .sheet(item: $lcpAuthentication.request) {
                    LCPDialog(request: $0)
                }
            }
        }
    }
}
```