### PR TITLE
Add resource_bundles back to ReadiumShared podspec

### DIFF
--- a/Support/CocoaPods/ReadiumShared.podspec
+++ b/Support/CocoaPods/ReadiumShared.podspec
@@ -8,6 +8,9 @@ Pod::Spec.new do |s|
   s.author       = { "Readium" => "contact@readium.org" }
   s.source       = { :git => 'https://github.com/readium/swift-toolkit.git', :tag => s.version }
   s.requires_arc = true
+  s.resource_bundles = {
+    "ReadiumShared" => ["Sources/Shared/Resources/**"],
+  }
   s.source_files  = "Sources/Shared/**/*.{m,h,swift}"
   s.swift_version = '5.10'
   s.platform     = :ios


### PR DESCRIPTION
Resolves #616

The addition of the localised string resources for the `AccessibilityMetadataDisplayGuide` require declaring in the podspec's `s.resource_bundles` so they get bundled correctly. This is required for React Native when using Cocoapods.