### PR TITLE
Add the scroll progressions in the EPUB `viewport`

### DIFF
--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -131,12 +131,12 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
 
     // MARK: - Location and progression
 
-    override func progression(in index: ReadingOrder.Index) -> Range<Double> {
+    override func progression(in index: ReadingOrder.Index) -> ClosedRange<Double> {
         guard
             spread.leading == index,
             let progression = progression
         else {
-            return 0 ..< 0
+            return 0 ... 0
         }
         return progression
     }
@@ -319,9 +319,9 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
     // MARK: - Progression
 
     // Current progression range in the page.
-    private var progression: Range<Double>?
+    private var progression: ClosedRange<Double>?
     // To check if a progression change was cancelled or not.
-    private var previousProgression: Range<Double>?
+    private var previousProgression: ClosedRange<Double>?
 
     // Called by the javascript code to notify that scrolling ended.
     private func progressionDidChange(_ body: Any) {
@@ -340,7 +340,7 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
         if previousProgression == nil {
             previousProgression = progression
         }
-        progression = firstProgression ..< lastProgression
+        progression = firstProgression ... lastProgression
 
         setNeedsNotifyPagesDidChange()
     }

--- a/Sources/Navigator/EPUB/EPUBSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBSpreadView.swift
@@ -342,9 +342,9 @@ class EPUBSpreadView: UIView, Loggable, PageView {
     // MARK: - Location and progression.
 
     /// Current progression in the resource with given href.
-    func progression(in index: ReadingOrder.Index) -> Range<Double> {
+    func progression(in index: ReadingOrder.Index) -> ClosedRange<Double> {
         // To be overridden in subclasses if the resource supports a progression.
-        0 ..< 0
+        0 ... 1
     }
 
     func go(to location: PageLocation) async {


### PR DESCRIPTION
* Add the scroll progression ranges for each visible reading order resource in the EPUB's `viewport` object.
* Fixed viewport positions with FXL EPUB.