### PR TITLE
Add the ability to customize audio parser specifications and ignored file extensions

### DIFF
--- a/Sources/Shared/Toolkit/Format/Sniffers/AudiobookFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/AudiobookFormatSniffer.swift
@@ -74,9 +74,7 @@ public struct ZABFormatSniffer: FormatSniffer {
         let entries = container.entries
             .filter {
                 $0.lastPathSegment?.hasPrefix(".") == false &&
-                    $0.lastPathSegment != "Thumbs.db" &&
-                    $0.pathExtension != "jpg" &&
-                    $0.pathExtension != .pdf
+                    $0.lastPathSegment != "Thumbs.db"
             }
         let containerExtensions = Set(entries.compactMap(\.pathExtension))
         guard

--- a/Sources/Shared/Toolkit/Format/Sniffers/AudiobookFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/AudiobookFormatSniffer.swift
@@ -74,9 +74,9 @@ public struct ZABFormatSniffer: FormatSniffer {
         let entries = container.entries
             .filter {
                 $0.lastPathSegment?.hasPrefix(".") == false &&
-                $0.lastPathSegment != "Thumbs.db" &&
-                $0.pathExtension != "jpg" &&
-                $0.pathExtension != .pdf
+                    $0.lastPathSegment != "Thumbs.db" &&
+                    $0.pathExtension != "jpg" &&
+                    $0.pathExtension != .pdf
             }
         let containerExtensions = Set(entries.compactMap(\.pathExtension))
         guard

--- a/Sources/Shared/Toolkit/Format/Sniffers/AudiobookFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/AudiobookFormatSniffer.swift
@@ -74,7 +74,9 @@ public struct ZABFormatSniffer: FormatSniffer {
         let entries = container.entries
             .filter {
                 $0.lastPathSegment?.hasPrefix(".") == false &&
-                    $0.lastPathSegment != "Thumbs.db"
+                $0.lastPathSegment != "Thumbs.db" &&
+                $0.pathExtension != "jpg" &&
+                $0.pathExtension != .pdf
             }
         let containerExtensions = Set(entries.compactMap(\.pathExtension))
         guard

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -120,6 +120,8 @@ public final class AudioParser: PublicationParser {
             "wpl",
             "xspf",
             "zpl",
+            "jpg",
+            "pdf"
         ]
 
         return url.pathExtension == nil

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -121,7 +121,7 @@ public final class AudioParser: PublicationParser {
             "xspf",
             "zpl",
             "jpg",
-            "pdf"
+            "pdf",
         ]
 
         return url.pathExtension == nil

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -12,18 +12,15 @@ import ReadiumShared
 ///
 /// It can also work for a standalone audio file.
 public final class AudioParser: PublicationParser {
-    private let assetRetriever: AssetRetriever
-    private let manifestAugmentor: AudioPublicationManifestAugmentor
+    /// The default set of audio format specifications that determine whether an archive qualifies as an audiobook.
+    /// These formats include common audio file types such as MP3, AAC, FLAC, etc.
+    public static let defaultAudioSpecifications: Set<FormatSpecification> = audioSpecifications
 
-    public init(
-        assetRetriever: AssetRetriever,
-        manifestAugmentor: AudioPublicationManifestAugmentor = AVAudioPublicationManifestAugmentor()
-    ) {
-        self.assetRetriever = assetRetriever
-        self.manifestAugmentor = manifestAugmentor
-    }
+    /// A set of file extensions that are ignored during audiobook processing.
+    /// These typically include playlist files, metadata, or auxiliary files that should not be treated as audio content.
+    public static let defaultIgnoredExtensions: Set<FileExtension> = ignoredExtensions
 
-    private let audioSpecifications: Set<FormatSpecification> = [
+    private static let audioSpecifications: Set<FormatSpecification> = [
         .aac,
         .aiff,
         .flac,
@@ -34,6 +31,38 @@ public final class AudioParser: PublicationParser {
         .wav,
         .webm,
     ]
+
+    private static let ignoredExtensions: Set<FileExtension> = [
+        "asx",
+        "bio",
+        "m3u",
+        "m3u8",
+        "pla",
+        "pls",
+        "smil",
+        "txt",
+        "vlc",
+        "wpl",
+        "xspf",
+        "zpl",
+    ]
+
+    private let assetRetriever: AssetRetriever
+    private let manifestAugmentor: AudioPublicationManifestAugmentor
+    private let ignoredExtensions: Set<FileExtension>
+    private let audioSpecifications: Set<FormatSpecification>
+
+    public init(
+        assetRetriever: AssetRetriever,
+        manifestAugmentor: AudioPublicationManifestAugmentor = AVAudioPublicationManifestAugmentor(),
+        audioSpecifications: Set<FormatSpecification> = AudioParser.defaultAudioSpecifications,
+        ignoredExtensions: Set<FileExtension> = AudioParser.defaultIgnoredExtensions
+    ) {
+        self.assetRetriever = assetRetriever
+        self.manifestAugmentor = manifestAugmentor
+        self.ignoredExtensions = ignoredExtensions
+        self.audioSpecifications = audioSpecifications
+    }
 
     public func parse(
         asset: Asset,
@@ -107,23 +136,6 @@ public final class AudioParser: PublicationParser {
         guard let filename = url.lastPathSegment else {
             return true
         }
-        let ignoredExtensions: [FileExtension] = [
-            "asx",
-            "bio",
-            "m3u",
-            "m3u8",
-            "pla",
-            "pls",
-            "smil",
-            "txt",
-            "vlc",
-            "wpl",
-            "xspf",
-            "zpl",
-            "jpg",
-            "pdf",
-        ]
-
         return url.pathExtension == nil
             || ignoredExtensions.contains(url.pathExtension!)
             || filename.hasPrefix(".")


### PR DESCRIPTION
## The Problem

Opening zipped audiobooks that contain JPG and PDF files results in a `PublicationParseError.formatNotSupported`.

### The Solution

Added support to customize audio parser specifications and ignored file extensions
