### PR TITLE
Update audio publication manifest augmentor api

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "21b63df3fbe6c22dec6104f05d9c13392a16a1782aae4269cd35eb9dacffef90",
+  "originHash" : "6c57d05a93b1a6b24af759f2ad90ce6166f484f12c6d5f744324fed58e7e684d",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -35,6 +35,33 @@
       "state" : {
         "revision" : "584db89a4c3c3be27206cce6afde037b2b6e38d8",
         "version" : "4.0.1"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+        "version" : "6.29.3"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "1a0c2df04b31ed7aa318354f3583faea24f006fc",
+        "version" : "5.15.8"
+      }
+    },
+    {
+      "identity" : "mbprogresshud",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jdg/MBProgressHUD.git",
+      "state" : {
+        "revision" : "bca42b801100b2b3a4eda0ba8dd33d858c780b0d",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6c57d05a93b1a6b24af759f2ad90ce6166f484f12c6d5f744324fed58e7e684d",
+  "originHash" : "21b63df3fbe6c22dec6104f05d9c13392a16a1782aae4269cd35eb9dacffef90",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -35,33 +35,6 @@
       "state" : {
         "revision" : "584db89a4c3c3be27206cce6afde037b2b6e38d8",
         "version" : "4.0.1"
-      }
-    },
-    {
-      "identity" : "grdb.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/groue/GRDB.swift.git",
-      "state" : {
-        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
-        "version" : "6.29.3"
-      }
-    },
-    {
-      "identity" : "kingfisher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/onevcat/Kingfisher.git",
-      "state" : {
-        "revision" : "1a0c2df04b31ed7aa318354f3583faea24f006fc",
-        "version" : "5.15.8"
-      }
-    },
-    {
-      "identity" : "mbprogresshud",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jdg/MBProgressHUD.git",
-      "state" : {
-        "revision" : "bca42b801100b2b3a4eda0ba8dd33d858c780b0d",
-        "version" : "1.2.0"
       }
     },
     {

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -56,7 +56,7 @@ public final class AudioParser: PublicationParser {
         }
 
         let container = SingleResourceContainer(publication: asset)
-        return makeBuilder(
+        return await makeBuilder(
             container: container,
             readingOrder: [(container.entry, asset.format)],
             title: nil
@@ -72,8 +72,8 @@ public final class AudioParser: PublicationParser {
         }
 
         return await makeReadingOrder(for: asset.container)
-            .flatMap { readingOrder in
-                makeBuilder(
+            .asyncFlatMap { readingOrder in
+                await makeBuilder(
                     container: asset.container,
                     readingOrder: readingOrder,
                     title: asset.container.guessTitle(ignoring: ignores)
@@ -132,7 +132,7 @@ public final class AudioParser: PublicationParser {
         container: Container,
         readingOrder: [(AnyURL, Format)],
         title: String?
-    ) -> Result<Publication.Builder, PublicationParseError> {
+    ) async -> Result<Publication.Builder, PublicationParseError> {
         guard !readingOrder.isEmpty else {
             return .failure(.reading(.decoding("No audio resources found in the publication")))
         }
@@ -150,7 +150,7 @@ public final class AudioParser: PublicationParser {
             }
         )
 
-        let augmented = manifestAugmentor.augment(manifest, using: container)
+        let augmented = await manifestAugmentor.augment(manifest, using: container)
 
         return .success(Publication.Builder(
             manifest: augmented.manifest,

--- a/Sources/Streamer/Parser/Audio/AudioPublicationManifestAugmentor.swift
+++ b/Sources/Streamer/Parser/Audio/AudioPublicationManifestAugmentor.swift
@@ -12,12 +12,17 @@ import UIKit
 /// Implements a strategy to augment a `Manifest` of an audio publication with additional metadata and
 /// cover, for example by looking into the audio files metadata.
 public protocol AudioPublicationManifestAugmentor {
-    func augment(_ baseManifest: Manifest, using container: Container) -> AudioPublicationAugmentedManifest
+    func augment(_ baseManifest: Manifest, using container: Container) async -> AudioPublicationAugmentedManifest
 }
 
 public struct AudioPublicationAugmentedManifest {
-    var manifest: Manifest
-    var cover: UIImage?
+    public var manifest: Manifest
+    public var cover: UIImage?
+
+    public init(manifest: Manifest, cover: UIImage? = nil) {
+        self.manifest = manifest
+        self.cover = cover
+    }
 }
 
 /// An `AudioPublicationManifestAugmentor` using AVFoundation to retrieve the audio metadata.
@@ -26,7 +31,7 @@ public struct AudioPublicationAugmentedManifest {
 public final class AVAudioPublicationManifestAugmentor: AudioPublicationManifestAugmentor {
     public init() {}
 
-    public func augment(_ manifest: Manifest, using container: Container) -> AudioPublicationAugmentedManifest {
+    public func augment(_ manifest: Manifest, using container: Container) async -> AudioPublicationAugmentedManifest {
         let avAssets = manifest.readingOrder.map { link in
             container[link.url()]?.sourceURL?.fileURL
                 .map { AVURLAsset(url: $0.url, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true]) }


### PR DESCRIPTION
### The Problem

Some zipped audiobooks containing MP3 files fail to parse the duration of the audio files. Additionally, the `AudioPublicationAugmentedManifest` initializer is internal, preventing the use of a custom `AudioPublicationManifestAugmentor`.

### The Solution

To parse the duration, we use the resource item to read the entry data. Since the data reader functions are asynchronous, I decided to update the `AudioPublicationManifestAugmentor` API to support async. I also modified the `AudioPublicationAugmentedManifest` initializer to allow the use of a custom `AudioPublicationManifestAugmentor`.

