### PR TITLE
Optimize the opening of really large LCP publications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Fixed
 
+#### Streamer
+
+* [#639](https://github.com/readium/swift-toolkit/issues/639) Optimized the opening of really large LCP protected publications.
+
 #### Navigator
 
 * [#70](https://github.com/readium/swift-toolkit/issues/70) Fixed restoring the reading progression with RTL EPUB.

--- a/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
+++ b/Sources/Navigator/Audiobook/PublicationMediaLoader.swift
@@ -54,7 +54,7 @@ final class PublicationMediaLoader: NSObject, AVAssetResourceLoaderDelegate, Log
         dispatchPrecondition(condition: .onQueue(queue))
 
         let href = href.anyURL.normalized
-        if let res = resources[equivalent: href] {
+        if let res = resources[href] {
             return res
         }
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -667,7 +667,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
                 : max(firstPositionIndex, Int(ceil(lastProgressionInLastResource * Double(positionsOfLastResource.count - 1))) - 1)
 
             location = await positionsOfFirstResource[firstPositionIndex].copy(
-                title: tableOfContentsTitleByHref[equivalent: link.url()],
+                title: tableOfContentsTitleByHref[link.url()],
                 locations: { $0.progression = firstProgressionInFirstResource }
             )
 

--- a/Sources/Shared/Toolkit/URL/URLProtocol.swift
+++ b/Sources/Shared/Toolkit/URL/URLProtocol.swift
@@ -170,15 +170,3 @@ private extension String {
         return segments.joined(separator: "/")
     }
 }
-
-public extension Dictionary where Key: URLProtocol {
-    /// Returns the value of the first key matching `key` after normalization.
-    subscript<T: URLConvertible>(equivalent key: T) -> Value? {
-        for (k, v) in self {
-            if k.isEquivalentTo(key) {
-                return v
-            }
-        }
-        return nil
-    }
-}

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -91,7 +91,7 @@ public final class AudioParser: PublicationParser {
                 container.entries
                     .compactMap { url -> (AnyURL, Format)? in
                         guard
-                            let format = formats[equivalent: url],
+                            let format = formats[url],
                             format.conformsToAny(audioSpecifications)
                         else {
                             return nil

--- a/Sources/Streamer/Parser/EPUB/EPUBEncryptionParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBEncryptionParser.swift
@@ -50,6 +50,7 @@ final class EPUBEncryptionParser: Loggable {
                 let algorithm = encryptedDataElement.firstChild(xpath: "enc:EncryptionMethod")?.attr("Algorithm"),
                 let resourceURI = encryptedDataElement.firstChild(xpath: "enc:CipherData/enc:CipherReference")?.attr("URI")
                 .flatMap(RelativeURL.init(epubHREF:))
+                .map(\.normalized)
             else {
                 continue
             }

--- a/Sources/Streamer/Parser/EPUB/OPFParser.swift
+++ b/Sources/Streamer/Parser/EPUB/OPFParser.swift
@@ -192,7 +192,7 @@ final class OPFParser: Loggable {
     private func makeLink(manifestItem: ReadiumFuzi.XMLElement, spineItem: ReadiumFuzi.XMLElement?, isCover: Bool) -> Link? {
         guard
             let relativeHref = manifestItem.attr("href").flatMap(RelativeURL.init(epubHREF:)),
-            let href = baseURL.resolve(relativeHref)
+            let href = baseURL.resolve(relativeHref)?.normalized
         else {
             return nil
         }
@@ -212,7 +212,7 @@ final class OPFParser: Loggable {
 
         var properties = parseStringProperties(stringProperties)
 
-        if let encryption = encryptions[equivalent: href]?.json, !encryption.isEmpty {
+        if let encryption = encryptions[href]?.json, !encryption.isEmpty {
             properties["encrypted"] = encryption
         }
 

--- a/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
+++ b/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
@@ -33,9 +33,9 @@ final class EPUBDeobfuscator {
     func deobfuscate(resource: Resource, at href: AnyURL) -> Resource {
         // Checks if the resource is obfuscated with a known algorithm.
         guard
-            let href = href.relativeURL,
+            let href = href.relativeURL?.normalized,
             !publicationId.isEmpty, publicationId != "urn:uuid:",
-            let algorithmId = encryptions[equivalent: href]?.algorithm,
+            let algorithmId = encryptions[href]?.algorithm,
             let algorithm = algorithms.first(withIdentifier: algorithmId)
         else {
             return resource

--- a/Sources/Streamer/Parser/Image/ImageParser.swift
+++ b/Sources/Streamer/Parser/Image/ImageParser.swift
@@ -86,7 +86,7 @@ public final class ImageParser: PublicationParser {
                 container.entries
                     .compactMap { url -> (AnyURL, Format)? in
                         guard
-                            let format = formats[equivalent: url],
+                            let format = formats[url],
                             format.conformsToAny(bitmapSpecifications)
                         else {
                             return nil


### PR DESCRIPTION
Large LCP-protected publications (e.g. 8k entries) were slow to open because we re-normalized all the URLs in the manifest each time we checked a single entry. Now, URLs are pre-normalized, and we only normalize the specific URL being checked.

---


### Fixed

#### Streamer

* [#639](https://github.com/readium/swift-toolkit/issues/639) Optimized the opening of really large LCP protected publications.

---

* Fixes #639 