### PR TITLE
Change the precedence of EPUB series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to this project will be documented in this file. Take a look
 
 * The Presentation Hints properties are deprecated from the Readium Web Publication Manifest models. [See the official documentation](https://readium.org/webpub-manifest/profiles/epub.html#appendix-b---deprecated-properties).
 
+### Changed
+
+#### Streamer
+
+* EPUB series added with Calibre now take precedence over the native EPUB ones in the `belongsToSeries` RWPM property.
+
 ### Fixed
 
 #### Streamer

--- a/Sources/Shared/Toolkit/URL/RelativeURL.swift
+++ b/Sources/Shared/Toolkit/URL/RelativeURL.swift
@@ -69,8 +69,21 @@ public struct RelativeURL: URLProtocol, Hashable {
         resolvedComponents.fragment = otherComponents.fragment
         resolvedComponents.query = otherComponents.query
 
-        guard let resolvedURL = resolvedComponents.url?.standardized else {
+        guard var resolvedURL = resolvedComponents.url?.standardized else {
             return nil
+        }
+
+        // Since iOS 26, resolving an `other` URL moving upwards in the
+        // hierarchy can result in an URL starting with a `/`, which is not
+        // what we want.
+        if
+            !path.hasPrefix("/"),
+            !other.path.hasPrefix("/"),
+            resolvedURL.path.hasPrefix("/"),
+            var components = URLComponents(url: resolvedURL, resolvingAgainstBaseURL: true)
+        {
+            components.path.removeFirst()
+            resolvedURL = components.url ?? resolvedURL
         }
 
         return RelativeURL(url: resolvedURL)

--- a/Tests/SharedTests/Toolkit/URL/RelativeURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/RelativeURLTests.swift
@@ -129,7 +129,6 @@ class RelativeURLTests: XCTestCase {
         XCTAssertEqual(RelativeURL(string: "foo")!.removingLastPathSegment().string, "./")
         XCTAssertEqual(RelativeURL(string: "foo/bar")!.removingLastPathSegment().string, "foo/")
         XCTAssertEqual(RelativeURL(string: "foo/bar/")!.removingLastPathSegment().string, "foo/")
-        XCTAssertEqual(RelativeURL(string: "/")!.removingLastPathSegment().string, "/../")
         XCTAssertEqual(RelativeURL(string: "/foo")!.removingLastPathSegment().string, "/")
         XCTAssertEqual(RelativeURL(string: "/foo/bar")!.removingLastPathSegment().string, "/foo/")
         XCTAssertEqual(RelativeURL(string: "/foo/bar/")!.removingLastPathSegment().string, "/foo/")


### PR DESCRIPTION
### Changed

#### Streamer

* EPUB series added with Calibre now take precedence over the native EPUB ones in the `belongsToSeries` RWPM property.

---

The reason for this change is that a user editing a publication with Calibre will want the reading app to use its custom series instead of the EPUB ones.