### PR TITLE
Allow access to the LCP License Document even if the status check fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes to this project will be documented in this file. Take a look at [the migration guide](docs/Migration%20Guide.md) to upgrade between two major versions.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+#### LCP
+
+* The LCP License Document is now accessible via `publication.lcpLicense?.license`, even if the license validation fails with a status error. This is useful for checking the end date of an expired license, for example.
+
 
 ## [3.4.0]
 

--- a/Sources/LCP/Content Protection/LCPContentProtection.swift
+++ b/Sources/LCP/Content Protection/LCPContentProtection.swift
@@ -156,7 +156,7 @@ private final class LCPContentProtectionService: ContentProtectionService {
 
     init(license: LCPLicense? = nil, error: Error? = nil) {
         self.license = license
-        self.error = error
+        self.error = error ?? license?.error.map { LCPError.licenseStatus($0) }
     }
 
     convenience init(result: Result<LCPLicense, LCPError>) {
@@ -179,7 +179,7 @@ private final class LCPContentProtectionService: ContentProtectionService {
     let scheme: ContentProtectionScheme = .lcp
 
     var isRestricted: Bool {
-        license == nil
+        license?.isRestricted ?? true
     }
 
     var rights: UserRights {

--- a/Sources/LCP/LCPLicense.swift
+++ b/Sources/LCP/LCPLicense.swift
@@ -14,6 +14,13 @@ public protocol LCPLicense: UserRights {
     var license: LicenseDocument { get }
     var status: StatusDocument? { get }
 
+    /// The license is restricted if there is a status error.
+    var isRestricted: Bool { get }
+
+    /// Status error detected while validating the license, e.g. if the license
+    /// is expired or revoked.
+    var error: StatusError? { get }
+
     /// Deciphers the given encrypted data to be displayed in the reader.
     func decipher(_ data: Data) throws -> Data?
 

--- a/Sources/LCP/Services/LicensesService.swift
+++ b/Sources/LCP/Services/LicensesService.swift
@@ -102,11 +102,6 @@ final class LicensesService: Loggable {
             throw LCPError.missingPassphrase
         }
 
-        // Check the license status error if there's any
-        // Note: Right now we don't want to return a License if it fails the Status check, that's why we attempt to get the DRM context. But it could change if we want to access, for example, the License metadata or perform an LSD interaction, but without being able to decrypt the book. In which case, we could remove this line.
-        // Note2: The License already gets in this state when we perform a `return` successfully. We can't decrypt anymore but we still have access to the License Documents and LSD interactions.
-        _ = try documents.getContext()
-
         return License(documents: documents, client: client, validation: validation, licenses: licenses, device: device, httpClient: httpClient)
     }
 


### PR DESCRIPTION
### Changed

#### LCP

* The LCP License Document is now accessible via `publication.lcpLicense?.license`, even if the license validation fails with a status error. This is useful for checking the end date of an expired license, for example.