### PR TITLE
Don't treat a missing passphrase as a validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 #### LCP
 
-* The LCP License Document is now accessible via `publication.lcpLicense?.license`, even if the license validation fails with a status error. This is useful for checking the end date of an expired license, for example.
+* The LCP License Document is now accessible via `publication.lcpLicense?.license`, even if the license validation fails with a status error or missing passphrase. This is useful for checking the end date of an expired license or renew a license.
 
 
 ## [3.4.0]

--- a/Sources/LCP/Content Protection/LCPContentProtection.swift
+++ b/Sources/LCP/Content Protection/LCPContentProtection.swift
@@ -156,7 +156,7 @@ private final class LCPContentProtectionService: ContentProtectionService {
 
     init(license: LCPLicense? = nil, error: Error? = nil) {
         self.license = license
-        self.error = error ?? license?.error.map { LCPError.licenseStatus($0) }
+        self.error = error ?? license?.error
     }
 
     convenience init(result: Result<LCPLicense, LCPError>) {

--- a/Sources/LCP/LCPLicense.swift
+++ b/Sources/LCP/LCPLicense.swift
@@ -17,9 +17,10 @@ public protocol LCPLicense: UserRights {
     /// The license is restricted if there is a status error.
     var isRestricted: Bool { get }
 
-    /// Status error detected while validating the license, e.g. if the license
-    /// is expired or revoked.
-    var error: StatusError? { get }
+    /// Error detected after validating the license, which prevents the user
+    /// from decrypting the book. For example, the license is expired/revoked
+    /// or the passphrase was not provided.
+    var error: LCPError? { get }
 
     /// Deciphers the given encrypted data to be displayed in the reader.
     func decipher(_ data: Data) throws -> Data?

--- a/Sources/LCP/License/License.swift
+++ b/Sources/LCP/License/License.swift
@@ -28,7 +28,7 @@ final class License: Loggable {
         self.httpClient = httpClient
 
         validation.observe { [weak self] result in
-            if case let .success(documents) = result, let documents = documents {
+            if case let .success(documents) = result {
                 self?.documents = documents
             }
         }
@@ -46,15 +46,22 @@ extension License: LCPLicense {
     }
 
     public var isRestricted: Bool {
-        error != nil
+        documents.context.getOrNil() == nil
     }
 
-    public var error: StatusError? {
+    public var error: LCPError? {
         switch documents.context {
         case .success:
             return nil
         case let .failure(error):
-            return error
+            switch error {
+            // We don't report the missingPassphrase case as an error
+            // because in this case the user cancelled the passphrase prompt.
+            case .missingPassphrase:
+                return nil
+            default:
+                return error
+            }
         }
     }
 

--- a/Sources/LCP/Services/LicensesService.swift
+++ b/Sources/LCP/Services/LicensesService.swift
@@ -98,9 +98,7 @@ final class LicensesService: Loggable {
             onLicenseValidated: onLicenseValidated
         )
 
-        guard let documents = try await validation.validate(.license(initialData)) else {
-            throw LCPError.missingPassphrase
-        }
+        let documents = try await validation.validate(.license(initialData))
 
         return License(documents: documents, client: client, validation: validation, licenses: licenses, device: device, httpClient: httpClient)
     }


### PR DESCRIPTION
Don't treat a missing passphrase as a validation error, to be able to access the License Document information in `publication.lcpLicense`, even if the user did not provide a passphrase.