### PR TITLE
Fixed lost progression when the system kills the WebKit process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * The safe area insets strategy was adjusted to take into account changes in iOS/iPadOS 26.
+* Fixed the lost progression with the EPUB navigator when the application becomes active again after the system terminated the WebKit process.
 
 
 ## [3.4.0]

--- a/TestApp/Sources/Common/Toolkit/Extensions/Locator.swift
+++ b/TestApp/Sources/Common/Toolkit/Extensions/Locator.swift
@@ -7,7 +7,7 @@
 import Foundation
 import ReadiumShared
 
-extension Locator: Codable {
+extension Locator: @retroactive Codable {
     public init(from decoder: Decoder) throws {
         let json = try decoder.singleValueContainer().decode(String.self)
         try self.init(jsonString: json)!


### PR DESCRIPTION
### Fixed

#### Navigator

* Fixed the lost progression with the EPUB navigator when the application becomes active again after the system terminated the WebKit process.

---

The operating system can terminate the WebKit processes of a background application to recover resources. If this occurs and the OS doesn't also kill the application, we lose the EPUB progress when the user reactivates it. This happens because the WebViews reload in the background, preventing the restoration of the inner scroll position.

To test this out:

1. launch the application on a Simulator
2. open a book in the middle of a resource
3. go back to the springboard (Cmd-Shift-H)
4. run `kill $(pgrep -P $(pgrep launchd_sim) 'com.apple.WebKit.WebContent')`
5. open the application again, notice that we're back to the beginning of the resource.
