### PR TITLE
End editing of internal navigator view when resigning first responder

### DIFF
--- a/Sources/Navigator/Input/InputObservableViewController.swift
+++ b/Sources/Navigator/Input/InputObservableViewController.swift
@@ -33,6 +33,18 @@ open class InputObservableViewController: UIViewController, InputObservable {
 
     override open var canBecomeFirstResponder: Bool { true }
 
+    override open func resignFirstResponder() -> Bool {
+        // Force end editing of the view to make sure any subview is also
+        // resigning its first responder status.
+        // This is helpful in the EPUB navigator because the web views may be
+        // first responders to intercept keyboard events.
+        if isViewLoaded {
+            view.endEditing(true)
+        }
+
+        return super.resignFirstResponder()
+    }
+
     override open func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         if isFirstResponder {
             on(.down, presses: presses, with: event)


### PR DESCRIPTION
This fix allows to resign first responder in the internal navigator view automatically. This is helpful when trying to intercept keyboard events in a SwiftUI view presented above the navigator.