### PR TITLE
Add injectLicense to LCPService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. Take a look
 * Added an initializer parameter for providing a custom device identifier (contributed by [@dewantawsif](https://github.com/readium/swift-toolkit/pull/661)).
     * You must ensure the identifier is unique and stable for the device (persist and reuse across app launches).
     * Recommended: generate an app-scoped UUID and store it securely (e.g., in the Keychain); avoid hardware or advertising identifiers.
+* You can use `LCPService.injectLicenseDocument(_:in)` to insert an LCPL into a package, if you downloaded it manually instead of using `LCPService.acquirePublication()`.
 
 ### Changed
 

--- a/Sources/LCP/LCPService.swift
+++ b/Sources/LCP/LCPService.swift
@@ -83,12 +83,12 @@ public final class LCPService: Loggable {
     /// Injects a `licenseDocument` into a publication package at `url`.
     ///
     /// This is useful if you downloaded the publication yourself instead of using `acquirePublication`.
-    public func injectLicense(
+    public func injectLicenseDocument(
         _ license: LicenseDocument,
         in url: FileURL
     ) async -> Result<Void, LCPError> {
         await wrap {
-            try await licenses.injectLicense(license, in: url)
+            try await licenses.injectLicenseDocument(license, in: url)
         }
     }
 

--- a/Sources/LCP/Services/LicensesService.swift
+++ b/Sources/LCP/Services/LicensesService.swift
@@ -134,7 +134,7 @@ final class LicensesService: Loggable {
         )
     }
 
-    func injectLicense(
+    func injectLicenseDocument(
         _ license: LicenseDocument,
         in url: FileURL
     ) async throws {


### PR DESCRIPTION
Add `injectLicense` to `LCPService` to provide apps with more control on publication acquisition.