### PR TITLE
Fix FXL auto spread settings after rotating the device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Fixed
 
+#### Navigator
+
+* Fixed EPUB fixed-layout spread settings not updating after device rotation when the app was in the background.
+
 #### LCP
 
 * Fixed crash when an EPUB resource is declared as LCP-encrypted in the manifest but contains unencrypted data.


### PR DESCRIPTION
### Fixed

#### Navigator

* Fixed EPUB fixed-layout spread settings not updating after device rotation when the app was in the background.

---

To reproduce the issue:

* Open an EPUB FXL in portrait mode and enable the AUTO spreads preference.
* Put the app in the background.
* Rotate the device to landscape.
* Reopen the app and notice that it still displays a single spread instead of the expected two.