### PR TITLE
Optimize sniffing the `Format` of `Container` resources

### DIFF
--- a/Sources/Shared/Toolkit/Format/Sniffers/HTMLFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/HTMLFormatSniffer.swift
@@ -29,7 +29,11 @@ public struct HTMLFormatSniffer: FormatSniffer {
     }
 
     public func sniffBlob(_ blob: FormatSnifferBlob, refining format: Format) async -> ReadResult<Format?> {
-        await blob.readAsXML()
+        guard !format.hasSpecification || format.conformsTo(.xml) else {
+            return .success(nil)
+        }
+
+        return await blob.readAsXML()
             .asyncMap { document in
                 if let format = sniffDocument(document) {
                     return format

--- a/Sources/Shared/Toolkit/Format/Sniffers/JSONFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/JSONFormatSniffer.swift
@@ -28,7 +28,11 @@ public struct JSONFormatSniffer: FormatSniffer {
     }
 
     public func sniffBlob(_ blob: FormatSnifferBlob, refining format: Format) async -> ReadResult<Format?> {
-        await blob.readAsJSON()
+        guard !format.hasSpecification else {
+            return .success(nil)
+        }
+
+        return await blob.readAsJSON()
             .map {
                 guard $0 != nil else {
                     return nil

--- a/Sources/Shared/Toolkit/Format/Sniffers/PDFFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/PDFFormatSniffer.swift
@@ -24,8 +24,12 @@ public struct PDFFormatSniffer: FormatSniffer {
     }
 
     public func sniffBlob(_ blob: FormatSnifferBlob, refining format: Format) async -> ReadResult<Format?> {
+        guard !format.hasSpecification else {
+            return .success(nil)
+        }
+
         // https://en.wikipedia.org/wiki/List_of_file_signatures
-        await blob.read(range: 0 ..< 5)
+        return await blob.read(range: 0 ..< 5)
             .map { data in
                 guard String(data: data, encoding: .utf8) == "%PDF-" else {
                     return nil

--- a/Sources/Shared/Toolkit/Format/Sniffers/RARFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/RARFormatSniffer.swift
@@ -22,8 +22,12 @@ public struct RARFormatSniffer: FormatSniffer {
     }
 
     public func sniffBlob(_ blob: FormatSnifferBlob, refining format: Format) async -> ReadResult<Format?> {
+        guard !format.hasSpecification else {
+            return .success(nil)
+        }
+
         // https://en.wikipedia.org/wiki/List_of_file_signatures
-        await blob.read(range: 0 ..< 8)
+        return await blob.read(range: 0 ..< 8)
             .map { data in
                 guard
                     data.count > 8,

--- a/Sources/Shared/Toolkit/Format/Sniffers/XMLFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/XMLFormatSniffer.swift
@@ -22,7 +22,11 @@ public struct XMLFormatSniffer: FormatSniffer {
     }
 
     public func sniffBlob(_ blob: FormatSnifferBlob, refining format: Format) async -> ReadResult<Format?> {
-        await blob.readAsXML()
+        guard !format.hasSpecification else {
+            return .success(nil)
+        }
+
+        return await blob.readAsXML()
             .map {
                 guard $0 != nil else {
                     return nil

--- a/Sources/Shared/Toolkit/Format/Sniffers/ZIPFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/ZIPFormatSniffer.swift
@@ -22,8 +22,12 @@ public struct ZIPFormatSniffer: FormatSniffer {
     }
 
     public func sniffBlob(_ blob: FormatSnifferBlob, refining format: Format) async -> ReadResult<Format?> {
+        guard !format.hasSpecification else {
+            return .success(nil)
+        }
+
         // https://en.wikipedia.org/wiki/List_of_file_signatures
-        await blob.read(range: 0 ..< 4)
+        return await blob.read(range: 0 ..< 4)
             .map { data in
                 guard
                     data == Data([0x50, 0x4B, 0x03, 0x04]) ||


### PR DESCRIPTION
When opening an archive with `ImageParser`, we sniff the format of all container resources to ensure they are supported. While we often infer the format from the file extension (e.g., `jpg`), we must sniff the bytes directly if the extension is missing.

Due to our current `Format` parsing logic, we sniff content to "refine" the format even when an extension is present. For example, a `.json` file might be refined into an RWPM manifest. This causes performance issues when opening large archives containing many binary resources; we sniff these files for XML or JSON structures unnecessarily.

As a temporary workaround, I have disabled sniffing for base formats like JSON and XML if the `Format` to refine already includes a specification. You may need to adjust the sniffing logic to handle this systematically in the future.