### PR TITLE
Add did scroll event callback to VisualNavigatorDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. Take a look
 * Support for displaying Divina (image-based publications like CBZ) in the fixed-layout EPUB navigator.
 * Bitmap images in the EPUB reading order are now supported as a fixed layout resource.
 * Added `offsetFirstPage` preference for fixed-layout EPUBs to control whether the first page is displayed alone or alongside the second page when spreads are enabled.
+* Added `func navigator(_ navigator: VisualNavigator, didScrollIn direction: ScrollDirection)` to `VisualNavigatorDelegate` protocol
 
 #### Streamer
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -1250,6 +1250,12 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
         }
     }
 
+    func spreadView(_ spreadView: EPUBSpreadView, didScrollIn direction: ScrollDirection) {
+        if paginationView?.currentView == spreadView {
+            delegate?.navigator(self, didScrollIn: direction)
+        }
+    }
+
     func spreadView(_ spreadView: EPUBSpreadView, present viewController: UIViewController) {
         present(viewController, animated: true)
     }

--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -317,6 +317,8 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
     private var progression: ClosedRange<Double>?
     // To check if a progression change was cancelled or not.
     private var previousProgression: ClosedRange<Double>?
+    // Previous scroll offset for determining scroll direction.
+    private var previousScrollOffset: CGPoint?
 
     // Called by the javascript code to notify that scrolling ended.
     private func progressionDidChange(_ body: Any) {
@@ -380,5 +382,20 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
     override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         super.scrollViewDidScroll(scrollView)
         setNeedsNotifyPagesDidChange()
+
+        let currentOffset = scrollView.contentOffset
+        if let previousOffset = previousScrollOffset {
+            // Determine direction based on scroll axis (vertical vs horizontal)
+            let direction: ScrollDirection
+            if viewModel.scroll, !viewModel.verticalText {
+                // Vertical scrolling mode
+                direction = currentOffset.y > previousOffset.y ? .forward : .backward
+            } else {
+                // Horizontal scrolling/pagination mode
+                direction = currentOffset.x > previousOffset.x ? .forward : .backward
+            }
+            delegate?.spreadView(self, didScrollIn: direction)
+        }
+        previousScrollOffset = currentOffset
     }
 }

--- a/Sources/Navigator/EPUB/EPUBSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBSpreadView.swift
@@ -30,6 +30,9 @@ protocol EPUBSpreadViewDelegate: AnyObject {
     /// Called when the pages visible in the spread changed.
     func spreadViewPagesDidChange(_ spreadView: EPUBSpreadView)
 
+    /// Called when the user scrolls through the content.
+    func spreadView(_ spreadView: EPUBSpreadView, didScrollIn direction: ScrollDirection)
+
     /// Called when the spread view needs to present a view controller.
     func spreadView(_ spreadView: EPUBSpreadView, present viewController: UIViewController)
 

--- a/Sources/Navigator/VisualNavigator.swift
+++ b/Sources/Navigator/VisualNavigator.swift
@@ -85,6 +85,14 @@ public struct VisualNavigatorPresentation {
     }
 }
 
+/// Direction of a scroll event.
+public enum ScrollDirection {
+    /// Scrolling up (vertical) or left (horizontal).
+    case backward
+    /// Scrolling down (vertical) or right (horizontal).
+    case forward
+}
+
 @MainActor public protocol VisualNavigatorDelegate: NavigatorDelegate {
     /// Returns the content insets that the navigator applies to its view.
     ///
@@ -119,6 +127,12 @@ public struct VisualNavigatorPresentation {
     /// Return `true` to navigate to the link, or `false` if you intend to
     /// present the link yourself
     func navigator(_ navigator: VisualNavigator, shouldNavigateToLink link: Link) -> Bool
+
+    /// Called when the user scrolls through the content.
+    ///
+    /// - Parameter direction: The direction of the scroll (forward = down/right,
+    ///   backward = up/left).
+    func navigator(_ navigator: VisualNavigator, didScrollIn direction: ScrollDirection)
 }
 
 public extension VisualNavigatorDelegate {
@@ -144,5 +158,9 @@ public extension VisualNavigatorDelegate {
 
     func navigator(_ navigator: VisualNavigator, shouldNavigateToLink link: Link) -> Bool {
         true
+    }
+
+    func navigator(_ navigator: VisualNavigator, didScrollIn direction: ScrollDirection) {
+        // Optional
     }
 }


### PR DESCRIPTION
Scroll event callback is added to `VisualNavigatorDelegate` to allow access to scroll events for clients using `EPUBNavigatorViewController`