### PR TITLE
Parse SMIL as alternate of reading order items

### DIFF
--- a/Sources/Streamer/Parser/EPUB/OPFParser.swift
+++ b/Sources/Streamer/Parser/EPUB/OPFParser.swift
@@ -27,6 +27,7 @@ final class OPFParser: Loggable {
         let id: String
         let link: Link
         let fallbackId: String?
+        let mediaOverlayId: String?
     }
 
     /// Relative path to the OPF in the EPUB container
@@ -214,7 +215,8 @@ final class OPFParser: Loggable {
         return ManifestItem(
             id: id,
             link: link,
-            fallbackId: manifestItem.attr("fallback")
+            fallbackId: manifestItem.attr("fallback"),
+            mediaOverlayId: manifestItem.attr("media-overlay")
         )
     }
 
@@ -259,6 +261,15 @@ final class OPFParser: Loggable {
                     spineLink: spineLink,
                     fallbackLink: fallbackItem.link
                 )
+            }
+
+            // Attach the SMIL media overlay as an alternate.
+            if
+                let mediaOverlayId = item.mediaOverlayId,
+                let smilIndex = items.firstIndex(where: { $0.id == mediaOverlayId && $0.link.mediaType?.matches(.smil) == true })
+            {
+                let smilItem = items.remove(at: smilIndex)
+                spineLink.alternates.append(smilItem.link)
             }
 
             readingOrder.append(spineLink)

--- a/Sources/Streamer/Parser/EPUB/SMILParser.swift
+++ b/Sources/Streamer/Parser/EPUB/SMILParser.swift
@@ -114,11 +114,11 @@ private struct SMILGuidedNavigationDocumentParsing {
         let id = element.attr("id")
         let epubType = element.attr("type", namespace: .epub)
 
-        let texttrefAttr = element.attr("textref", namespace: .epub)
-        if texttrefAttr == nil {
+        let textrefAttr = element.attr("textref", namespace: .epub)
+        if textrefAttr == nil {
             warnings?.log("<seq> is missing required epub:textref", model: GuidedNavigationObject.self, source: element, severity: .minor)
         }
-        let textref = texttrefAttr.flatMap { resolveURL($0) }
+        let textref = textrefAttr.flatMap { resolveURL($0) }
 
         let children = parseObjects(in: element)
 

--- a/Tests/StreamerTests/Fixtures/OPF/links.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/links.opf
@@ -21,7 +21,7 @@
     <item id="css" href="../style.css" media-type="text/css"/>
     <!-- Spine items -->
     <item id="titlepage" href="../titlepage.xhtml" media-type="application/xhtml+xml"/>
-    <item id="chapter01" href="chapter01.xhtml" media-type="application/xhtml+xml"/>
+    <item id="chapter01" href="chapter01.xhtml" media-type="application/xhtml+xml" media-overlay="chapter01_smil"/>
     <item id="chapter02" href="chapter02.xhtml" media-type="application/xhtml+xml"/>
     <!-- SMIL without duration -->
     <item id="chapter01_smil" href="chapter01.smil" media-type="application/smil+xml"/>

--- a/Tests/StreamerTests/Fixtures/OPF/media-overlays.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/media-overlays.opf
@@ -3,14 +3,16 @@
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     <dc:title>Alice's Adventures in Wonderland</dc:title>
     <meta property="media:duration">1:32:29</meta>
-    <meta property="media:duration" refines="#chapter01">0:23:45</meta>
-    <meta property="media:duration" refines="#chapter02">0:08:44</meta>
+    <meta property="media:duration" refines="#chapter01_smil">0:23:45</meta>
+    <meta property="media:duration" refines="#chapter02_smil">0:08:44</meta>
     <meta property="media:active-class">-epub-media-overlay-active</meta>
     <meta property="media:playback-active-class">-epub-media-overlay-playing</meta>
   </metadata>
   <manifest>
-    <item id="chapter01" href="chapter01.xhtml" media-type="application/xhtml+xml"/>
-    <item id="chapter02" href="chapter02.xhtml" media-type="application/xhtml+xml"/>
+    <item id="chapter01" href="chapter01.xhtml" media-type="application/xhtml+xml" media-overlay="chapter01_smil"/>
+    <item id="chapter02" href="chapter02.xhtml" media-type="application/xhtml+xml" media-overlay="chapter02_smil"/>
+    <item id="chapter01_smil" href="chapter01.smil" media-type="application/smil+xml"/>
+    <item id="chapter02_smil" href="chapter02.smil" media-type="application/smil+xml"/>
   </manifest>
   <spine>
     <itemref idref="chapter01"/>

--- a/Tests/StreamerTests/Parser/EPUB/OPFParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/OPFParserTests.swift
@@ -47,14 +47,19 @@ class OPFParserTests: XCTestCase {
         XCTAssertEqual(sut.links, [])
         XCTAssertEqual(sut.readingOrder, [
             link(href: "titlepage.xhtml", mediaType: .xhtml),
-            link(href: "EPUB/chapter01.xhtml", mediaType: .xhtml),
+            Link(
+                href: "EPUB/chapter01.xhtml",
+                mediaType: .xhtml,
+                alternates: [
+                    Link(href: "EPUB/chapter01.smil", mediaType: .smil),
+                ]
+            ),
         ])
         XCTAssertEqual(sut.resources, try [
             link(href: "EPUB/fonts/MinionPro.otf", mediaType: XCTUnwrap(MediaType("application/vnd.ms-opentype"))),
             link(href: "EPUB/nav.xhtml", mediaType: .xhtml, rels: [.contents]),
             link(href: "style.css", mediaType: .css),
             link(href: "EPUB/chapter02.xhtml", mediaType: .xhtml),
-            link(href: "EPUB/chapter01.smil", mediaType: .smil),
             Link(href: "EPUB/chapter02.smil", mediaType: .smil, duration: 1949.0),
             link(href: "EPUB/images/alice01a.png", mediaType: .png, rels: [.cover]),
             link(href: "EPUB/images/alice02a.gif", mediaType: .gif),
@@ -225,12 +230,19 @@ class OPFParserTests: XCTestCase {
 
     // MARK: - Media Overlays
 
-    func testParseMediaOverlaysDurationPerSpineItem() throws {
+    func testParseMediaOverlaysSmilAsAlternate() throws {
         let sut = try parseManifest("media-overlays", at: "EPUB/content.opf").manifest
-        // chapter01: 0:23:45 = 23*60 + 45 = 1425
-        XCTAssertEqual(sut.readingOrder[0].duration, 1425.0)
-        // chapter02: 0:08:44 = 8*60 + 44 = 524
-        XCTAssertEqual(sut.readingOrder[1].duration, 524.0)
+
+        // SMIL should be an alternate of each reading order item, not in resources
+        XCTAssertEqual(sut.readingOrder[0].href, "EPUB/chapter01.xhtml")
+        XCTAssertEqual(sut.readingOrder[0].alternates, [
+            Link(href: "EPUB/chapter01.smil", mediaType: .smil, duration: 1425.0),
+        ])
+        XCTAssertEqual(sut.readingOrder[1].href, "EPUB/chapter02.xhtml")
+        XCTAssertEqual(sut.readingOrder[1].alternates, [
+            Link(href: "EPUB/chapter02.smil", mediaType: .smil, duration: 524.0),
+        ])
+        XCTAssertTrue(sut.resources.isEmpty)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Put the EPUB SMIL resources as `alternate` of reading order items instead of independent `resources`.