### PR TITLE
Fix EPUB contributor role parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ All notable changes to this project will be documented in this file. Take a look
     * `Recipes/` contains self-contained and explained code you can reuse in your own application.
     * `App/` folder contains the scaffolding (file management, navigation, error handling) needed to run the Playground.
 
+### Fixed
+
+#### Streamer
+
+* Fixed parsing of EPUB contributors.
+    * Fixed `media:narrator` contributors not being recognized as narrators.
+    * Fixed `dc:creator` elements with a known MARC relator role (e.g. `opf:role="trl"`) being incorrectly routed to the `author` collection instead of the role's collection.
+    * A known role on a contributor no longer leaks into the `roles` field of the `Contributor` object when it is already expressed by the contributor's collection (e.g. `authors`, `publishers`).
+
 
 ## [3.8.0]
 

--- a/Playground/.xcodegen
+++ b/Playground/.xcodegen
@@ -106,9 +106,7 @@ Sources/Assets.xcassets/AppIcon.appiconset/Contents.json
 Sources/Assets.xcassets/AppIcon.appiconset/icon_1024x1024.png
 Sources/Assets.xcassets/AppIcon.appiconset/readiumlogo_2048-83.5@2x.png
 Sources/Assets.xcassets/Contents.json
-Sources/Data
 Sources/Info.plist
-Sources/Publication
 Sources/Recipes
 Sources/Recipes/A01-OpenPublication.swift
 Sources/Recipes/A02-ReadMetadata.swift"

--- a/Playground/Sources/Info.plist
+++ b/Playground/Sources/Info.plist
@@ -18,6 +18,8 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Sources/Shared/Publication/Contributor.swift
+++ b/Sources/Shared/Publication/Contributor.swift
@@ -7,7 +7,7 @@
 import Foundation
 import ReadiumInternal
 
-/// https://readium.org/webpub-manifest/schema/contributor-object.schema.json
+/// https://readium.org/webpub-manifest/schema/contributor.schema.json
 public struct Contributor: Hashable, Sendable {
     /// The name of the contributor.
     public var localizedName: LocalizedString

--- a/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
@@ -414,26 +414,27 @@ final class EPUBMetadataParser: Loggable {
         let role: String? = element.attr("id")
             .map { id in metas["role", refining: id].map(\.content) }?.first
             ?? element.attr("role") // falls back to EPUB 2 role attribute
-
-        let roles = role.map { role in knownRoles.contains(role) ? [] : [role] } ?? []
+        
+        let isKnownRole = role.map { knownRoles.contains($0) } ?? false
 
         let contributor = Contributor(
             name: name,
             sortAs: element.attr("file-as"),
-            roles: roles
+            role: isKnownRole ? nil : role
         )
 
-        let type: String? = if element.tag == "creator" || element.attr("property") == "dcterms:creator" {
-            "aut"
-        } else if element.tag == "publisher" || element.attr("property") == "dcterms:publisher" {
-            "pbl"
-        } else if element.tag == "narrator" {
-            "nrt"
-        } else if role == nil {
-            nil
-        } else {
-            knownRoles.contains(role!) ? role : nil
-        }
+        let type: String? =
+            if element.tag == "publisher" || element.attr("property") == "dcterms:publisher" {
+                "pbl"
+            } else if element.attr("property") == "media:narrator" {
+                "nrt"
+            } else if let role, isKnownRole {
+                role
+            } else if element.tag == "creator" || element.attr("property") == "dcterms:creator" {
+                "aut"
+            } else {
+                nil
+            }
 
         return (role: type, contributor: contributor)
     }

--- a/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
@@ -414,7 +414,7 @@ final class EPUBMetadataParser: Loggable {
         let role: String? = element.attr("id")
             .map { id in metas["role", refining: id].map(\.content) }?.first
             ?? element.attr("role") // falls back to EPUB 2 role attribute
-        
+
         let isKnownRole = role.map { knownRoles.contains($0) } ?? false
 
         let contributor = Contributor(

--- a/Tests/StreamerTests/Fixtures/OPF/contributors.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/contributors.opf
@@ -1,83 +1,84 @@
 <?xml version="1.0"?>
-<!-- DOCTYPE package 
-  PUBLIC "+//ISBN 0-9673008-1-9//DTD OEB 1.2 Package//EN"
-  "http://openebook.org/dtds/oeb-1.2/oebpkg12.dtd" -->
-<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="3.0" >
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="3.0">
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/"
       xmlns:dc-alias="http://purl.org/dc/elements/1.1/"
       xmlns:dcterms="http://purl.org/dc/terms/"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:opf="http://www.idpf.org/2007/opf">
-    <dc:title>Alice's Adventures in Wonderland</dc:title> 
+    <dc:title>Contributors Test</dc:title>
 
-    <!-- dc:creator is by default an Author -->
+    <!-- ── EPUB 2.x: dc:creator with opf:role attribute ────────────────────────── -->
+
+    <!-- No role: defaults to author -->
     <dc:creator>Author 1</dc:creator>
-    <!-- dc:publisher is by default a Publisher -->
-    <dc:publisher>Publisher 1</dc:publisher>
-    <!-- dc:contributor is by default a Contributor -->
+    <!-- Known role on dc:creator overrides the author default -->
+    <dc:creator opf:role="pbl">Creator As Publisher</dc:creator>
+    <!-- Unknown role on dc:creator still falls back to author; role is preserved on the object -->
+    <dc:creator opf:role="xyz">Creator Unknown Role</dc:creator>
+
+    <!-- ── EPUB 2.x: dc:contributor with opf:role attribute ─────────────────────── -->
+
+    <!-- No role: defaults to contributor -->
     <dc:contributor>Contributor 1</dc:contributor>
+    <!-- Each known MARC relator code routes the contributor to the correct bucket -->
+    <dc:contributor opf:role="aut">Author 2</dc:contributor>
+    <dc:contributor opf:role="pbl">Publisher 2</dc:contributor>
+    <dc:contributor opf:role="trl">Translator 1</dc:contributor>
+    <dc:contributor opf:role="edt">Editor 1</dc:contributor>
+    <dc:contributor opf:role="art">Artist 1</dc:contributor>
+    <!-- opf:file-as is carried through to sortAs -->
+    <dc:contributor opf:role="ill" opf:file-as="Illustrator, The First">Illustrator 1</dc:contributor>
+    <dc:contributor opf:role="clr">Colorist 1</dc:contributor>
+    <dc:contributor opf:role="nrt">Narrator 1</dc:contributor>
+    <!-- Unknown role: stays in contributor bucket; role is preserved on the object -->
+    <dc:contributor opf:role="unknown">Unknown 1</dc:contributor>
 
-    <dc:contributor id="author-2">Author 2</dc:contributor>
-    <meta refines="#author-2" property="role">aut</meta>
+    <!-- ── EPUB 2.x: dc:publisher ──────────────────────────────────────────────── -->
 
-    <dc:contributor id="translator">Translator</dc:contributor> 
-    <meta refines="#translator" property="role">trl</meta>
+    <!-- dc:publisher is always routed to publisher, regardless of any role -->
+    <dc:publisher>Publisher 1</dc:publisher>
 
-    <dc:contributor id="editor">Editor</dc:contributor> 
-    <meta refines="#editor" property="role">edt</meta>
+    <!-- ── EPUB 3.x: dc:* elements with meta refines ───────────────────────────── -->
 
-    <dc:contributor id="artist">Artist</dc:contributor> 
-    <meta refines="#artist" property="role">art</meta>
+    <!-- No refine: same defaults as EPUB 2.x -->
+    <dc:creator id="creator-a">Author A</dc:creator>
+    <dc:contributor id="contributor-a">Contributor A</dc:contributor>
+    <!-- Known role via refine routes to the correct bucket -->
+    <dc:contributor id="author-b">Author B</dc:contributor>
+    <meta refines="#author-b" property="role">aut</meta>
+    <!-- Known role refine on dc:creator overrides the author default -->
+    <dc:creator id="creator-b">Creator B As Publisher</dc:creator>
+    <meta refines="#creator-b" property="role">pbl</meta>
+    <!-- dc:publisher with a conflicting role refine is still always a publisher -->
+    <dc:publisher id="publisher-a">Publisher A</dc:publisher>
+    <meta refines="#publisher-a" property="role">aut</meta>
+    <!-- Unknown role via refine: stays in contributor bucket; role is preserved on the object -->
+    <dc:contributor id="unknown-a">Unknown A</dc:contributor>
+    <meta refines="#unknown-a" property="role">unknown</meta>
+    <!-- Only the first role refine is used when multiple are present -->
+    <dc:contributor id="multi-role">Author Multi-Role</dc:contributor>
+    <meta refines="#multi-role" property="role">aut</meta>
+    <meta refines="#multi-role" property="role">pbl</meta>
 
-    <dc:contributor id="illustrator-1">Illustrator 1</dc:contributor> 
-    <meta refines="#illustrator-1" property="role">ill</meta>
+    <!-- ── EPUB 3.x: dcterms: meta elements ────────────────────────────────────── -->
 
-    <dc:contributor id="colorist">Colorist</dc:contributor> 
-    <meta refines="#colorist" property="role">clr</meta>
-
-    <dc:contributor id="narrator">Narrator</dc:contributor> 
-    <meta refines="#narrator" property="role">nrt</meta>
-
-    <dc:contributor id="publisher">Publisher 2</dc:contributor> 
-    <meta refines="#publisher" property="role">pbl</meta>
-
-    <!-- sortAs and role as attributes -->
-    <dc:contributor opf:file-as="sorting" opf:role="ill">Illustrator 2</dc:contributor> 
-
-    <dc:contributor id="unknown">Unknown</dc:contributor> 
-    <meta refines="#unknown" property="role">unknown</meta>
-
-    <!-- Only the first role is used -->
-    <dc:contributor id="cameleon-1">Cameleon 1</dc:contributor>
-    <meta refines="#cameleon-1" property="role">aut</meta>
-    <meta refines="#cameleon-1" property="role">pbl</meta>
-
-    <!-- Without namespace prefix -->
-    <creator xmlns="http://purl.org/dc/elements/1.1/">Author 3</creator>
-
-    <!-- With a "non-standard" namespace prefix -->
-    <dc-alias:creator>Author 4</dc-alias:creator>
-
-
-    <!-- EPUB 3 contributors -->
-
-    <!-- dcterms:creator is by default an Author -->
-    <meta property="dcterms:creator">Author A</meta>
-    <!-- dcterms:publisher is by default a Publisher -->
-    <meta property="dcterms:publisher">Publisher A</meta>
-    <!-- dcterms:contributor is by default a Contributor -->
-    <meta property="dcterms:contributor">Contributor A</meta>
-
-    <meta id="publisher—b" property="dcterms:publisher">Publisher B</meta>
+    <!-- Default routing mirrors dc:* behaviour -->
+    <meta property="dcterms:creator">Author C</meta>
+    <meta property="dcterms:contributor">Contributor B</meta>
+    <!-- dcterms:publisher with a conflicting role refine is still always a publisher -->
+    <meta id="publisher-b" property="dcterms:publisher">Publisher B</meta>
     <meta refines="#publisher-b" property="role">aut</meta>
 
-    <!-- sortAs and role as attributes -->
-    <meta property="dcterms:contributor" opf:file-as="sorting" opf:role="ill">Illustrator A</meta> 
+    <!-- ── EPUB 3.x: media:narrator ────────────────────────────────────────────── -->
 
-    <!-- Only the first role is used -->
-    <meta id="cameleon-a" property="dcterms:contributor">Cameleon A</meta>
-    <meta refines="#cameleon-a" property="role">aut</meta>
-    <meta refines="#cameleon-a" property="role">pbl</meta>
+    <!-- media:narrator is always routed to narrator -->
+    <meta property="media:narrator">Narrator 2</meta>
+
+    <!-- ── Namespace variants ──────────────────────────────────────────────────── -->
+
+    <!-- dc:creator without a namespace prefix is recognised as a creator -->
+    <creator xmlns="http://purl.org/dc/elements/1.1/">Author NS-Default</creator>
+    <!-- dc:creator with a non-standard namespace prefix is recognised as a creator -->
+    <dc-alias:creator>Author NS-Alias</dc-alias:creator>
 
   </metadata>
   <manifest>

--- a/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
@@ -147,41 +147,66 @@ class EPUBMetadataParserTests: XCTestCase {
 
         XCTAssertEqual(sut, Metadata(
             conformsTo: [.epub],
-            title: "Alice's Adventures in Wonderland",
+            title: "Contributors Test",
             authors: [
+                // EPUB 2.x dc:creator: no role → author default
                 Contributor(name: "Author 1"),
-                Contributor(name: "Author 3"),
-                Contributor(name: "Author 4"),
+                // EPUB 2.x dc:creator: unknown role still falls back to author; role preserved
+                Contributor(name: "Creator Unknown Role", role: "xyz"),
+                // EPUB 3.x dc:creator: no refine → author default
                 Contributor(name: "Author A"),
+                // EPUB 3.x dcterms:creator: no refine → author default
+                Contributor(name: "Author C"),
+                // Namespace variants are recognised as creators
+                Contributor(name: "Author NS-Default"),
+                Contributor(name: "Author NS-Alias"),
+                // EPUB 2.x dc:contributor: opf:role="aut" routes to author
                 Contributor(name: "Author 2"),
-                Contributor(name: "Cameleon 1"),
-                Contributor(name: "Cameleon A"),
+                // EPUB 3.x dc:contributor: role refine "aut" routes to author
+                Contributor(name: "Author B"),
+                // Only the first role refine is used; "aut" wins over "pbl"
+                Contributor(name: "Author Multi-Role"),
             ],
-            translators: [Contributor(name: "Translator")],
-            editors: [Contributor(name: "Editor")],
-            artists: [Contributor(name: "Artist")],
+            translators: [Contributor(name: "Translator 1")],
+            editors: [Contributor(name: "Editor 1")],
+            artists: [Contributor(name: "Artist 1")],
             illustrators: [
-                Contributor(name: "Illustrator 1"),
-                Contributor(name: "Illustrator 2", sortAs: "sorting"),
-                Contributor(name: "Illustrator A", sortAs: "sorting"),
+                // opf:file-as is carried through to sortAs
+                Contributor(name: "Illustrator 1", sortAs: "Illustrator, The First"),
             ],
-            letterers: [],
-            pencilers: [],
-            colorists: [Contributor(name: "Colorist")],
-            inkers: [],
-            narrators: [Contributor(name: "Narrator")],
+            colorists: [Contributor(name: "Colorist 1")],
+            narrators: [
+                // EPUB 2.x dc:contributor: opf:role="nrt"
+                Contributor(name: "Narrator 1"),
+                // EPUB 3.x media:narrator element
+                Contributor(name: "Narrator 2"),
+            ],
             contributors: [
+                // dc:contributor with no role
                 Contributor(name: "Contributor 1"),
-                Contributor(name: "Unknown", roles: ["unknown"]),
+                // dc:contributor with unknown role; role is preserved on the object
+                Contributor(name: "Unknown 1", role: "unknown"),
+                // EPUB 3.x dc:contributor with no refine
                 Contributor(name: "Contributor A"),
+                // EPUB 3.x dc:contributor with unknown role refine; role preserved
+                Contributor(name: "Unknown A", role: "unknown"),
+                // EPUB 3.x dcterms:contributor with no refine
+                Contributor(name: "Contributor B"),
             ],
             publishers: [
+                // EPUB 2.x dc:creator: known role "pbl" overrides author default
+                Contributor(name: "Creator As Publisher"),
+                // EPUB 3.x dc:creator: role refine "pbl" overrides author default
+                Contributor(name: "Creator B As Publisher"),
+                // EPUB 2.x dc:publisher: always publisher
                 Contributor(name: "Publisher 1"),
+                // EPUB 3.x dc:publisher with conflicting role refine is still publisher
                 Contributor(name: "Publisher A"),
+                // EPUB 3.x dcterms:publisher with conflicting role refine is still publisher
                 Contributor(name: "Publisher B"),
+                // EPUB 2.x dc:contributor: opf:role="pbl" routes to publisher
                 Contributor(name: "Publisher 2"),
             ],
-            imprints: [],
             layout: .reflowable
         ))
     }


### PR DESCRIPTION
### Fixed

#### Streamer

* Fixed parsing of EPUB contributors.
    * Fixed `media:narrator` contributors not being recognized as narrators.
    * Fixed `dc:creator` elements with a known MARC relator role (e.g. `opf:role="trl"`) being incorrectly routed to the `author` collection instead of the role's collection.
    * A known role on a contributor no longer leaks into the `roles` field of the `Contributor` object when it is already expressed by the contributor's collection (e.g. `authors`, `publishers`).