### PR TITLE
Fix parsing of URI templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Fixed
 
+#### Shared
+
+* Fixed parsing of URI templates.
+    * Fixed `URITemplate` not recognizing `{&...}` (form-style query continuation) expressions.
+    * Fixed `URITemplate` expanding a form-style expression (`{?...}` or `{&...}`) to a bare `?` or `&` when none of the listed variables are provided. It now correctly expands to an empty string.
+
 #### Streamer
 
 * Fixed parsing of EPUB contributors.

--- a/Sources/Shared/Toolkit/URL/URITemplate.swift
+++ b/Sources/Shared/Toolkit/URL/URITemplate.swift
@@ -18,10 +18,12 @@ public struct URITemplate: CustomStringConvertible {
         self.uri = uri
     }
 
+    private static let parametersRegex = NSRegularExpression(#"\{[?&]?([^}]+)\}"#)
+
     /// List of URI template parameter keys.
     public var parameters: Set<String> {
         Set(
-            NSRegularExpression(#"\{\??([^}]+)\}"#)
+            URITemplate.parametersRegex
                 .matchesGroups(in: uri)
                 .flatMap { groups -> [String] in
                     guard groups.count == 2 else {
@@ -35,7 +37,7 @@ public struct URITemplate: CustomStringConvertible {
 
     /// Expands the URI by replacing the template variables by the given parameters.
     ///
-    /// Any extra parameter is appended as query parameters.
+    /// Extra parameters not found in the template are ignored.
     /// See RFC 6570 on URI template: https://tools.ietf.org/html/rfc6570
     public func expand(with parameters: [String: LosslessStringConvertible]) -> String {
         let parameters = parameters.mapValues { $0.description }
@@ -43,27 +45,31 @@ public struct URITemplate: CustomStringConvertible {
         func expandSimpleString(_ string: String) -> String {
             string
                 .split(separator: ",")
-                .map { parameters[String($0)]?.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? "" }
+                .map { parameters[String($0).trimmingCharacters(in: .whitespaces)]?.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? "" }
                 .joined(separator: ",")
         }
 
-        func expandFormStyle(_ string: String) -> String {
-            "?" + string
+        func expandFormStyle(prefix: String, _ string: String) -> String {
+            let pairs = string
                 .split(separator: ",")
-                .map {
-                    "\($0)=\(parameters[String($0)]?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+                .compactMap { variable -> String? in
+                    let key = String(variable).trimmingCharacters(in: .whitespaces)
+                    guard let value = parameters[key] else { return nil }
+                    return "\(key)=\(value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
                 }
                 .joined(separator: "&")
+            return pairs.isEmpty ? "" : prefix + pairs
         }
 
-        return ReplacingRegularExpression(#"\{(\??)([^}]+)\}"#) { _, groups in
+        return ReplacingRegularExpression(#"\{([?&]?)([^}]+)\}"#) { _, groups in
             guard groups.count == 3 else {
                 return ""
             }
-            return (groups[1].isEmpty)
-                ? expandSimpleString(groups[2])
-                : expandFormStyle(groups[2])
-
+            switch groups[1] {
+            case "?": return expandFormStyle(prefix: "?", groups[2])
+            case "&": return expandFormStyle(prefix: "&", groups[2])
+            default: return expandSimpleString(groups[2])
+            }
         }.stringByReplacingMatches(in: uri)
     }
 

--- a/Tests/SharedTests/Toolkit/URITemplateTests.swift
+++ b/Tests/SharedTests/Toolkit/URITemplateTests.swift
@@ -5,60 +5,116 @@
 //
 
 @testable import ReadiumShared
-import XCTest
+import Testing
 
-class URITemplateTests: XCTestCase {
-    func testParameters() {
-        XCTAssertEqual(
-            URITemplate("/url{?x,hello,y}name{z,y,w}").parameters,
-            ["x", "hello", "y", "z", "w"]
-        )
+@Suite struct URITemplateTests {
+    @Suite struct Parameters {
+        @Test func simpleVariables() {
+            #expect(URITemplate("{x,hello,y}").parameters == ["x", "hello", "y"])
+        }
+
+        @Test func formQueryVariables() {
+            #expect(URITemplate("{?x,y}").parameters == ["x", "y"])
+        }
+
+        @Test func formContinuationVariables() {
+            #expect(URITemplate("{&x,y}").parameters == ["x", "y"])
+        }
+
+        @Test func trimsWhitespace() {
+            #expect(URITemplate("{&end, id,name}").parameters == ["end", "id", "name"])
+        }
+
+        @Test func emptyForPlainURL() {
+            #expect(URITemplate("/url").parameters == [])
+        }
+
+        @Test func mixedOperators() {
+            #expect(URITemplate("/url{?x,hello,y}name{z,y,w}").parameters == ["x", "hello", "y", "z", "w"])
+        }
     }
 
-    func testParametersWithNoVariables() {
-        XCTAssertEqual(URITemplate("/url").parameters, [])
-    }
+    @Suite struct Expand {
+        @Suite struct SimpleString {
+            @Test func multipleVariables() {
+                #expect(
+                    URITemplate("/url{x,hello,y}name{z,y,w}").expand(with: [
+                        "x": "aaa",
+                        "hello": "Hello, world",
+                        "y": "b",
+                        "z": "45",
+                        "w": "w",
+                    ]) == "/urlaaa,Hello,%20world,bname45,b,w"
+                )
+            }
 
-    func testExpandSimpleStringTemplates() {
-        XCTAssertEqual(
-            URITemplate("/url{x,hello,y}name{z,y,w}").expand(with: [
-                "x": "aaa",
-                "hello": "Hello, world",
-                "y": "b",
-                "z": "45",
-                "w": "w",
-            ]),
-            "/urlaaa,Hello,%20world,bname45,b,w"
-        )
-    }
+            @Test func missingVariableExpandsToEmpty() {
+                #expect(URITemplate("{x,y}").expand(with: ["x": "a"]) == "a,")
+            }
+        }
 
-    func testExpandFormStyleAmpersandSeparatedTemplates() {
-        XCTAssertEqual(
-            URITemplate("/url{?x,hello,y}name").expand(with: [
-                "x": "aaa",
-                "hello": "Hello, world",
-                "y": "b",
-            ]),
-            "/url?x=aaa&hello=Hello,%20world&y=bname"
-        )
-    }
+        @Suite struct FormQuery {
+            @Test func standardExpansion() {
+                #expect(
+                    URITemplate("/url{?x,hello,y}name").expand(with: [
+                        "x": "aaa",
+                        "hello": "Hello, world",
+                        "y": "b",
+                    ]) == "/url?x=aaa&hello=Hello,%20world&y=bname"
+                )
+            }
 
-    func testExpandIgnoresExtraParameters() {
-        XCTAssertEqual(
-            URITemplate("/path{?search}").expand(with: [
-                "search": "banana",
-                "code": "14",
-            ]),
-            "/path?search=banana"
-        )
-    }
+            @Test func missingVariablesOmitted() {
+                #expect(URITemplate("{?x,y}").expand(with: ["x": "a"]) == "?x=a")
+            }
 
-    func testExpandWithNoVariables() {
-        XCTAssertEqual(
-            URITemplate("/path").expand(with: [
-                "search": "banana",
-            ]),
-            "/path"
-        )
+            @Test func allVariablesMissingExpandsToEmpty() {
+                #expect(URITemplate("{?x,y}").expand(with: [:]) == "")
+            }
+        }
+
+        @Suite struct FormContinuation {
+            @Test func standardExpansion() {
+                #expect(
+                    URITemplate("{&x,y}").expand(with: ["x": "a", "y": "b"]) == "&x=a&y=b"
+                )
+            }
+
+            @Test func appendsToExistingQueryString() {
+                #expect(
+                    URITemplate("/url?a=1{&x,y}").expand(with: ["x": "foo", "y": "bar"]) == "/url?a=1&x=foo&y=bar"
+                )
+            }
+
+            @Test func trimsWhitespaceAroundVariableNames() {
+                #expect(URITemplate("{& a , b }").expand(with: ["a": "1", "b": "2"]) == "&a=1&b=2")
+            }
+
+            @Test func missingVariablesOmitted() {
+                #expect(URITemplate("{&x,y}").expand(with: ["x": "a"]) == "&x=a")
+            }
+
+            @Test func allVariablesMissingExpandsToEmpty() {
+                #expect(URITemplate("{&x,y}").expand(with: [:]) == "")
+            }
+        }
+
+        @Suite struct General {
+            @Test func noVariableTemplateUnchanged() {
+                #expect(URITemplate("/path").expand(with: ["search": "banana"]) == "/path")
+            }
+
+            @Test func extraParametersIgnored() {
+                #expect(
+                    URITemplate("/path{?search}").expand(with: ["search": "banana", "code": "14"]) == "/path?search=banana"
+                )
+            }
+
+            @Test func mixedOperators() {
+                #expect(
+                    URITemplate("/url{?x}{&y}").expand(with: ["x": "a", "y": "b"]) == "/url?x=a&y=b"
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
### Fixed

#### Shared

* Fixed parsing of URI templates.
    * Fixed `URITemplate` not recognizing `{&...}` (form-style query continuation) expressions.
    * Fixed `URITemplate` expanding a form-style expression (`{?...}` or `{&...}`) to a bare `?` or `&` when none of the listed variables are provided. It now correctly expands to an empty string.