### PR TITLE
Add support for SVG covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file. Take a look
     * `Recipes/` contains self-contained and explained code you can reuse in your own application.
     * `App/` folder contains the scaffolding (file management, navigation, error handling) needed to run the Playground.
 
+#### Shared
+
+* Added support for SVG covers in `ResourceCoverService`. SVG images can now be used as publication covers and are rendered to bitmaps (contributed by [@grighakobian](https://github.com/readium/swift-toolkit/pull/751)).
+
 ### Removed
 
 * Carthage is no longer a supported distribution method. Please migrate to Swift Package Manager or CocoaPods.

--- a/Sources/Shared/Publication/Services/Cover/CoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/CoverService.swift
@@ -27,14 +27,12 @@ public typealias CoverServiceFactory = (PublicationServiceContext) -> CoverServi
 public protocol CoverService: PublicationService {
     /// Returns the publication cover as a bitmap at its maximum size.
     ///
-    /// If the cover is not a bitmap format (e.g. SVG), it will be scaled down to fit the screen
-    /// using `UIScreen.main.bounds.size`.
+    /// If the cover is not a bitmap format (e.g. SVG), it will be rendered at its intrinsic size,
+    /// or scaled down to a reasonable maximum to avoid excessive memory usage.
     func cover() async -> ReadResult<UIImage?>
 
-    /// Returns the publication cover as a bitmap, scaled down to fit the given `maxSize`.
-    ///
-    /// If the cover is not in a bitmap format (e.g. SVG), it is exported as a bitmap filling
-    /// `maxSize`. The cover might be cached in memory for next calls.
+    /// Returns the publication cover as a bitmap, scaled down to fit within `maxSize` while
+    /// preserving the aspect ratio. The cover might be cached in memory for next calls.
     func coverFitting(maxSize: CGSize) async -> ReadResult<UIImage?>
 }
 

--- a/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
@@ -28,7 +28,7 @@ public final class ResourceCoverService: CoverService {
     }
 
     public func coverFitting(maxSize: CGSize) async -> ReadResult<UIImage?> {
-        await loadCover(maxSize: maxSize).map { $0?.scaleToFit(maxSize: maxSize) }
+        await loadCover(maxSize: maxSize)
     }
 
     private func loadCover(maxSize: CGSize?) async -> ReadResult<UIImage?> {
@@ -41,16 +41,13 @@ public final class ResourceCoverService: CoverService {
 
         // Fallback: first reading order bitmap/SVG or alternate
         if let firstLink = context.manifest.readingOrder.first {
-            if firstLink.mediaType?.isBitmap == true || firstLink.mediaType?.matches(.svg) == true {
-                if let image = await loadImage(from: firstLink, maxSize: maxSize) {
-                    return .success(image)
-                }
+            if let image = await loadImage(from: firstLink, maxSize: maxSize) {
+                return .success(image)
             }
+
             for alternate in firstLink.alternates {
-                if alternate.mediaType?.isBitmap == true || alternate.mediaType?.matches(.svg) == true {
-                    if let image = await loadImage(from: alternate, maxSize: maxSize) {
-                        return .success(image)
-                    }
+                if let image = await loadImage(from: alternate, maxSize: maxSize) {
+                    return .success(image)
                 }
             }
         }
@@ -60,15 +57,23 @@ public final class ResourceCoverService: CoverService {
 
     private func loadImage(from link: Link, maxSize: CGSize?) async -> UIImage? {
         guard
+            let mediaType = link.mediaType,
+            mediaType.isBitmap || mediaType.matches(.svg),
             let resource = context.container[link.url()],
             let data = try? await resource.read().get()
         else {
             return nil
         }
+
         if link.mediaType?.matches(.svg) == true {
             return UIImage.fromSVG(data, maxSize: maxSize ?? Self.defaultCoverMaxSize)
         }
-        return UIImage(data: data)
+
+        let image = UIImage(data: data)
+        if let maxSize = maxSize {
+            return image?.scaleToFit(maxSize: maxSize)
+        }
+        return image
     }
 
     public static func makeFactory() -> (PublicationServiceContext) -> ResourceCoverService {

--- a/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
@@ -30,13 +30,13 @@ public final class ResourceCoverService: CoverService {
 
         // Fallback: first reading order bitmap/SVG or alternate
         if let firstLink = context.manifest.readingOrder.first {
-            if firstLink.mediaType?.isImage == true {
+            if firstLink.mediaType?.isBitmap == true || firstLink.mediaType?.matches(.svg) == true {
                 if let image = await loadImage(from: firstLink) {
                     return .success(image)
                 }
             }
             for alternate in firstLink.alternates {
-                if alternate.mediaType?.isImage == true {
+                if alternate.mediaType?.isBitmap == true || alternate.mediaType?.matches(.svg) == true {
                     if let image = await loadImage(from: alternate) {
                         return .success(image)
                     }
@@ -54,7 +54,7 @@ public final class ResourceCoverService: CoverService {
         else {
             return nil
         }
-        if link.mediaType?.isSVG == true {
+        if link.mediaType?.matches(.svg) == true {
             return UIImage.fromSVG(data)
         }
         return UIImage(data: data)

--- a/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
@@ -65,7 +65,7 @@ public final class ResourceCoverService: CoverService {
             return nil
         }
 
-        if link.mediaType?.matches(.svg) == true {
+        if mediaType.matches(.svg) {
             return UIImage.fromSVG(data, maxSize: maxSize ?? Self.defaultCoverMaxSize)
         }
 

--- a/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
@@ -24,7 +24,7 @@ public final class ResourceCoverService: CoverService {
         } else {
             UIScreen.main.scale
         }
-        self.coverMaxSize = CGSize(
+        coverMaxSize = CGSize(
             width: 400 * scale,
             height: 600 * scale
         )

--- a/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
@@ -14,20 +14,13 @@ import UIKit
 /// 2. First `readingOrder` resource if it's a bitmap or SVG, or if it has a
 ///    bitmap/SVG `alternates`.
 public final class ResourceCoverService: CoverService {
+    /// Default maximum size in points for SVG cover rendering.
+    private static let defaultCoverMaxSize = CGSize(width: 400, height: 600)
+
     private let context: PublicationServiceContext
-    private let coverMaxSize: CGSize
 
     public init(context: PublicationServiceContext) {
         self.context = context
-        let scale: CGFloat = if #available(iOS 16.0, *) {
-            UITraitCollection.current.displayScale
-        } else {
-            UIScreen.main.scale
-        }
-        coverMaxSize = CGSize(
-            width: 400 * scale,
-            height: 600 * scale
-        )
     }
 
     public func cover() async -> ReadResult<UIImage?> {
@@ -73,7 +66,7 @@ public final class ResourceCoverService: CoverService {
             return nil
         }
         if link.mediaType?.matches(.svg) == true {
-            return UIImage.fromSVG(data, maxSize: maxSize ?? coverMaxSize)
+            return UIImage.fromSVG(data, maxSize: maxSize ?? Self.defaultCoverMaxSize)
         }
         return UIImage(data: data)
     }

--- a/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
@@ -11,19 +11,37 @@ import UIKit
 ///
 /// It will look for:
 /// 1. Links with explicit `cover` relation in the resources.
-/// 2. First `readingOrder` resource if it's a bitmap, or if it has a bitmap
-///    `alternates`.
+/// 2. First `readingOrder` resource if it's a bitmap or SVG, or if it has a
+///    bitmap/SVG `alternates`.
 public final class ResourceCoverService: CoverService {
     private let context: PublicationServiceContext
+    private let coverMaxSize: CGSize
 
     public init(context: PublicationServiceContext) {
         self.context = context
+        let scale: CGFloat = if #available(iOS 16.0, *) {
+            UITraitCollection.current.displayScale
+        } else {
+            UIScreen.main.scale
+        }
+        self.coverMaxSize = CGSize(
+            width: 400 * scale,
+            height: 600 * scale
+        )
     }
 
     public func cover() async -> ReadResult<UIImage?> {
+        await loadCover(maxSize: nil)
+    }
+
+    public func coverFitting(maxSize: CGSize) async -> ReadResult<UIImage?> {
+        await loadCover(maxSize: maxSize).map { $0?.scaleToFit(maxSize: maxSize) }
+    }
+
+    private func loadCover(maxSize: CGSize?) async -> ReadResult<UIImage?> {
         // Try resources with explicit `cover` relation
         for link in context.manifest.linksWithRel(.cover) {
-            if let image = await loadImage(from: link) {
+            if let image = await loadImage(from: link, maxSize: maxSize) {
                 return .success(image)
             }
         }
@@ -31,13 +49,13 @@ public final class ResourceCoverService: CoverService {
         // Fallback: first reading order bitmap/SVG or alternate
         if let firstLink = context.manifest.readingOrder.first {
             if firstLink.mediaType?.isBitmap == true || firstLink.mediaType?.matches(.svg) == true {
-                if let image = await loadImage(from: firstLink) {
+                if let image = await loadImage(from: firstLink, maxSize: maxSize) {
                     return .success(image)
                 }
             }
             for alternate in firstLink.alternates {
                 if alternate.mediaType?.isBitmap == true || alternate.mediaType?.matches(.svg) == true {
-                    if let image = await loadImage(from: alternate) {
+                    if let image = await loadImage(from: alternate, maxSize: maxSize) {
                         return .success(image)
                     }
                 }
@@ -47,7 +65,7 @@ public final class ResourceCoverService: CoverService {
         return .success(nil)
     }
 
-    private func loadImage(from link: Link) async -> UIImage? {
+    private func loadImage(from link: Link, maxSize: CGSize?) async -> UIImage? {
         guard
             let resource = context.container[link.url()],
             let data = try? await resource.read().get()
@@ -55,7 +73,7 @@ public final class ResourceCoverService: CoverService {
             return nil
         }
         if link.mediaType?.matches(.svg) == true {
-            return UIImage.fromSVG(data)
+            return UIImage.fromSVG(data, maxSize: maxSize ?? coverMaxSize)
         }
         return UIImage(data: data)
     }

--- a/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/ResourceCoverService.swift
@@ -28,15 +28,15 @@ public final class ResourceCoverService: CoverService {
             }
         }
 
-        // Fallback: first reading order bitmap or alternate
+        // Fallback: first reading order bitmap/SVG or alternate
         if let firstLink = context.manifest.readingOrder.first {
-            if firstLink.mediaType?.isBitmap == true {
+            if firstLink.mediaType?.isImage == true {
                 if let image = await loadImage(from: firstLink) {
                     return .success(image)
                 }
             }
             for alternate in firstLink.alternates {
-                if alternate.mediaType?.isBitmap == true {
+                if alternate.mediaType?.isImage == true {
                     if let image = await loadImage(from: alternate) {
                         return .success(image)
                     }
@@ -53,6 +53,9 @@ public final class ResourceCoverService: CoverService {
             let data = try? await resource.read().get()
         else {
             return nil
+        }
+        if link.mediaType?.isSVG == true {
+            return UIImage.fromSVG(data)
         }
         return UIImage(data: data)
     }

--- a/Sources/Shared/Toolkit/Extensions/UIImage.swift
+++ b/Sources/Shared/Toolkit/Extensions/UIImage.swift
@@ -5,10 +5,53 @@
 //
 
 import func AVFoundation.AVMakeRect
+import CoreGraphics
 import Foundation
 import UIKit
 
+private enum CoreSVG {
+    typealias CreateFromData = @convention(c) (CFData, CFDictionary?) -> Unmanaged<CFTypeRef>?
+    typealias GetCanvasSize = @convention(c) (CFTypeRef) -> CGSize
+    typealias DrawInContext = @convention(c) (CGContext, CFTypeRef) -> Void
+
+    static let createFromData: CreateFromData? = load("CGSVGDocumentCreateFromData")
+    static let getCanvasSize: GetCanvasSize? = load("CGSVGDocumentGetCanvasSize")
+    static let drawInContext: DrawInContext? = load("CGContextDrawSVGDocument")
+
+    private static func load<T>(_ name: String) -> T? {
+        guard let sym = dlsym(dlopen(nil, RTLD_LAZY), name) else { return nil }
+        return unsafeBitCast(sym, to: T.self)
+    }
+}
+
 extension UIImage {
+    /// Creates a `UIImage` by rendering an SVG document from the given data.
+    ///
+    /// Returns `nil` if the data is not a valid SVG or if SVG rendering is
+    /// unavailable on the current platform.
+    static func fromSVG(_ data: Data) -> UIImage? {
+        guard
+            let createFromData = CoreSVG.createFromData,
+            let getCanvasSize = CoreSVG.getCanvasSize,
+            let drawInContext = CoreSVG.drawInContext,
+            let document = createFromData(data as CFData, nil)
+        else {
+            return nil
+        }
+        let svgDocument = document.takeRetainedValue()
+        let size = getCanvasSize(svgDocument)
+        guard size.width > 0, size.height > 0 else {
+            return nil
+        }
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { ctx in
+            let cgContext = ctx.cgContext
+            cgContext.translateBy(x: 0, y: size.height)
+            cgContext.scaleBy(x: 1, y: -1)
+            drawInContext(cgContext, svgDocument)
+        }
+    }
+
     func scaleToFit(maxSize: CGSize) -> UIImage {
         if size.width <= maxSize.width, size.height <= maxSize.height {
             return self

--- a/Sources/Shared/Toolkit/Extensions/UIImage.swift
+++ b/Sources/Shared/Toolkit/Extensions/UIImage.swift
@@ -40,12 +40,13 @@ extension UIImage {
             let createFromData = CoreSVG.createFromData,
             let getCanvasSize = CoreSVG.getCanvasSize,
             let drawInContext = CoreSVG.drawInContext,
+            let releaseDocument = CoreSVG.releaseDocument,
             let document = createFromData(data as CFData, nil)
         else {
             return nil
         }
         let svgDocument = document.takeUnretainedValue()
-        defer { CoreSVG.releaseDocument?(svgDocument) }
+        defer { releaseDocument(svgDocument) }
 
         let canvasSize = getCanvasSize(svgDocument)
         guard canvasSize.width > 0, canvasSize.height > 0 else {

--- a/Sources/Shared/Toolkit/Extensions/UIImage.swift
+++ b/Sources/Shared/Toolkit/Extensions/UIImage.swift
@@ -13,10 +13,12 @@ private enum CoreSVG {
     typealias CreateFromData = @convention(c) (CFData, CFDictionary?) -> Unmanaged<CFTypeRef>?
     typealias GetCanvasSize = @convention(c) (CFTypeRef) -> CGSize
     typealias DrawInContext = @convention(c) (CGContext, CFTypeRef) -> Void
+    typealias ReleaseDocument = @convention(c) (CFTypeRef) -> Void
 
     static let createFromData: CreateFromData? = load("CGSVGDocumentCreateFromData")
     static let getCanvasSize: GetCanvasSize? = load("CGSVGDocumentGetCanvasSize")
     static let drawInContext: DrawInContext? = load("CGContextDrawSVGDocument")
+    static let releaseDocument: ReleaseDocument? = load("CGSVGDocumentRelease")
 
     private static func load<T>(_ name: String) -> T? {
         guard let sym = dlsym(dlopen(nil, RTLD_LAZY), name) else { return nil }
@@ -38,7 +40,8 @@ extension UIImage {
         else {
             return nil
         }
-        let svgDocument = document.takeRetainedValue()
+        let svgDocument = document.takeUnretainedValue()
+        defer { CoreSVG.releaseDocument?(svgDocument) }
         let size = getCanvasSize(svgDocument)
         guard size.width > 0, size.height > 0 else {
             return nil

--- a/Sources/Shared/Toolkit/Extensions/UIImage.swift
+++ b/Sources/Shared/Toolkit/Extensions/UIImage.swift
@@ -27,11 +27,15 @@ private enum CoreSVG {
 }
 
 extension UIImage {
-    /// Creates a `UIImage` by rendering an SVG document from the given data.
+    /// Creates a `UIImage` by rendering an SVG document from the given data,
+    /// scaled down to fit `maxSize` while preserving the aspect ratio.
+    ///
+    /// If the SVG canvas is smaller than `maxSize`, it is rendered at its
+    /// native size to avoid upscaling embedded bitmaps.
     ///
     /// Returns `nil` if the data is not a valid SVG or if SVG rendering is
     /// unavailable on the current platform.
-    static func fromSVG(_ data: Data) -> UIImage? {
+    static func fromSVG(_ data: Data, maxSize: CGSize) -> UIImage? {
         guard
             let createFromData = CoreSVG.createFromData,
             let getCanvasSize = CoreSVG.getCanvasSize,
@@ -42,15 +46,32 @@ extension UIImage {
         }
         let svgDocument = document.takeUnretainedValue()
         defer { CoreSVG.releaseDocument?(svgDocument) }
-        let size = getCanvasSize(svgDocument)
-        guard size.width > 0, size.height > 0 else {
+
+        let canvasSize = getCanvasSize(svgDocument)
+        guard canvasSize.width > 0, canvasSize.height > 0 else {
             return nil
         }
-        let renderer = UIGraphicsImageRenderer(size: size)
+
+        // Render at the smaller of the canvas size and the requested max
+        // size, preserving the SVG aspect ratio.
+        let renderSize: CGSize
+        if canvasSize.width <= maxSize.width, canvasSize.height <= maxSize.height {
+            renderSize = canvasSize
+        } else {
+            let targetRect = AVMakeRect(
+                aspectRatio: canvasSize,
+                insideRect: CGRect(origin: .zero, size: maxSize)
+            )
+            renderSize = targetRect.size
+        }
+
+        let renderer = UIGraphicsImageRenderer(size: renderSize)
         return renderer.image { ctx in
             let cgContext = ctx.cgContext
-            cgContext.translateBy(x: 0, y: size.height)
-            cgContext.scaleBy(x: 1, y: -1)
+            let scaleX = renderSize.width / canvasSize.width
+            let scaleY = renderSize.height / canvasSize.height
+            cgContext.translateBy(x: 0, y: renderSize.height)
+            cgContext.scaleBy(x: scaleX, y: -scaleY)
             drawInContext(cgContext, svgDocument)
         }
     }

--- a/Sources/Shared/Toolkit/Format/MediaType.swift
+++ b/Sources/Shared/Toolkit/Format/MediaType.swift
@@ -191,16 +191,6 @@ public struct MediaType: Sendable, Hashable, RawRepresentable, JSONValueEncodabl
         matchesAny(.avif, .bmp, .gif, .jpeg, .jxl, .png, .tiff, .webp)
     }
 
-    /// Returns whether this media type is of an SVG image.
-    public var isSVG: Bool {
-        matches(.svg)
-    }
-
-    /// Returns whether this media type is of an image, including both bitmap and vectorial formats.
-    public var isImage: Bool {
-        isBitmap || isSVG
-    }
-
     /// Returns whether this media type is of an audio clip.
     public var isAudio: Bool {
         type == "audio"

--- a/Sources/Shared/Toolkit/Format/MediaType.swift
+++ b/Sources/Shared/Toolkit/Format/MediaType.swift
@@ -191,6 +191,16 @@ public struct MediaType: Sendable, Hashable, RawRepresentable, JSONValueEncodabl
         matchesAny(.avif, .bmp, .gif, .jpeg, .jxl, .png, .tiff, .webp)
     }
 
+    /// Returns whether this media type is of an SVG image.
+    public var isSVG: Bool {
+        matches(.svg)
+    }
+
+    /// Returns whether this media type is of an image, including both bitmap and vectorial formats.
+    public var isImage: Bool {
+        isBitmap || isSVG
+    }
+
     /// Returns whether this media type is of an audio clip.
     public var isAudio: Bool {
         type == "audio"

--- a/Tests/SharedTests/Fixtures/Publication/Services/cover-svg.svg
+++ b/Tests/SharedTests/Fixtures/Publication/Services/cover-svg.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="150" viewBox="0 0 100 150">
+  <rect width="100" height="150" fill="#336699"/>
+  <text x="50" y="80" text-anchor="middle" fill="white" font-size="14">Cover</text>
+</svg>

--- a/Tests/SharedTests/Fixtures/Toolkit/Extensions/cover-svg.svg
+++ b/Tests/SharedTests/Fixtures/Toolkit/Extensions/cover-svg.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="150" viewBox="0 0 100 150">
+  <rect width="100" height="150" fill="#336699"/>
+  <text x="50" y="80" text-anchor="middle" fill="white" font-size="14">Cover</text>
+</svg>

--- a/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
@@ -77,6 +77,69 @@ class CoverServiceTests: XCTestCase {
         AssertImageEqual(result, .success(cover))
     }
 
+    /// `ResourceCoverService` loads an SVG cover when the resource has an explicit `.cover`
+    /// relation and an SVG media type.
+    func testResourceCoverServiceHandlesSVGCoverLink() async {
+        let publication = makePublication(
+            resources: [Link(href: "cover-svg.svg", mediaType: .svg, rels: [.cover])],
+            containerURL: fixtures.url(for: "cover-svg.svg"),
+            containerHref: "cover-svg.svg"
+        )
+        let result = await publication.cover()
+        switch result {
+        case let .success(image):
+            XCTAssertNotNil(image, "SVG cover should produce a non-nil UIImage")
+        case let .failure(error):
+            XCTFail("Expected success but got \(error)")
+        }
+    }
+
+    /// `ResourceCoverService` uses the first SVG reading order item when no explicit `.cover`
+    /// link is declared.
+    func testResourceCoverServiceUsesFirstSVGReadingOrderItem() async {
+        let publication = makePublication(
+            readingOrder: [
+                Link(href: "cover-svg.svg", mediaType: .svg),
+            ],
+            resources: [],
+            containerURL: fixtures.url(for: "cover-svg.svg"),
+            containerHref: "cover-svg.svg"
+        )
+        let result = await publication.cover()
+        switch result {
+        case let .success(image):
+            XCTAssertNotNil(image, "SVG reading order item should produce a non-nil UIImage")
+        case let .failure(error):
+            XCTFail("Expected success but got \(error)")
+        }
+    }
+
+    /// `ResourceCoverService` uses the first SVG alternate of the first reading order item
+    /// when that item is not an image.
+    func testResourceCoverServiceUsesFirstReadingOrderSVGAlternate() async {
+        let publication = makePublication(
+            readingOrder: [
+                Link(
+                    href: "chapter1.xhtml",
+                    mediaType: .xhtml,
+                    alternates: [
+                        Link(href: "cover-svg.svg", mediaType: .svg),
+                    ]
+                ),
+            ],
+            resources: [],
+            containerURL: fixtures.url(for: "cover-svg.svg"),
+            containerHref: "cover-svg.svg"
+        )
+        let result = await publication.cover()
+        switch result {
+        case let .success(image):
+            XCTAssertNotNil(image, "SVG alternate should produce a non-nil UIImage")
+        case let .failure(error):
+            XCTFail("Expected success but got \(error)")
+        }
+    }
+
     /// `ResourceCoverService` returns nil when no explicit `.cover` link is declared and no bitmap
     /// is available.
     func testResourceCoverServiceReturnsNilWhenNoBitmapAvailable() async {
@@ -118,7 +181,9 @@ class CoverServiceTests: XCTestCase {
     private func makePublication(
         readingOrder: [Link] = [],
         resources: [Link] = [Link(href: "cover.jpg", rels: [.cover])],
-        cover: CoverServiceFactory? = nil
+        cover: CoverServiceFactory? = nil,
+        containerURL: FileURL? = nil,
+        containerHref: String = "cover.jpg"
     ) -> Publication {
         var builder = PublicationServicesBuilder()
         if let cover { builder.setCoverServiceFactory(cover) }
@@ -129,8 +194,8 @@ class CoverServiceTests: XCTestCase {
                 resources: resources
             ),
             container: SingleResourceContainer(
-                resource: FileResource(file: coverURL),
-                at: AnyURL(string: "cover.jpg")!
+                resource: FileResource(file: containerURL ?? coverURL),
+                at: AnyURL(string: containerHref)!
             ),
             servicesBuilder: builder
         )

--- a/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
@@ -5,233 +5,80 @@
 //
 
 @testable import ReadiumShared
-import XCTest
+import Testing
+import UIKit
 
-class CoverServiceTests: XCTestCase {
-    let fixtures = Fixtures(path: "Publication/Services")
+private let fixtures = Fixtures(path: "Publication/Services")
+private let coverURL = fixtures.url(for: "cover.jpg")
+private let cover = UIImage(contentsOfFile: coverURL.path)!
+private let cover2 = UIImage(data: fixtures.data(at: "cover2.jpg"))!
 
-    lazy var coverURL = fixtures.url(for: "cover.jpg")
-    lazy var cover = UIImage(contentsOfFile: coverURL.path)!
-    lazy var cover2 = UIImage(data: fixtures.data(at: "cover2.jpg"))!
+@Suite struct CoverServiceTests {
+    @Suite struct PublicationHelpers {
+        @Test func coverDelegatesToCustomService() async throws {
+            let pub = makePublication { _ in TestCoverService(cover: cover2) }
+            let image = try await pub.cover().get()
+            #expect(image?.pngData() == cover2.pngData())
+        }
 
-    /// `Publication.cover` will use a custom `CoverService` if provided.
-    func testCoverHelperUsesCustomCoverService() async {
-        let publication = makePublication { _ in TestCoverService(cover: self.cover2) }
-        let result = await publication.cover()
-        AssertImageEqual(result, .success(cover2))
-    }
+        @Test func coverUsesResourceCoverServiceByDefault() async throws {
+            let image = try await makePublication().cover().get()
+            #expect(image?.pngData() == cover.pngData())
+        }
 
-    /// `Publication.cover` uses `ResourceCoverService` by default.
-    func testCoverHelperUsesResourceCoverServiceByDefault() async {
-        let publication = makePublication()
-        let result = await publication.cover()
-        AssertImageEqual(result, .success(cover))
-    }
+        @Test func coverReturnsNilWithoutService() async throws {
+            let image = try await makePublicationWithoutCoverService().cover().get()
+            #expect(image == nil)
+        }
 
-    /// `Publication.coverFitting` will use a custom `CoverService` if provided.
-    func testCoverFittingHelperUsesCustomCoverService() async {
-        let size = CGSize(width: 100, height: 100)
-        let publication = makePublication { _ in TestCoverService(cover: self.cover2) }
-        let result = await publication.coverFitting(maxSize: size)
-        AssertImageEqual(result, .success(cover2.scaleToFit(maxSize: size)))
-    }
+        @Test func coverFittingDelegatesToCustomService() async throws {
+            let size = CGSize(width: 100, height: 100)
+            let pub = makePublication { _ in TestCoverService(cover: cover2) }
+            let image = try await pub.coverFitting(maxSize: size).get()
+            #expect(image?.pngData() == cover2.scaleToFit(maxSize: size).pngData())
+        }
 
-    /// `Publication.coverFitting` uses `ResourceCoverService` by default.
-    func testCoverFittingHelperUsesResourceCoverServiceByDefault() async {
-        let size = CGSize(width: 100, height: 100)
-        let publication = makePublication()
-        let result = await publication.coverFitting(maxSize: size)
-        AssertImageEqual(result, .success(cover.scaleToFit(maxSize: size)))
-    }
+        @Test func coverFittingUsesResourceCoverServiceByDefault() async throws {
+            let size = CGSize(width: 100, height: 100)
+            let image = try await makePublication().coverFitting(maxSize: size).get()
+            #expect(image?.pngData() == cover.scaleToFit(maxSize: size).pngData())
+        }
 
-    /// `ResourceCoverService` uses the first bitmap reading order item when no explicit `.cover`
-    /// link is declared.
-    func testResourceCoverServiceUsesFirstBitmapReadingOrderItem() async {
-        let publication = makePublication(
-            readingOrder: [
-                Link(href: "cover.jpg", mediaType: .jpeg),
-                Link(href: "page2.jpg", mediaType: .jpeg),
-            ],
-            resources: []
-        )
-        let result = await publication.cover()
-        AssertImageEqual(result, .success(cover))
-    }
-
-    /// `ResourceCoverService` uses the first bitmap alternate of the first reading order item
-    /// when that item is not a bitmap.
-    func testResourceCoverServiceUsesFirstReadingOrderBitmapAlternate() async {
-        let publication = makePublication(
-            readingOrder: [
-                Link(
-                    href: "chapter1.xhtml",
-                    mediaType: .xhtml,
-                    alternates: [
-                        Link(href: "cover.jpg", mediaType: .jpeg),
-                    ]
-                ),
-            ],
-            resources: []
-        )
-        let result = await publication.cover()
-        AssertImageEqual(result, .success(cover))
-    }
-
-    /// `ResourceCoverService` loads an SVG cover when the resource has an explicit `.cover`
-    /// relation and an SVG media type.
-    func testResourceCoverServiceHandlesSVGCoverLink() async {
-        let publication = makePublication(
-            resources: [Link(href: "cover-svg.svg", mediaType: .svg, rels: [.cover])],
-            containerURL: fixtures.url(for: "cover-svg.svg"),
-            containerHref: "cover-svg.svg"
-        )
-        let result = await publication.cover()
-        switch result {
-        case let .success(image):
-            XCTAssertNotNil(image, "SVG cover should produce a non-nil UIImage")
-        case let .failure(error):
-            XCTFail("Expected success but got \(error)")
+        @Test func coverFittingReturnsNilWithoutService() async throws {
+            let image = try await makePublicationWithoutCoverService()
+                .coverFitting(maxSize: CGSize(width: 100, height: 100)).get()
+            #expect(image == nil)
         }
     }
+}
 
-    /// `ResourceCoverService` uses the first SVG reading order item when no explicit `.cover`
-    /// link is declared.
-    func testResourceCoverServiceUsesFirstSVGReadingOrderItem() async {
-        let publication = makePublication(
-            readingOrder: [
-                Link(href: "cover-svg.svg", mediaType: .svg),
-            ],
-            resources: [],
-            containerURL: fixtures.url(for: "cover-svg.svg"),
-            containerHref: "cover-svg.svg"
-        )
-        let result = await publication.cover()
-        switch result {
-        case let .success(image):
-            XCTAssertNotNil(image, "SVG reading order item should produce a non-nil UIImage")
-        case let .failure(error):
-            XCTFail("Expected success but got \(error)")
-        }
-    }
+private func makePublication(
+    cover: CoverServiceFactory? = nil
+) -> Publication {
+    var builder = PublicationServicesBuilder()
+    if let cover { builder.setCoverServiceFactory(cover) }
+    return Publication(
+        manifest: Manifest(
+            metadata: Metadata(title: "title"),
+            resources: [Link(href: "cover.jpg", mediaType: .jpeg, rels: [.cover])]
+        ),
+        container: SingleResourceContainer(
+            resource: FileResource(file: coverURL),
+            at: AnyURL(string: "cover.jpg")!
+        ),
+        servicesBuilder: builder
+    )
+}
 
-    /// `ResourceCoverService` uses the first SVG alternate of the first reading order item
-    /// when that item is not an image.
-    func testResourceCoverServiceUsesFirstReadingOrderSVGAlternate() async {
-        let publication = makePublication(
-            readingOrder: [
-                Link(
-                    href: "chapter1.xhtml",
-                    mediaType: .xhtml,
-                    alternates: [
-                        Link(href: "cover-svg.svg", mediaType: .svg),
-                    ]
-                ),
-            ],
-            resources: [],
-            containerURL: fixtures.url(for: "cover-svg.svg"),
-            containerHref: "cover-svg.svg"
-        )
-        let result = await publication.cover()
-        switch result {
-        case let .success(image):
-            XCTAssertNotNil(image, "SVG alternate should produce a non-nil UIImage")
-        case let .failure(error):
-            XCTFail("Expected success but got \(error)")
-        }
-    }
-
-    /// `coverFitting` scales an SVG cover down to the requested max size.
-    func testCoverFittingSVGScalesDown() async {
-        let size = CGSize(width: 50, height: 75)
-        let publication = makePublication(
-            resources: [Link(href: "cover-svg.svg", mediaType: .svg, rels: [.cover])],
-            containerURL: fixtures.url(for: "cover-svg.svg"),
-            containerHref: "cover-svg.svg"
-        )
-        let result = await publication.coverFitting(maxSize: size)
-        switch result {
-        case let .success(image):
-            XCTAssertNotNil(image, "SVG coverFitting should produce a non-nil UIImage")
-            if let image {
-                XCTAssertLessThanOrEqual(image.size.width, size.width)
-                XCTAssertLessThanOrEqual(image.size.height, size.height)
-            }
-        case let .failure(error):
-            XCTFail("Expected success but got \(error)")
-        }
-    }
-
-    /// `UIImage.fromSVG` returns nil for empty data.
-    func testFromSVGReturnsNilForEmptyData() {
-        XCTAssertNil(UIImage.fromSVG(Data(), maxSize: CGSize(width: 400, height: 600)))
-    }
-
-    /// `UIImage.fromSVG` returns nil for non-SVG data.
-    func testFromSVGReturnsNilForNonSVGData() {
-        let jpegData = fixtures.data(at: "cover.jpg")
-        XCTAssertNil(UIImage.fromSVG(jpegData, maxSize: CGSize(width: 400, height: 600)))
-    }
-
-    /// `ResourceCoverService` returns nil when no explicit `.cover` link is declared and no bitmap
-    /// is available.
-    func testResourceCoverServiceReturnsNilWhenNoBitmapAvailable() async {
-        let publication = makePublication(
-            readingOrder: [Link(href: "chapter1.xhtml", mediaType: .xhtml)],
-            resources: []
-        )
-        let result = await publication.cover()
-        AssertImageEqual(result, .success(nil))
-    }
-
-    /// `ResourceCoverService` prioritizes explicit `.cover` links over first reading order item.
-    func testResourceCoverServicePrioritizesExplicitCoverLink() async throws {
-        let publication = try Publication(
-            manifest: Manifest(
-                metadata: Metadata(title: "title"),
-                readingOrder: [
-                    Link(href: "page1.jpg", mediaType: .jpeg),
-                ],
-                resources: [
-                    Link(href: "cover2.jpg", rels: [.cover]),
-                ]
-            ),
-            container: CompositeContainer(
-                SingleResourceContainer(
-                    resource: FileResource(file: fixtures.url(for: "cover.jpg")),
-                    at: XCTUnwrap(AnyURL(string: "page1.jpg"))
-                ),
-                SingleResourceContainer(
-                    resource: FileResource(file: fixtures.url(for: "cover2.jpg")),
-                    at: XCTUnwrap(AnyURL(string: "cover2.jpg"))
-                )
-            )
-        )
-        let result = await publication.cover()
-        AssertImageEqual(result, .success(cover2))
-    }
-
-    private func makePublication(
-        readingOrder: [Link] = [],
-        resources: [Link] = [Link(href: "cover.jpg", rels: [.cover])],
-        cover: CoverServiceFactory? = nil,
-        containerURL: FileURL? = nil,
-        containerHref: String = "cover.jpg"
-    ) -> Publication {
-        var builder = PublicationServicesBuilder()
-        if let cover { builder.setCoverServiceFactory(cover) }
-        return Publication(
-            manifest: Manifest(
-                metadata: Metadata(title: "title"),
-                readingOrder: readingOrder,
-                resources: resources
-            ),
-            container: SingleResourceContainer(
-                resource: FileResource(file: containerURL ?? coverURL),
-                at: AnyURL(string: containerHref)!
-            ),
-            servicesBuilder: builder
-        )
-    }
+private func makePublicationWithoutCoverService() -> Publication {
+    Publication(
+        manifest: Manifest(metadata: Metadata(title: "title")),
+        container: SingleResourceContainer(
+            resource: FileResource(file: coverURL),
+            at: AnyURL(string: "cover.jpg")!
+        ),
+        servicesBuilder: PublicationServicesBuilder(cover: nil)
+    )
 }
 
 private struct TestCoverService: CoverService {

--- a/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
@@ -140,6 +140,38 @@ class CoverServiceTests: XCTestCase {
         }
     }
 
+    /// `coverFitting` scales an SVG cover down to the requested max size.
+    func testCoverFittingSVGScalesDown() async {
+        let size = CGSize(width: 50, height: 75)
+        let publication = makePublication(
+            resources: [Link(href: "cover-svg.svg", mediaType: .svg, rels: [.cover])],
+            containerURL: fixtures.url(for: "cover-svg.svg"),
+            containerHref: "cover-svg.svg"
+        )
+        let result = await publication.coverFitting(maxSize: size)
+        switch result {
+        case let .success(image):
+            XCTAssertNotNil(image, "SVG coverFitting should produce a non-nil UIImage")
+            if let image {
+                XCTAssertLessThanOrEqual(image.size.width, size.width)
+                XCTAssertLessThanOrEqual(image.size.height, size.height)
+            }
+        case let .failure(error):
+            XCTFail("Expected success but got \(error)")
+        }
+    }
+
+    /// `UIImage.fromSVG` returns nil for empty data.
+    func testFromSVGReturnsNilForEmptyData() {
+        XCTAssertNil(UIImage.fromSVG(Data(), maxSize: CGSize(width: 400, height: 600)))
+    }
+
+    /// `UIImage.fromSVG` returns nil for non-SVG data.
+    func testFromSVGReturnsNilForNonSVGData() {
+        let jpegData = fixtures.data(at: "cover.jpg")
+        XCTAssertNil(UIImage.fromSVG(jpegData, maxSize: CGSize(width: 400, height: 600)))
+    }
+
     /// `ResourceCoverService` returns nil when no explicit `.cover` link is declared and no bitmap
     /// is available.
     func testResourceCoverServiceReturnsNilWhenNoBitmapAvailable() async {

--- a/Tests/SharedTests/Publication/Services/Cover/ResourceCoverServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Cover/ResourceCoverServiceTests.swift
@@ -1,0 +1,168 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumShared
+import Testing
+import UIKit
+
+private let fixtures = Fixtures(path: "Publication/Services")
+private let coverURL = fixtures.url(for: "cover.jpg")
+private let cover = UIImage(contentsOfFile: coverURL.path)!
+private let cover2 = UIImage(data: fixtures.data(at: "cover2.jpg"))!
+
+@Suite struct ResourceCoverServiceTests {
+    @Suite("cover()") struct Cover {
+        @Test func prioritizesExplicitCoverLinkOverReadingOrder() async throws {
+            let pub = try Publication(
+                manifest: Manifest(
+                    metadata: Metadata(title: "title"),
+                    readingOrder: [Link(href: "page1.jpg", mediaType: .jpeg)],
+                    resources: [Link(href: "cover2.jpg", mediaType: .jpeg, rels: [.cover])]
+                ),
+                container: CompositeContainer(
+                    SingleResourceContainer(
+                        resource: FileResource(file: fixtures.url(for: "cover.jpg")),
+                        at: #require(AnyURL(string: "page1.jpg"))
+                    ),
+                    SingleResourceContainer(
+                        resource: FileResource(file: fixtures.url(for: "cover2.jpg")),
+                        at: #require(AnyURL(string: "cover2.jpg"))
+                    )
+                )
+            )
+            let image = try await pub.cover().get()
+            #expect(image?.pngData() == cover2.pngData())
+        }
+
+        @Test func fallsBackToNextCoverLinkOnMissingResource() async throws {
+            let pub = try Publication(
+                manifest: Manifest(
+                    metadata: Metadata(title: "title"),
+                    resources: [
+                        Link(href: "missing.jpg", mediaType: .jpeg, rels: [.cover]),
+                        Link(href: "cover2.jpg", mediaType: .jpeg, rels: [.cover]),
+                    ]
+                ),
+                container: SingleResourceContainer(
+                    resource: FileResource(file: fixtures.url(for: "cover2.jpg")),
+                    at: #require(AnyURL(string: "cover2.jpg"))
+                )
+            )
+            let image = try await pub.cover().get()
+            #expect(image?.pngData() == cover2.pngData())
+        }
+
+        @Test func usesFirstBitmapReadingOrderItem() async throws {
+            let pub = makePublication(
+                readingOrder: [
+                    Link(href: "cover.jpg", mediaType: .jpeg),
+                    Link(href: "page2.jpg", mediaType: .jpeg),
+                ],
+                resources: []
+            )
+            let image = try await pub.cover().get()
+            #expect(image?.pngData() == cover.pngData())
+        }
+
+        @Test func usesFirstReadingOrderBitmapAlternate() async throws {
+            let pub = makePublication(
+                readingOrder: [
+                    Link(
+                        href: "chapter1.xhtml",
+                        mediaType: .xhtml,
+                        alternates: [Link(href: "cover.jpg", mediaType: .jpeg)]
+                    ),
+                ],
+                resources: []
+            )
+            let image = try await pub.cover().get()
+            #expect(image?.pngData() == cover.pngData())
+        }
+
+        @Test func usesSVGCoverLink() async throws {
+            let pub = makePublication(
+                resources: [Link(href: "cover-svg.svg", mediaType: .svg, rels: [.cover])],
+                containerURL: fixtures.url(for: "cover-svg.svg"),
+                containerHref: "cover-svg.svg"
+            )
+            #expect(try await pub.cover().get() != nil)
+        }
+
+        @Test func returnsNilWhenNoCoverImageFound() async throws {
+            let pub = makePublication(
+                readingOrder: [Link(href: "chapter1.xhtml", mediaType: .xhtml)],
+                resources: []
+            )
+            #expect(try await pub.cover().get() == nil)
+        }
+    }
+
+    @Suite("coverFitting()") struct CoverFitting {
+        @Test func doesNotUpscaleBitmap() async throws {
+            // cover.jpg is 598×800; requesting a larger max size must not upscale it.
+            let size = CGSize(width: 1000, height: 1200)
+            let image = try await makePublication().coverFitting(maxSize: size).get()
+            #expect(image?.pngData() == cover.pngData())
+        }
+
+        @Test func scalesDownBitmap() async throws {
+            let size = CGSize(width: 100, height: 100)
+            let pub = makePublication(
+                readingOrder: [Link(href: "cover.jpg", mediaType: .jpeg)],
+                resources: []
+            )
+            let image = try await pub.coverFitting(maxSize: size).get()
+            #expect(image?.pngData() == cover.scaleToFit(maxSize: size).pngData())
+        }
+
+        @Test func scalesDownSVG() async throws {
+            let size = CGSize(width: 75, height: 75)
+            let pub = makePublication(
+                resources: [Link(href: "cover-svg.svg", mediaType: .svg, rels: [.cover])],
+                containerURL: fixtures.url(for: "cover-svg.svg"),
+                containerHref: "cover-svg.svg"
+            )
+            let image = try #require(try await pub.coverFitting(maxSize: size).get())
+            #expect(image.size.width == 50)
+            #expect(image.size.height == 75)
+        }
+
+        @Test func doesNotUpscaleSVG() async throws {
+            // SVG canvas is 100×150; requesting a larger max size must not upscale it.
+            let pub = makePublication(
+                resources: [Link(href: "cover-svg.svg", mediaType: .svg, rels: [.cover])],
+                containerURL: fixtures.url(for: "cover-svg.svg"),
+                containerHref: "cover-svg.svg"
+            )
+            let image = try #require(try await pub.coverFitting(maxSize: CGSize(width: 200, height: 300)).get())
+            #expect(image.size.width == 100)
+            #expect(image.size.height == 150)
+        }
+    }
+}
+
+private func makePublication(
+    readingOrder: [Link] = [],
+    resources: [Link] = [Link(href: "cover.jpg", mediaType: .jpeg, rels: [.cover])],
+    cover: CoverServiceFactory? = nil,
+    containerURL: FileURL? = nil,
+    containerHref: String = "cover.jpg"
+) -> Publication {
+    var builder = PublicationServicesBuilder()
+    if let cover { builder.setCoverServiceFactory(cover) }
+    return Publication(
+        manifest: Manifest(
+            metadata: Metadata(title: "title"),
+            readingOrder: readingOrder,
+            resources: resources
+        ),
+        container: SingleResourceContainer(
+            resource: FileResource(file: containerURL ?? coverURL),
+            at: AnyURL(string: containerHref)!
+        ),
+        servicesBuilder: builder
+    )
+}

--- a/Tests/SharedTests/Toolkit/Extensions/UIImageTests.swift
+++ b/Tests/SharedTests/Toolkit/Extensions/UIImageTests.swift
@@ -59,7 +59,6 @@ private let image = UIImage(contentsOfFile: fixtures.url(for: "image.jpg").path)
             // SVG canvas is 100×150; at maxSize 75×75 the aspect ratio matches exactly.
             let maxSize = CGSize(width: 75, height: 75)
             let image = try #require(UIImage.fromSVG(fixtures.data(at: "cover-svg.svg"), maxSize: maxSize))
-            print(image.size)
             #expect(image.size.width == 50)
             #expect(image.size.height == 75)
         }

--- a/Tests/SharedTests/Toolkit/Extensions/UIImageTests.swift
+++ b/Tests/SharedTests/Toolkit/Extensions/UIImageTests.swift
@@ -5,33 +5,63 @@
 //
 
 @testable import ReadiumShared
-import XCTest
+import Testing
+import UIKit
 
-class UIImageTests: XCTestCase {
-    let fixtures = Fixtures(path: "Toolkit/Extensions")
-    var image: UIImage!
+private let fixtures = Fixtures(path: "Toolkit/Extensions")
+private let image = UIImage(contentsOfFile: fixtures.url(for: "image.jpg").path)!
 
-    override func setUpWithError() throws {
-        image = UIImage(contentsOfFile: fixtures.url(for: "image.jpg").path)!
+@Suite struct UIImageTests {
+    @Suite("scaleToFit(maxSize:)") struct ScaleToFit {
+        // image.jpg is 598×800
+
+        @Test func returnsSameImageWhenSizeMatches() {
+            #expect(image.scaleToFit(maxSize: image.size) == image)
+        }
+
+        @Test(arguments: [
+            CGSize(width: 1000, height: 800),
+            CGSize(width: 598, height: 1000),
+            CGSize(width: 1000, height: 1000),
+        ])
+        func returnsSameImageWhenMaxSizeIsLarger(maxSize: CGSize) {
+            #expect(image.scaleToFit(maxSize: maxSize) == image)
+        }
+
+        @Test func scalesDownFittingHeight() {
+            let actual = image.scaleToFit(maxSize: CGSize(width: 300, height: 400))
+            #expect(actual.size == CGSize(width: 299, height: 400))
+        }
+
+        @Test func scalesDownFittingWidth() {
+            let actual = image.scaleToFit(maxSize: CGSize(width: 399, height: 800))
+            #expect(actual.size == CGSize(width: 399, height: 534))
+        }
     }
 
-    func testScaleToFitReturnsBitmapWhenSizeMatches() {
-        XCTAssertEqual(image.scaleToFit(maxSize: image.size), image)
-    }
+    @Suite("fromSVG()") struct FromSVG {
+        @Test func returnsNilForEmptyData() {
+            #expect(UIImage.fromSVG(Data(), maxSize: CGSize(width: 400, height: 600)) == nil)
+        }
 
-    func testScaleToFitReturnsBitmapWhenSizeIsBigger() {
-        XCTAssertEqual(image.scaleToFit(maxSize: CGSize(width: 1000, height: 800)), image)
-        XCTAssertEqual(image.scaleToFit(maxSize: CGSize(width: 598, height: 1000)), image)
-        XCTAssertEqual(image.scaleToFit(maxSize: CGSize(width: 1000, height: 1000)), image)
-    }
+        @Test func returnsNilForNonSVGData() {
+            #expect(UIImage.fromSVG(fixtures.data(at: "image.jpg"), maxSize: CGSize(width: 400, height: 600)) == nil)
+        }
 
-    func testScaleToFitScalesDownFittingHeight() {
-        let size = image.scaleToFit(maxSize: CGSize(width: 300, height: 400)).size
-        XCTAssertEqual(size, CGSize(width: 299, height: 400))
-    }
+        @Test func rendersAtNativeSizeWhenSmaller() throws {
+            // SVG canvas is 100×150; it must not be upscaled.
+            let image = try #require(UIImage.fromSVG(fixtures.data(at: "cover-svg.svg"), maxSize: CGSize(width: 400, height: 600)))
+            #expect(image.size.width == 100)
+            #expect(image.size.height == 150)
+        }
 
-    func testScaleToFitScalesDownFittingWidth() {
-        let size = image.scaleToFit(maxSize: CGSize(width: 399, height: 800)).size
-        XCTAssertEqual(size, CGSize(width: 399, height: 534))
+        @Test func scalesDownPreservingAspectRatio() throws {
+            // SVG canvas is 100×150; at maxSize 75×75 the aspect ratio matches exactly.
+            let maxSize = CGSize(width: 75, height: 75)
+            let image = try #require(UIImage.fromSVG(fixtures.data(at: "cover-svg.svg"), maxSize: maxSize))
+            print(image.size)
+            #expect(image.size.width == 50)
+            #expect(image.size.height == 75)
+        }
     }
 }


### PR DESCRIPTION
### Summary

This pull request addresses the [SVG covers are not supported](https://github.com/readium/swift-toolkit/issues/738) issue.


### Known limitation
The `SVG` rendering uses `CGSVGDocument` `CoreGraphics` functions loaded dynamically via `dlsym`. While these are stable since iOS 13 and widely used, they are not part of the public API. A future iteration could replace this with a third-party `SVG` parsing library (e.g. `SVGKit`) or a `WebKit` snapshot approach for full public API compliance.