### PR TITLE
Document device name behavior for LCP registration

### DIFF
--- a/Sources/LCP/LCPService.swift
+++ b/Sources/LCP/LCPService.swift
@@ -28,7 +28,10 @@ public final class LCPService: Loggable {
     ///   - assetRetriever: The retriever used to fetch protected assets.
     ///   - httpClient: The HTTP client used for network requests to LSD/LCP servers.
     ///   - deviceName: Device name used when registering a license to an LSD server.
-    ///     If not provided, the device name will be the default `UIDevice.current.name`.
+    ///     If not provided, the device name will be `UIDevice.current.name`. Since iOS 16,
+    ///     this returns a generic name (e.g. "iPhone") unless the
+    ///     `com.apple.developer.device-information.user-assigned-device-name` entitlement
+    ///     is added to your app.
     ///   - deviceId: Device ID used when registering a license to an LSD server.
     ///     You must ensure the identifier is unique and stable for the device (persist and
     ///     reuse across app launches). If not provided, the device ID will be generated as

--- a/docs/Guides/Readium LCP.md
+++ b/docs/Guides/Readium LCP.md
@@ -173,6 +173,19 @@ A file required by the LCP library needs to be downloaded from an insecure HTTP 
 </dict>
 ```
 
+### Device name for LCP registration
+
+When registering a license with an LSD server, Readium LCP identifies the device by name using `UIDevice.current.name`. Since iOS 16, this returns a generic string such as "iPhone" instead of the user-assigned device name.
+
+To obtain the actual device name, add the [`com.apple.developer.device-information.user-assigned-device-name`](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_device-information_user-assigned-device-name) entitlement to your app's `.entitlements` file. This entitlement requires approval from Apple.
+
+```xml
+<key>com.apple.developer.device-information.user-assigned-device-name</key>
+<true/>
+```
+
+Alternatively, you can supply your own device name when initializing `LCPService` via the `deviceName` parameter.
+
 ## Initializing the `LCPService`
 
 `ReadiumLCP` offers an `LCPService` object that exposes its API. Since the `ReadiumLCP` package is not linked with `R2LCPClient`, you need to create your own adapter when setting up the `LCPService`.


### PR DESCRIPTION
Since iOS 16, `UIDevice.current.name` returns a generic string (e.g. "iPhone") instead of the user-assigned device name. This affects LCP device registration with LSD servers, where the device name is used to identify the device.

This PR adds a new section to the LCP guide explaining:
  - The iOS 16 behavioral change
  - How to request the `com.apple.developer.device-information.user-assigned-device-name` entitlement to restore the user-assigned name
  - How to pass a custom `deviceName` via `LCPService.init` as an alternative