### PR TITLE
Report continuous `totalProgression` in the EPUB locator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * [#737](https://github.com/readium/swift-toolkit/issues/737) Fixed screen flashes when turning pages without animation in the EPUB navigator.
+* The EPUB navigator now reports a continuous `locator.locations.totalProgression` value, interpolated from the actual scroll position within the resource's global progression range. Previously, the value was quantized to the nearest position in the position list.
 
 #### Streamer
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -695,78 +695,15 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             return (nil, nil)
         }
 
-        let visibleReadingOrder: [(index: Int, href: AnyURL)] = spreadView.spread.readingOrderIndices
-            .map { ($0, readingOrder[$0].url()) }
-
-        var viewport = Viewport(
-            readingOrder: visibleReadingOrder.map(\.href),
-            progressions: visibleReadingOrder.reduce([:]) { progressions, i in
-                var progressions = progressions
-                progressions[i.href] = spreadView.progression(in: i.index)
-                return progressions
-            },
-            positions: nil
+        let (locator, viewport) = await EPUBViewportAndLocationCalculator.compute(
+            readingOrderIndices: spreadView.spread.readingOrderIndices,
+            progression: { spreadView.progression(in: $0) },
+            readingOrder: readingOrder,
+            positionsByReadingOrder: positionsByReadingOrder,
+            tableOfContentsTitleByHref: tableOfContentsTitleByHref,
+            fallbackLocator: { [publication] in await publication.locate($0) }
         )
-
-        let firstIndex = spreadView.spread.readingOrderIndices.lowerBound
-        let lastIndex = spreadView.spread.readingOrderIndices.upperBound
-        let progressionOfFirstResource = spreadView.progression(in: firstIndex)
-        let progressionOfLastResource = spreadView.progression(in: lastIndex)
-        let firstProgressionInFirstResource = min(max(progressionOfFirstResource.lowerBound, 0.0), 1.0)
-        let lastProgressionInLastResource = min(max(progressionOfLastResource.upperBound, 0.0), 1.0)
-
-        let link = readingOrder[firstIndex]
-        let location: Locator?
-
-        if
-            // The positions are not always available, for example a Readium
-            // WebPub doesn't have any unless a Publication Positions Web
-            // Service is provided
-            let positionsOfFirstResource = positionsByReadingOrder.getOrNil(firstIndex),
-            let positionsOfLastResource = positionsByReadingOrder.getOrNil(lastIndex),
-            !positionsOfFirstResource.isEmpty,
-            !positionsOfLastResource.isEmpty
-        {
-            // Map the continuous resource progression (0-1) to the index of the
-            // nearest position within that resource.
-            let firstPositionIndex = Int(ceil(firstProgressionInFirstResource * Double(positionsOfFirstResource.count - 1)))
-            let lastPositionIndex = (lastProgressionInLastResource == 1.0)
-                ? positionsOfLastResource.count - 1
-                : max(firstPositionIndex, Int(ceil(lastProgressionInLastResource * Double(positionsOfLastResource.count - 1))) - 1)
-
-            // Compute a continuous totalProgression by linearly interpolating
-            // the resource-level progression within the resource's global
-            // range. The resource's range spans from the totalProgression of
-            // its first position to the totalProgression of the next resource's
-            // first position (or 1.0 for the last resource).
-            let resourceTotalProgressionStart = positionsOfFirstResource.first?.locations.totalProgression ?? 0.0
-            let resourceTotalProgressionEnd = positionsByReadingOrder.getOrNil(firstIndex + 1)?.first?.locations.totalProgression ?? 1.0
-            let continuousTotalProgression = resourceTotalProgressionStart + firstProgressionInFirstResource * (resourceTotalProgressionEnd - resourceTotalProgressionStart)
-
-            // Build the locator from the nearest position, then override
-            // progression fields with the actual continuous scroll values.
-            location = await positionsOfFirstResource[firstPositionIndex].copy(
-                title: tableOfContentsTitleByHref[link.url()],
-                locations: {
-                    $0.progression = firstProgressionInFirstResource
-                    $0.totalProgression = continuousTotalProgression
-                }
-            )
-
-            if
-                let firstPosition = location?.locations.position,
-                let lastPosition = positionsOfLastResource[lastPositionIndex].locations.position
-            {
-                viewport.positions = firstPosition ... lastPosition
-            }
-
-        } else {
-            location = await publication.locate(link)?.copy(
-                locations: { $0.progression = firstProgressionInFirstResource }
-            )
-        }
-
-        return (location, viewport)
+        return (locator, viewport)
     }
 
     public func firstVisibleElementLocator() async -> Locator? {

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -727,16 +727,30 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             !positionsOfFirstResource.isEmpty,
             !positionsOfLastResource.isEmpty
         {
-            // Gets the current locator from the positions, and fill its missing
-            // data.
+            // Map the continuous resource progression (0-1) to the index of the
+            // nearest position within that resource.
             let firstPositionIndex = Int(ceil(firstProgressionInFirstResource * Double(positionsOfFirstResource.count - 1)))
             let lastPositionIndex = (lastProgressionInLastResource == 1.0)
                 ? positionsOfLastResource.count - 1
                 : max(firstPositionIndex, Int(ceil(lastProgressionInLastResource * Double(positionsOfLastResource.count - 1))) - 1)
 
+            // Compute a continuous totalProgression by linearly interpolating
+            // the resource-level progression within the resource's global
+            // range. The resource's range spans from the totalProgression of
+            // its first position to the totalProgression of the next resource's
+            // first position (or 1.0 for the last resource).
+            let resourceTotalProgressionStart = positionsOfFirstResource.first?.locations.totalProgression ?? 0.0
+            let resourceTotalProgressionEnd = positionsByReadingOrder.getOrNil(firstIndex + 1)?.first?.locations.totalProgression ?? 1.0
+            let continuousTotalProgression = resourceTotalProgressionStart + firstProgressionInFirstResource * (resourceTotalProgressionEnd - resourceTotalProgressionStart)
+
+            // Build the locator from the nearest position, then override
+            // progression fields with the actual continuous scroll values.
             location = await positionsOfFirstResource[firstPositionIndex].copy(
                 title: tableOfContentsTitleByHref[link.url()],
-                locations: { $0.progression = firstProgressionInFirstResource }
+                locations: {
+                    $0.progression = firstProgressionInFirstResource
+                    $0.totalProgression = continuousTotalProgression
+                }
             )
 
             if

--- a/Sources/Navigator/EPUB/EPUBViewportAndLocationCalculator.swift
+++ b/Sources/Navigator/EPUB/EPUBViewportAndLocationCalculator.swift
@@ -1,0 +1,122 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+import ReadiumShared
+
+/// Computes the current `Locator` and `Viewport` from a spread's visible
+/// progressions and the publication's position list.
+enum EPUBViewportAndLocationCalculator {
+    /// Computes the locator and viewport for the currently visible spread.
+    ///
+    /// - Parameters:
+    ///   - readingOrderIndices: Closed range of reading-order indices visible
+    ///     in the spread (single value for reflowable, two values for FXL
+    ///     double spreads).
+    ///   - progression: Returns the visible scroll progression range (0–1)
+    ///     for a given reading-order index. For fixed-layout resources this
+    ///     is always `0...1`.
+    ///   - readingOrder: The publication's reading order links.
+    ///   - positionsByReadingOrder: Positions grouped by reading-order index.
+    ///     May be empty if the publication has no positions.
+    ///   - tableOfContentsTitleByHref: Mapping from resource URL to its table-
+    ///     of-contents title, used to populate `Locator.title`.
+    ///   - fallbackLocator: Called with the first visible link when no
+    ///     positions are available; should return a basic locator for that
+    ///     link (e.g. from `Publication.locate(_:)`).
+    static func compute(
+        readingOrderIndices: ClosedRange<Int>,
+        progression: (Int) -> ClosedRange<Double>,
+        readingOrder: [Link],
+        positionsByReadingOrder: [[Locator]],
+        tableOfContentsTitleByHref: [AnyURL: String],
+        fallbackLocator: (Link) async -> Locator?
+    ) async -> (locator: Locator?, viewport: EPUBNavigatorViewController.Viewport) {
+        let visibleReadingOrder: [(index: Int, href: AnyURL)] = readingOrderIndices
+            .map { ($0, readingOrder[$0].url()) }
+
+        var viewport = EPUBNavigatorViewController.Viewport(
+            readingOrder: visibleReadingOrder.map(\.href),
+            progressions: visibleReadingOrder.reduce(into: [:]) { acc, i in
+                acc[i.href] = progression(i.index)
+            },
+            positions: nil
+        )
+
+        let firstIndex = readingOrderIndices.lowerBound
+        let lastIndex = readingOrderIndices.upperBound
+        let firstProgressionInFirstResource = min(max(progression(firstIndex).lowerBound, 0.0), 1.0)
+        let lastProgressionInLastResource = min(max(progression(lastIndex).upperBound, 0.0), 1.0)
+
+        let link = readingOrder[firstIndex]
+        let locator: Locator?
+
+        if
+            // The positions are not always available, for example a Readium
+            // WebPub doesn't have any unless a Publication Positions Web
+            // Service is provided.
+            let positionsOfFirstResource = positionsByReadingOrder.getOrNil(firstIndex),
+            let positionsOfLastResource = positionsByReadingOrder.getOrNil(lastIndex),
+            !positionsOfFirstResource.isEmpty,
+            !positionsOfLastResource.isEmpty
+        {
+            // Map the resource progression (0–1) to a position index using
+            // ceil, so the reported position advances as soon as the reader
+            // enters it. This pairs with lastPositionIndex which uses
+            // ceil(x) - 1 to find the last fully-entered position.
+            let firstPositionIndex = Int(ceil(
+                firstProgressionInFirstResource * Double(positionsOfFirstResource.count - 1)
+            ))
+            let lastPositionIndex: Int = (lastProgressionInLastResource == 1.0)
+                ? positionsOfLastResource.count - 1
+                : max(
+                    // In a single-resource spread, clamp against firstPositionIndex
+                    // to prevent an invalid lastPositionIndex < firstPositionIndex
+                    // range. In a two-resource spread the two indices are into
+                    // different arrays, so clamp against 0 instead.
+                    firstIndex == lastIndex ? firstPositionIndex : 0,
+                    Int(ceil(lastProgressionInLastResource * Double(positionsOfLastResource.count - 1))) - 1
+                )
+
+            // Compute a continuous totalProgression by linearly interpolating
+            // the resource-level progression within the resource's global
+            // range. The resource's range spans from the totalProgression of
+            // its first position to the totalProgression of the next resource's
+            // first position (or 1.0 for the last resource).
+            let resourceTotalProgressionStart = positionsOfFirstResource.first?.locations.totalProgression ?? 0.0
+            let resourceTotalProgressionEnd = positionsByReadingOrder.getOrNil(firstIndex + 1)?
+                .first?.locations.totalProgression ?? 1.0
+            let continuousTotalProgression =
+                resourceTotalProgressionStart
+                    + firstProgressionInFirstResource
+                    * (resourceTotalProgressionEnd - resourceTotalProgressionStart)
+
+            // Build the locator from the nearest position, then override
+            // progression fields with the actual continuous scroll values.
+            locator = positionsOfFirstResource[firstPositionIndex].copy(
+                title: tableOfContentsTitleByHref[link.url()],
+                locations: {
+                    $0.progression = firstProgressionInFirstResource
+                    $0.totalProgression = continuousTotalProgression
+                }
+            )
+
+            if
+                let firstPosition = locator?.locations.position,
+                let lastPosition = positionsOfLastResource[lastPositionIndex].locations.position
+            {
+                viewport.positions = firstPosition ... lastPosition
+            }
+
+        } else {
+            locator = await fallbackLocator(link)?.copy(
+                locations: { $0.progression = firstProgressionInFirstResource }
+            )
+        }
+
+        return (locator, viewport)
+    }
+}

--- a/Support/Carthage/.xcodegen
+++ b/Support/Carthage/.xcodegen
@@ -469,6 +469,7 @@
 ../../Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
 ../../Sources/Navigator/EPUB/EPUBSpread.swift
 ../../Sources/Navigator/EPUB/EPUBSpreadView.swift
+../../Sources/Navigator/EPUB/EPUBViewportAndLocationCalculator.swift
 ../../Sources/Navigator/EPUB/HTMLDecorationTemplate.swift
 ../../Sources/Navigator/EPUB/Preferences
 ../../Sources/Navigator/EPUB/Preferences/EPUBPreferences.swift

--- a/Support/Carthage/Readium.xcodeproj/project.pbxproj
+++ b/Support/Carthage/Readium.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		B49522888052E9F41D0DD013 /* ZIPFormatSniffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AA8BD22E2F5495286C0A1C /* ZIPFormatSniffer.swift */; };
 		B4D55F234AD2CB5728184346 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F669F31B0B6EC690C48916EC /* Bundle.swift */; };
 		B57EC602072D4276D502B80D /* AudiobookFormatSniffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1674CCC0BA8B1F4E2D2B3A4C /* AudiobookFormatSniffer.swift */; };
+		B5D6D29E36F6B8946A26D088 /* EPUBViewportAndLocationCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2751AB538A1BFBE02F2AF00B /* EPUBViewportAndLocationCalculator.swift */; };
 		B676871C6BC2D08EC8279B8D /* ReadingProgression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F646B746EB27124F9456F8 /* ReadingProgression.swift */; };
 		B7B0C7AD992344EA09937D6D /* ReadiumShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97BC822B36D72EF548162129 /* ReadiumShared.framework */; };
 		B912ABB7DE8FC1A7A8EC1D84 /* EPUBNavigatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5ED9E15482AED288A6634F /* EPUBNavigatorViewController.swift */; };
@@ -564,6 +565,7 @@
 		251275D0DF87F85158A5FEA9 /* Assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Assets; path = ../../Sources/Navigator/EPUB/Assets; sourceTree = SOURCE_ROOT; };
 		258351CE21165EDED7F87878 /* URLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocol.swift; sourceTree = "<group>"; };
 		2732AFC91AB15FA09C60207A /* Locator+Audio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locator+Audio.swift"; sourceTree = "<group>"; };
+		2751AB538A1BFBE02F2AF00B /* EPUBViewportAndLocationCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBViewportAndLocationCalculator.swift; sourceTree = "<group>"; };
 		281F650E9B9CEE601D8125EE /* Metadata+EPUB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Metadata+EPUB.swift"; sourceTree = "<group>"; };
 		2828D89EBB52CCA782ED1146 /* ReadiumFuzi.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ReadiumFuzi.xcframework; path = ../../Carthage/Build/ReadiumFuzi.xcframework; sourceTree = "<group>"; };
 		28792F801221D49F61B92CF8 /* TDM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TDM.swift; sourceTree = "<group>"; };
@@ -1109,6 +1111,7 @@
 				0C45688D0A9C1F81F463FF92 /* EPUBReflowableSpreadView.swift */,
 				98D8CC7BC117BBFB206D01CC /* EPUBSpread.swift */,
 				E233289C75C9F73E6E28DDB4 /* EPUBSpreadView.swift */,
+				2751AB538A1BFBE02F2AF00B /* EPUBViewportAndLocationCalculator.swift */,
 				8AB3B86AB42261727B2811CF /* HTMLDecorationTemplate.swift */,
 				B673858EDF2BBCB316C28CBE /* WebViewServer.swift */,
 				01819314A9C8B44F7EF6EC7D /* CSS */,
@@ -2489,6 +2492,7 @@
 				1CB986C7E440F94F264A3567 /* EPUBSettings.swift in Sources */,
 				DFA6D21F48B69ED6839BC9AC /* EPUBSpread.swift in Sources */,
 				60AFAA2C97E8597D7A9792C2 /* EPUBSpreadView.swift in Sources */,
+				B5D6D29E36F6B8946A26D088 /* EPUBViewportAndLocationCalculator.swift in Sources */,
 				A116A1DB98A28C79CFD93EDE /* EditingAction.swift in Sources */,
 				5DE20E8A77050BF50B659452 /* HTMLDecorationTemplate.swift in Sources */,
 				E16AA8A927AAE141702F2D3B /* HTMLFontFamilyDeclaration.swift in Sources */,

--- a/Tests/NavigatorTests/EPUB/EPUBViewportAndLocationCalculatorTests.swift
+++ b/Tests/NavigatorTests/EPUB/EPUBViewportAndLocationCalculatorTests.swift
@@ -1,0 +1,406 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumNavigator
+import ReadiumShared
+import Testing
+
+@Suite enum EPUBViewportAndLocationCalculatorTests {
+    @Suite("Viewport") struct ViewportSuite {
+        @Test("builds reading order URLs from a single-resource spread")
+        func singleResourceReadingOrder() async {
+            let ro = makeReadingOrder(count: 2)
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.0 ... 0.5 },
+                readingOrder: ro,
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(viewport.readingOrder == [ro[0].url()])
+        }
+
+        @Test("records progression range for the visible resource")
+        func progressionRange() async {
+            let ro = makeReadingOrder(count: 2)
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.25 ... 0.75 },
+                readingOrder: ro,
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(viewport.progressions[ro[0].url()] == 0.25 ... 0.75)
+        }
+
+        @Test("includes both resources for a two-index spread")
+        func twoIndexSpread() async {
+            let ro = makeReadingOrder(count: 2)
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 1,
+                progression: { i in i == 0 ? 0.0 ... 1.0 : 0.0 ... 1.0 },
+                readingOrder: ro,
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 1),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(viewport.readingOrder == [ro[0].url(), ro[1].url()])
+            #expect(viewport.progressions[ro[0].url()] == 0.0 ... 1.0)
+            #expect(viewport.progressions[ro[1].url()] == 0.0 ... 1.0)
+        }
+    }
+
+    @Suite("Locator - positions available") struct LocatorWithPositionsSuite {
+        // 2 resources × 4 positions = 8 total.
+        // Resource 0: totalProgression 0/8 … 3/8; resource 1: 4/8 … 7/8.
+        // resourceTotalProgressionEnd for resource 0 = 4/8 = 0.5.
+
+        @Test("totalProgression at start of first resource is 0.0")
+        func totalProgressionAtStart() async {
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.0 ... 0.0 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(locator?.locations.totalProgression == 0.0)
+        }
+
+        @Test("totalProgression at end of first resource equals start of second")
+        func totalProgressionAtResourceBoundary() async {
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 1.0 ... 1.0 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            // Resource 0 ends where resource 1 begins: totalProgression = 4/8 = 0.5
+            #expect(locator?.locations.totalProgression == 0.5)
+        }
+
+        @Test("totalProgression at end of last resource is 1.0")
+        func totalProgressionAtEnd() async {
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 1 ... 1,
+                progression: { _ in 1.0 ... 1.0 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(locator?.locations.totalProgression == 1.0)
+        }
+
+        @Test("totalProgression interpolates linearly mid-resource")
+        func totalProgressionInterpolation() async {
+            // At 0.5 progression in resource 0:
+            // continuousTotalProgression = 0.0 + 0.5 * (0.5 - 0.0) = 0.25
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.5 ... 0.5 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(locator?.locations.totalProgression == 0.25)
+        }
+
+        @Test("progression field reflects actual scroll offset")
+        func progressionFieldIsScrollOffset() async {
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.3 ... 0.7 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(locator?.locations.progression == 0.3)
+        }
+
+        @Test("position index is selected via ceil of resource progression")
+        func positionIndexViaCeil() async {
+            // progression=0.5, 4 positions → ceil(0.5 * 3) = ceil(1.5) = 2 → position 3 (1-based)
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.5 ... 0.5 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            // Index 2 in resource 0 has position number 3 (absolute index 2, 1-based)
+            #expect(locator?.locations.position == 3)
+        }
+
+        @Test("position index at start of resource is 0")
+        func positionIndexAtStart() async {
+            // progression=0.0, 4 positions → ceil(0.0 * 3) = 0
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.0 ... 0.0 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            // Index 0 in resource 0 has position number 1
+            #expect(locator?.locations.position == 1)
+        }
+
+        @Test("title is taken from tableOfContentsTitleByHref")
+        func titleFromTOC() async {
+            let ro = makeReadingOrder(count: 1)
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.0 ... 0.0 },
+                readingOrder: ro,
+                positionsByReadingOrder: makePositions(resourceCount: 1, positionsPerResource: 1),
+                tableOfContentsTitleByHref: [ro[0].url(): "Chapter One"],
+                fallbackLocator: noFallback
+            )
+            #expect(locator?.title == "Chapter One")
+        }
+
+        @Test("title is nil when href not in table of contents")
+        func noTitle() async {
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.0 ... 0.0 },
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, positionsPerResource: 1),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(locator?.title == nil)
+        }
+    }
+
+    @Suite("Viewport positions - positions available") struct ViewportPositionsSuite {
+        @Test("positions range is single position when viewing start of resource")
+        func singlePositionAtStart() async {
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.0 ... 0.0 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            // firstProgression=0.0 → positionIndex=0 → position 1
+            // lastProgression=0.0 → ceil(0.0*3)-1 = -1 → max(0,-1) = 0 → position 1
+            #expect(viewport.positions == 1 ... 1)
+        }
+
+        @Test("positions range spans multiple positions when viewport shows a range")
+        func multiPositionRange() async {
+            // firstProgression=0.0 → firstPositionIndex=0 → position 1
+            // lastProgression=1.0 → lastPositionIndex=count-1=3 → position 4
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.0 ... 1.0 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(viewport.positions == 1 ... 4)
+        }
+
+        @Test("lastProgression == 1.0 uses last position index in resource")
+        func lastProgressionExactlyOne() async {
+            let positions = makePositions(resourceCount: 1, positionsPerResource: 4)
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.0 ... 1.0 },
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: positions,
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            // lastPositionIndex = count - 1 = 3 → position 4
+            #expect(viewport.positions?.upperBound == 4)
+        }
+
+        @Test("lastProgression near 1.0 does not reach last position index")
+        func lastProgressionNearOne() async {
+            // The last position index is only reached when lastProgression is
+            // exactly 1.0 (handled by the special-case branch). For any value
+            // strictly below 1.0 the formula is ceil(x * (count-1)) - 1, which
+            // advances one position at a time as x increases — intentionally
+            // stopping one step short of the final position until the very end.
+            // This prevents the position from jumping ahead before the reader
+            // has fully scrolled into it.
+            let positions = makePositions(resourceCount: 1, positionsPerResource: 4)
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                // upperBound is just below 1.0 but not exactly 1.0
+                progression: { _ in 0.0 ... 0.9999 },
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: positions,
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            // ceil(0.9999 * 3) - 1 = ceil(2.9997) - 1 = 3 - 1 = 2 → position 3
+            #expect(viewport.positions?.upperBound == 3)
+        }
+    }
+
+    @Suite("Locator - no positions (fallback)") struct FallbackSuite {
+        @Test("uses fallback locator when positionsByReadingOrder is empty")
+        func useFallback() async {
+            let ro = makeReadingOrder(count: 1)
+            let fallback = Locator(href: ro[0].url(), mediaType: .html, title: "Fallback")
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.3 ... 0.3 },
+                readingOrder: ro,
+                positionsByReadingOrder: [],
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: { _ in fallback }
+            )
+            #expect(locator?.title == "Fallback")
+        }
+
+        @Test("progression is set on the fallback locator")
+        func fallbackProgressionIsSet() async {
+            let ro = makeReadingOrder(count: 1)
+            let fallback = Locator(href: ro[0].url(), mediaType: .html)
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.42 ... 0.42 },
+                readingOrder: ro,
+                positionsByReadingOrder: [],
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: { _ in fallback }
+            )
+            #expect(locator?.locations.progression == 0.42)
+        }
+
+        @Test("uses fallback when positions array does not cover the current resource index")
+        func fallbackWhenPositionsMissingForResource() async {
+            let ro = makeReadingOrder(count: 3)
+            let fallback = Locator(href: ro[2].url(), mediaType: .html, title: "Chapter 3")
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 2 ... 2,
+                progression: { _ in 0.5 ... 0.5 },
+                readingOrder: ro,
+                // positions only cover resources 0 and 1, not resource 2
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 1),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: { _ in fallback }
+            )
+            #expect(locator?.title == "Chapter 3")
+            #expect(locator?.locations.progression == 0.5)
+        }
+
+        @Test("viewport.positions is nil when no positions available")
+        func viewportPositionsIsNil() async {
+            let ro = makeReadingOrder(count: 1)
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.0 ... 1.0 },
+                readingOrder: ro,
+                positionsByReadingOrder: [],
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: { link in Locator(href: link.url(), mediaType: .html) }
+            )
+            #expect(viewport.positions == nil)
+        }
+    }
+
+    @Suite("Two-index spread (FXL)") struct TwoIndexSpreadSuite {
+        @Test("totalProgression is computed from the first resource's range")
+        func totalProgressionUsesFirstResource() async {
+            // FXL: progression always returns 0...1, so firstProgression=0.0.
+            // Resource 0 range: 0/2 = 0.0 … 1/2 = 0.5.
+            // continuousTotalProgression = 0.0 + 0.0 * (0.5 - 0.0) = 0.0
+            let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 1,
+                progression: { _ in 0.0 ... 1.0 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 1),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(locator?.locations.totalProgression == 0.0)
+        }
+
+        @Test("viewport.positions spans both resources in a two-index FXL spread")
+        func viewportPositionsSpanBothResources() async {
+            // Each FXL resource has one position; resource 0 → position 1, resource 1 → position 2.
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 1,
+                progression: { _ in 0.0 ... 1.0 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 1),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(viewport.positions == 1 ... 2)
+        }
+
+        @Test("viewport progressions contains an entry for each visible resource")
+        func viewportContainsBothResources() async {
+            let ro = makeReadingOrder(count: 2)
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 1,
+                progression: { i in i == 0 ? 0.1 ... 0.9 : 0.2 ... 0.8 },
+                readingOrder: ro,
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 1),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(viewport.progressions[ro[0].url()] == 0.1 ... 0.9)
+            #expect(viewport.progressions[ro[1].url()] == 0.2 ... 0.8)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+/// Builds a reading order of `count` links with hrefs "chap1.html", "chap2.html", …
+private func makeReadingOrder(count: Int) -> [Link] {
+    (1 ... count).map { Link(href: "chap\($0).html", mediaType: .html) }
+}
+
+/// Builds positions for `resourceCount` resources, each with `positionsPerResource`
+/// positions. `totalProgression` is distributed evenly across the whole publication;
+/// `progression` within each resource is distributed evenly; position numbers are
+/// 1-based and sequential.
+private func makePositions(resourceCount: Int, positionsPerResource: Int) -> [[Locator]] {
+    let total = resourceCount * positionsPerResource
+
+    return (0 ..< resourceCount).map { r in
+        (0 ..< positionsPerResource).map { p in
+            let absoluteIndex = r * positionsPerResource + p
+            return Locator(
+                href: AnyURL(string: "chap\(r + 1).html")!,
+                mediaType: .html,
+                locations: .init(
+                    progression: positionsPerResource > 1
+                        ? Double(p) / Double(positionsPerResource - 1)
+                        : 0.0,
+                    totalProgression: Double(absoluteIndex) / Double(total),
+                    position: absoluteIndex + 1
+                )
+            )
+        }
+    }
+}
+
+/// A no-op fallback locator used when positions are available (fallback branch
+/// should not be reached).
+private func noFallback(_ link: Link) async -> Locator? {
+    nil
+}


### PR DESCRIPTION
`locator.locations.totalProgression` in the EPUB navigator was quantized – its value was copied directly from the nearest position in the position list, so it could only take discrete steps of `1/positionCount`. For a publication with 50 positions, `totalProgression` would jump in increments of 0.02 regardless of the actual scroll position.

This was inconsistent with `locator.locations.progression` (the resource-level scroll offset), which has always been a continuous value derived from the actual WebView scroll position.

The practical consequence: any UI that tracks reading progress – such as a progress bar or a visible-range indicator – would move in discrete jumps rather than smoothly reflecting the reader's position. It also made it impossible for apps to correctly derive a continuous global progression range from `viewport.progressions` without re-implementing Readium's internal position lookup logic.

No changes to navigation or position restoration behaviour – those rely on `progression` and `position`, not `totalProgression`.