### PR TITLE
Fix LCP-enabled TestApp

### DIFF
--- a/TestApp/Makefile
+++ b/TestApp/Makefile
@@ -33,8 +33,6 @@ spm: clean
 ifdef lcp
 	@cp Integrations/SPM/project+lcp.yml project.yml
 	curl --create-dirs --output R2LCPClient/Package.swift "$(lcp)"
-	# Downgrades the SPM version to work with Xcode 12.4
-	@sed -i '' -e 's/5.5/5.3.0/g' R2LCPClient/Package.swift
 else
 	@cp Integrations/SPM/project.yml .
 endif
@@ -80,8 +78,6 @@ dev: clean
 ifdef lcp
 	@cp Integrations/Local/project+lcp.yml project.yml
 	curl --create-dirs --output R2LCPClient/Package.swift "$(lcp)"
-	# Downgrades the SPM version to work with Xcode 12.4
-	@sed -i '' -e 's/5.5/5.3.0/g' R2LCPClient/Package.swift
 else
 	@cp Integrations/Local/project.yml .
 endif


### PR DESCRIPTION
The LCP-enabled TestApp build fails with the latest liblcp because of a checksum issue.

The checksum was corrupted by a broken `sed` in the TestApp's `Makefile`.
We don't need to support Xcode 12 anymore.