### PR TITLE
Support task cancellation in HTTP client fetch and download

### DIFF
--- a/Sources/Shared/Toolkit/HTTP/HTTPClient.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPClient.swift
@@ -32,6 +32,9 @@ public extension HTTPClient {
         let response = await stream(
             request: request,
             consume: { chunk, _ in
+                if Task.isCancelled {
+                    return .failure(.cancelled)
+                }
                 data.append(chunk)
                 return .success(())
             }
@@ -116,6 +119,10 @@ public extension HTTPClient {
         let result = await stream(
             request: request,
             consume: { data, progression in
+                if Task.isCancelled {
+                    return .failure(.cancelled)
+                }
+
                 do {
                     try fileHandle.seekToEnd()
                     try fileHandle.write(contentsOf: data)


### PR DESCRIPTION
Added cooperative cancellation checks to the `HTTPClient` extension methods that consume streamed data.

**Motivation:**
Without these checks, once a stream starts, fetch and download will continue accumulating data even if the calling task has been cancelled. This could waste network bandwidth and memory for requests that are no longer needed (e.g., a user navigated away). Adding cooperative cancellation lets these operations bail out promptly between chunks.
