### PR TITLE
Fix race condition when applying EPUB decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file. Take a look
     * Fixed screen glitches when turning with animations disabled.
     * A slide animation is now used when navigating between adjacent resources.
 * The EPUB navigator now reports a continuous `locator.locations.totalProgression` value, interpolated from the actual scroll position within the resource's global progression range. Previously, the value was quantized to the nearest position in the position list.
+* Fixed a race condition in `EPUBNavigatorViewController` where rapidly calling `apply(decorations:in:)` for the same group could cause multiple highlights to appear simultaneously.
 
 #### Streamer
 

--- a/Sources/Navigator/Decorator/DecorableNavigator.swift
+++ b/Sources/Navigator/Decorator/DecorableNavigator.swift
@@ -16,7 +16,7 @@ public protocol DecorableNavigator {
     /// submit the updated list of decorations when there are changes.
     /// Name each decoration group as you see fit. A good practice is to use the name of the feature requiring
     /// decorations, e.g. `annotation`, `search`, `tts`, etc.
-    func apply(decorations: [Decoration], in group: String)
+    func apply(decorations: [Decoration], in group: DecorationGroup)
 
     /// Indicates whether the Navigator supports the given decoration `style`.
     ///
@@ -30,18 +30,24 @@ public protocol DecorableNavigator {
     /// - Parameters:
     ///   - group: The name of the decoration group to observe.
     ///   - onActivated: Called when the user activates the decoration, e.g. with a click or tap.
-    func observeDecorationInteractions(inGroup group: String, onActivated: @escaping OnActivatedCallback)
+    func observeDecorationInteractions(inGroup group: DecorationGroup, onActivated: @escaping OnActivatedCallback)
 
     /// Called when the user activates a decoration, e.g. with a click or tap.
     typealias OnActivatedCallback = (_ event: OnDecorationActivatedEvent) -> Void
 }
+
+/// Identifies a decoration group.
+///
+/// Use a descriptive name for each group, typically matching the feature that
+/// owns the decorations, e.g. `search`, `annotation`, `tts`.
+public typealias DecorationGroup = String
 
 /// Holds the metadata about a decoration activation interaction.
 public struct OnDecorationActivatedEvent {
     /// Activated decoration.
     public let decoration: Decoration
     /// Name of the group the decoration belongs to.
-    public let group: String
+    public let group: DecorationGroup
     /// Frame of the bounding rect for the decoration, in the coordinate of the navigator view. This is only useful in
     /// the context of a VisualNavigator.
     public let rect: CGRect?

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -825,12 +825,19 @@ open class EPUBNavigatorViewController: InputObservableViewController,
 
     public func apply(decorations: [Decoration], in group: DecorationGroup) {
         decorationTasks[group]?.cancel()
-        decorationTasks[group] = Task {
-            await initialized()
+        var task: Task<Void, Never>?
+        task = Task { [weak self] in
+            defer {
+                if let self, self.decorationTasks[group] == task {
+                    self.decorationTasks[group] = nil
+                }
+            }
+            guard let self else { return }
+            await self.initialized()
 
             guard
                 !Task.isCancelled,
-                let paginationView = paginationView
+                let paginationView = self.paginationView
             else {
                 return
             }
@@ -841,7 +848,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
                 let source = self.decorations[group] ?? []
                 let target = decorations.map {
                     var d = $0
-                    d.locator = publication.normalizeLocator(d.locator)
+                    d.locator = self.publication.normalizeLocator(d.locator)
                     return DiffableDecoration(decoration: d)
                 }
                 self.decorations[group] = target
@@ -860,7 +867,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
                     }
                 } else {
                     for (href, changes) in target.changesByHREF(from: source) {
-                        guard let script = changes.javascript(forGroup: group, styles: config.decorationTemplates) else {
+                        guard let script = changes.javascript(forGroup: group, styles: self.config.decorationTemplates) else {
                             continue
                         }
                         tasks.addTask { @MainActor [weak self] in
@@ -877,6 +884,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
                 }
             }
         }
+        decorationTasks[group] = task
     }
 
     public func observeDecorationInteractions(inGroup group: DecorationGroup, onActivated: @escaping OnActivatedCallback) {

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -809,24 +809,35 @@ open class EPUBNavigatorViewController: InputObservableViewController,
 
     // MARK: - DecorableNavigator
 
-    private var decorations: [String: [DiffableDecoration]] = [:]
+    private var decorations: [DecorationGroup: [DiffableDecoration]] = [:]
 
     /// Decoration group callbacks, indexed by the group name.
-    private var decorationCallbacks: [String: [DecorableNavigator.OnActivatedCallback]] = [:]
+    private var decorationCallbacks: [DecorationGroup: [DecorableNavigator.OnActivatedCallback]] = [:]
+
+    /// Pending decoration tasks, indexed by group name. Stored to allow
+    /// cancellation when a new `apply(decorations:in:)` call supersedes a
+    /// previous one.
+    private var decorationTasks: [DecorationGroup: Task<Void, Never>] = [:]
 
     public func supports(decorationStyle style: Decoration.Style.Id) -> Bool {
         config.decorationTemplates.keys.contains(style)
     }
 
-    public func apply(decorations: [Decoration], in group: String) {
-        Task {
+    public func apply(decorations: [Decoration], in group: DecorationGroup) {
+        decorationTasks[group]?.cancel()
+        decorationTasks[group] = Task {
             await initialized()
 
-            guard let paginationView = paginationView else {
+            guard
+                !Task.isCancelled,
+                let paginationView = paginationView
+            else {
                 return
             }
 
             await withTaskGroup(of: Void.self) { tasks in
+                guard !Task.isCancelled else { return }
+
                 let source = self.decorations[group] ?? []
                 let target = decorations.map {
                     var d = $0
@@ -838,6 +849,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
                 if decorations.isEmpty {
                     for (_, pageView) in paginationView.loadedViews {
                         tasks.addTask {
+                            guard !Task.isCancelled else { return }
                             await (pageView as? EPUBSpreadView)?.evaluateScript(
                                 // The updates command are using `requestAnimationFrame()`, so we need it for
                                 // `clear()` as well otherwise we might recreate a highlight after it has been
@@ -853,6 +865,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
                         }
                         tasks.addTask { @MainActor [weak self] in
                             guard
+                                !Task.isCancelled,
                                 let spreadView = self?.loadedSpreadViewForHREF(href),
                                 spreadView.isSpreadLoaded
                             else {
@@ -866,7 +879,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
         }
     }
 
-    public func observeDecorationInteractions(inGroup group: String, onActivated: @escaping OnActivatedCallback) {
+    public func observeDecorationInteractions(inGroup group: DecorationGroup, onActivated: @escaping OnActivatedCallback) {
         var callbacks = decorationCallbacks[group] ?? []
         callbacks.append(onActivated)
         decorationCallbacks[group] = callbacks
@@ -1186,7 +1199,7 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
         }
     }
 
-    func spreadView(_ spreadView: EPUBSpreadView, didActivateDecoration id: Decoration.Id, inGroup group: String, frame: CGRect?, point: CGPoint?) {
+    func spreadView(_ spreadView: EPUBSpreadView, didActivateDecoration id: Decoration.Id, inGroup group: DecorationGroup, frame: CGRect?, point: CGPoint?) {
         guard
             let callbacks = decorationCallbacks[group].takeIf({ !$0.isEmpty }),
             let decoration: Decoration = decorations[group]?

--- a/Sources/Navigator/EPUB/EPUBSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBSpreadView.swift
@@ -22,7 +22,7 @@ protocol EPUBSpreadViewDelegate: AnyObject {
     func spreadView(_ spreadView: EPUBSpreadView, didTapOnInternalLink href: String, clickEvent: ClickEvent?)
 
     /// Called when the user tapped on a decoration.
-    func spreadView(_ spreadView: EPUBSpreadView, didActivateDecoration id: Decoration.Id, inGroup group: String, frame: CGRect?, point: CGPoint?)
+    func spreadView(_ spreadView: EPUBSpreadView, didActivateDecoration id: Decoration.Id, inGroup group: DecorationGroup, frame: CGRect?, point: CGPoint?)
 
     /// Called when the text selection changes.
     func spreadView(_ spreadView: EPUBSpreadView, selectionDidChange text: Locator.Text?, frame: CGRect)


### PR DESCRIPTION
### Fixed

#### Navigator

* Fixed a race condition in `EPUBNavigatorViewController` where rapidly calling `apply(decorations:in:)` for the same group could cause multiple highlights to appear simultaneously.