### PR TITLE
Add continuous vertical scrolling for reflowable EPUBs

### DIFF
--- a/Sources/Navigator/EPUB/ContinuousPaginationView.swift
+++ b/Sources/Navigator/EPUB/ContinuousPaginationView.swift
@@ -1,0 +1,519 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import ReadiumShared
+import UIKit
+
+/// A vertical pagination container used in continuous scroll mode.
+final class ContinuousPaginationView: UIView, Loggable, PaginationContainerView {
+    weak var delegate: PaginationViewDelegate?
+
+    private(set) var pageCount: Int = 0
+    private(set) var currentIndex: Int = 0
+    private(set) var loadedViews: [Int: UIView & PageView] = [:]
+
+    var currentView: (UIView & PageView)? {
+        loadedViews[currentIndex]
+    }
+
+    var viewportRect: CGRect {
+        CGRect(origin: scrollView.contentOffset, size: scrollView.bounds.size)
+    }
+
+    private let preloadPreviousPositionCount: Int
+    private let preloadNextPositionCount: Int
+    private let scrollView = UIScrollView()
+
+    private var estimatedPageHeight: CGFloat {
+        max(scrollView.bounds.height, bounds.height, 1)
+    }
+
+    private var pageHeights: [CGFloat] = []
+    private var loadingIndexQueue: [Int] = []
+    private var onViewLoadedCallbacks: [Int: CompletionList] = [:]
+    private var readyViewIndices: Set<Int> = []
+    private var loadPagesTask: Task<Void, Never>?
+    private var pendingReloadNavigationTask: Task<Void, Never>?
+
+    private var scrollAnimationContinuation: CheckedContinuation<Void, Never>?
+    private var isAdjustingContentOffset = false
+
+    var isScrollEnabled: Bool {
+        didSet { scrollView.isScrollEnabled = isScrollEnabled }
+    }
+
+    init(
+        frame: CGRect,
+        preloadPreviousPositionCount: Int,
+        preloadNextPositionCount: Int,
+        isScrollEnabled: Bool
+    ) {
+        self.preloadPreviousPositionCount = preloadPreviousPositionCount
+        self.preloadNextPositionCount = preloadNextPositionCount
+        self.isScrollEnabled = isScrollEnabled
+
+        super.init(frame: frame)
+
+        scrollView.delegate = self
+        scrollView.frame = bounds
+        scrollView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+        scrollView.alwaysBounceHorizontal = false
+        scrollView.alwaysBounceVertical = false
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.isScrollEnabled = isScrollEnabled
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        addSubview(scrollView)
+
+        // Keep the same content-inset behavior as PaginationView across iOS versions.
+        insertSubview(UIView(frame: .zero), at: 0)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard pageCount > 0 else {
+            scrollView.contentSize = bounds.size
+            return
+        }
+
+        let width = scrollView.bounds.width
+        var y: CGFloat = 0
+
+        for index in 0 ..< pageCount {
+            let height = pageHeights.getOrNil(index) ?? estimatedPageHeight
+            if let view = loadedViews[index] {
+                view.frame = CGRect(x: 0, y: y, width: width, height: height)
+            }
+            y += height
+        }
+
+        scrollView.contentSize = CGSize(width: width, height: max(y, scrollView.bounds.height))
+        clampContentOffsetIfNeeded()
+    }
+
+    override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
+
+        guard newSuperview == nil else {
+            return
+        }
+
+        loadPagesTask?.cancel()
+        pendingReloadNavigationTask?.cancel()
+        for (_, view) in loadedViews {
+            (view as? ContinuousPageView)?.onPreferredHeightChange = nil
+            view.removeFromSuperview()
+        }
+        loadedViews.removeAll()
+        onViewLoadedCallbacks.removeAll()
+        readyViewIndices.removeAll()
+    }
+
+    func reloadAtIndex(
+        _ index: Int,
+        location: PageLocation,
+        pageCount: Int,
+        readingProgression: ReadingProgression,
+        navigateToLocationAfterReload: Bool
+    ) {
+        precondition(pageCount >= 1)
+        precondition(0 ..< pageCount ~= index)
+
+        self.pageCount = pageCount
+        pageHeights = Array(repeating: estimatedPageHeight, count: pageCount)
+
+        loadPagesTask?.cancel()
+        pendingReloadNavigationTask?.cancel()
+        loadingIndexQueue.removeAll()
+        onViewLoadedCallbacks.removeAll()
+        readyViewIndices.removeAll()
+
+        for (_, view) in loadedViews {
+            (view as? ContinuousPageView)?.onPreferredHeightChange = nil
+            view.removeFromSuperview()
+        }
+        loadedViews.removeAll()
+
+        synchronizeLayout()
+
+        currentIndex = index
+        scrollView.contentOffset = CGPoint(x: 0, y: yOffset(before: index))
+
+        setCurrentIndex(index)
+
+        guard navigateToLocationAfterReload else {
+            return
+        }
+
+        pendingReloadNavigationTask = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+
+            defer {
+                self.pendingReloadNavigationTask = nil
+            }
+
+            _ = await self.goToIndex(
+                index,
+                location: location,
+                options: NavigatorGoOptions(animated: false),
+                cancelPendingReloadNavigation: false
+            )
+        }
+    }
+
+    func goToIndex(_ index: Int, location: PageLocation, options: NavigatorGoOptions) async -> Bool {
+        await goToIndex(index, location: location, options: options, cancelPendingReloadNavigation: true)
+    }
+
+    private func goToIndex(
+        _ index: Int,
+        location: PageLocation,
+        options: NavigatorGoOptions,
+        cancelPendingReloadNavigation: Bool
+    ) async -> Bool {
+        guard 0 ..< pageCount ~= index else {
+            return false
+        }
+
+        if cancelPendingReloadNavigation {
+            pendingReloadNavigationTask?.cancel()
+            pendingReloadNavigationTask = nil
+        }
+
+        setCurrentIndex(index)
+        let isReady = await waitUntilViewIsLoaded(at: index)
+        synchronizeLayout()
+
+        guard isReady || location.isStart else {
+            log(.warning, "Timed out waiting for continuous page \(index) to become ready for \(location)")
+            return false
+        }
+
+        let baseOffset = yOffset(before: index)
+        let pageHeight = pageHeights.getOrNil(index) ?? estimatedPageHeight
+        let localOffset = (
+            isReady
+                ? await resolvedTargetYOffset(at: index, location: location, viewportHeight: scrollView.bounds.height)
+                : nil
+        ) ?? defaultTargetYOffset(for: location, pageHeight: pageHeight, viewportHeight: scrollView.bounds.height)
+        guard localOffset.isFinite else {
+            return false
+        }
+        let targetY = clampYOffset(baseOffset + localOffset)
+
+        guard abs(scrollView.contentOffset.y - targetY) > 0.5 else {
+            return true
+        }
+
+        await setContentOffset(CGPoint(x: 0, y: targetY), animated: options.animated && !UIAccessibility.isReduceMotionEnabled)
+        updateCurrentIndexFromViewport()
+        delegate?.paginationViewDidUpdateViews(self)
+        return true
+    }
+
+    func go(to direction: EPUBSpreadView.Direction, options: NavigatorGoOptions, readingProgression: ReadingProgression) async -> Bool {
+        let isForward = switch readingProgression {
+        case .ltr:
+            direction == .right
+        case .rtl:
+            direction == .left
+        }
+        let delta = scrollView.bounds.height * (isForward ? 1 : -1)
+        let targetY = clampYOffset(scrollView.contentOffset.y + delta)
+
+        guard abs(scrollView.contentOffset.y - targetY) > 0.5 else {
+            return false
+        }
+
+        await setContentOffset(CGPoint(x: 0, y: targetY), animated: options.animated && !UIAccessibility.isReduceMotionEnabled)
+        updateCurrentIndexFromViewport()
+        delegate?.paginationViewDidUpdateViews(self)
+        return true
+    }
+
+    private func setCurrentIndex(_ index: Int) {
+        currentIndex = index
+
+        scheduleLoadPage(at: index)
+        let lastIndex = scheduleLoadPages(from: index, upToPositionCount: preloadNextPositionCount, direction: .forward)
+        let firstIndex = scheduleLoadPages(from: index, upToPositionCount: preloadPreviousPositionCount, direction: .backward)
+
+        for (loadedIndex, view) in loadedViews {
+            guard firstIndex ... lastIndex ~= loadedIndex else {
+                (view as? ContinuousPageView)?.onPreferredHeightChange = nil
+                view.removeFromSuperview()
+                loadedViews.removeValue(forKey: loadedIndex)
+                readyViewIndices.remove(loadedIndex)
+                continue
+            }
+        }
+
+        loadPages()
+    }
+
+    private func loadPages() {
+        loadPagesTask?.cancel()
+        loadPagesTask = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            await self.loadNextPage()
+            self.delegate?.paginationViewDidUpdateViews(self)
+        }
+    }
+
+    private func loadNextPage() async {
+        guard let index = loadingIndexQueue.popFirst() else {
+            return
+        }
+
+        if loadedViews[index] == nil, let view = delegate?.paginationView(self, pageViewAtIndex: index) {
+            loadedViews[index] = view
+            scrollView.addSubview(view)
+            bindContinuousPageViewCallbacks(view, index: index)
+            synchronizeLayout()
+        }
+
+        guard let view = loadedViews[index] else {
+            return
+        }
+
+        await view.go(to: .start, animated: false)
+        updatePageHeight(at: index)
+        synchronizeLayout()
+        readyViewIndices.insert(index)
+        onViewLoadedCallbacks[index]?.complete()
+        onViewLoadedCallbacks[index] = nil
+
+        await loadNextPage()
+    }
+
+    private func bindContinuousPageViewCallbacks(_ view: UIView & PageView, index: Int) {
+        guard let view = view as? (UIView & ContinuousPageView) else {
+            return
+        }
+
+        view.onPreferredHeightChange = { [weak self] in
+            DispatchQueue.main.async {
+                self?.updatePageHeight(at: index)
+            }
+        }
+    }
+
+    private func updatePageHeight(at index: Int) {
+        guard let view = loadedViews[index] else {
+            return
+        }
+
+        let oldHeight = pageHeights.getOrNil(index) ?? estimatedPageHeight
+        let newHeight: CGFloat = {
+            guard let view = view as? (UIView & ContinuousPageView) else {
+                return oldHeight
+            }
+            return max(view.preferredHeight(for: scrollView.bounds.width), 1)
+        }()
+
+        guard abs(newHeight - oldHeight) > 0.5 else {
+            return
+        }
+
+        let pageMinY = yOffset(before: index)
+        let viewportMinY = viewportRect.minY
+        pageHeights[index] = newHeight
+
+        if pageMinY < viewportMinY {
+            isAdjustingContentOffset = true
+            scrollView.contentOffset.y += newHeight - oldHeight
+            isAdjustingContentOffset = false
+        }
+
+        setNeedsLayout()
+        layoutIfNeeded()
+        delegate?.paginationViewDidUpdateViews(self)
+    }
+
+    private func waitUntilViewIsLoaded(at index: Int, timeout: TimeInterval = 2.0) async -> Bool {
+        guard !readyViewIndices.contains(index) else {
+            return true
+        }
+
+        let sleepNanoseconds: UInt64 = 50_000_000
+        let timeoutNanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
+        let maxAttempts = max(Int(timeoutNanoseconds / sleepNanoseconds), 1)
+
+        for _ in 0 ..< maxAttempts {
+            if readyViewIndices.contains(index) {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: sleepNanoseconds)
+        }
+
+        let isReady = readyViewIndices.contains(index)
+        if !isReady {
+            log(.warning, "Continuous page \(index) did not finish loading within \(timeout)s")
+        }
+        return isReady
+    }
+
+    private func synchronizeLayout() {
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
+
+    private func targetYOffset(at index: Int, location: PageLocation, viewportHeight: CGFloat) async -> CGFloat? {
+        guard let view = loadedViews[index] as? (UIView & ContinuousPageView) else {
+            return nil
+        }
+        return await view.targetYOffset(for: location, viewportHeight: viewportHeight)
+    }
+
+    private func resolvedTargetYOffset(at index: Int, location: PageLocation, viewportHeight: CGFloat) async -> CGFloat? {
+        let attemptCount: Int = {
+            guard case let .locator(locator) = location else {
+                return 1
+            }
+            return (locator.locations.progression == nil) ? 6 : 1
+        }()
+
+        for attempt in 0 ..< attemptCount {
+            if let offset = await targetYOffset(at: index, location: location, viewportHeight: viewportHeight), offset.isFinite {
+                return offset
+            }
+
+            guard attempt < attemptCount - 1 else {
+                break
+            }
+
+            synchronizeLayout()
+            try? await Task.sleep(seconds: 0.05)
+        }
+
+        return nil
+    }
+
+    private func defaultTargetYOffset(for location: PageLocation, pageHeight: CGFloat, viewportHeight: CGFloat) -> CGFloat {
+        switch location {
+        case .start:
+            return 0
+        case .end:
+            return max(pageHeight - viewportHeight, 0)
+        case let .locator(locator):
+            guard let progression = locator.locations.progression else {
+                return .nan
+            }
+            return max(0, pageHeight * progression)
+        }
+    }
+
+    private func setContentOffset(_ contentOffset: CGPoint, animated: Bool) async {
+        if animated {
+            await withCheckedContinuation { continuation in
+                scrollAnimationContinuation?.resume()
+                scrollAnimationContinuation = continuation
+                scrollView.setContentOffset(contentOffset, animated: true)
+            }
+        } else {
+            scrollView.contentOffset = contentOffset
+        }
+    }
+
+    private func clampContentOffsetIfNeeded() {
+        let clamped = clampYOffset(scrollView.contentOffset.y)
+        guard abs(clamped - scrollView.contentOffset.y) > 0.5 else {
+            return
+        }
+
+        isAdjustingContentOffset = true
+        scrollView.contentOffset.y = clamped
+        isAdjustingContentOffset = false
+    }
+
+    private func clampYOffset(_ y: CGFloat) -> CGFloat {
+        let maxOffset = max(scrollView.contentSize.height - scrollView.bounds.height, 0)
+        return min(max(y, 0), maxOffset)
+    }
+
+    private func yOffset(before index: Int) -> CGFloat {
+        pageHeights.prefix(index).reduce(0, +)
+    }
+
+    private func updateCurrentIndexFromViewport() {
+        guard pageCount > 0 else {
+            return
+        }
+
+        let offset = clampYOffset(scrollView.contentOffset.y + 1)
+        var accumulatedHeight: CGFloat = 0
+
+        for index in 0 ..< pageCount {
+            accumulatedHeight += pageHeights.getOrNil(index) ?? estimatedPageHeight
+            if offset < accumulatedHeight || index == pageCount - 1 {
+                guard currentIndex != index else {
+                    return
+                }
+                setCurrentIndex(index)
+                return
+            }
+        }
+    }
+
+    @discardableResult
+    private func scheduleLoadPage(at index: Int) -> Bool {
+        guard 0 ..< pageCount ~= index else {
+            return false
+        }
+
+        loadingIndexQueue.removeAll { $0 == index }
+        loadingIndexQueue.append(index)
+        return true
+    }
+
+    private func scheduleLoadPages(from sourceIndex: Int, upToPositionCount positionCount: Int, direction: PageIndexDirection) -> Int {
+        let index = sourceIndex + direction.rawValue
+        guard
+            positionCount > 0,
+            scheduleLoadPage(at: index),
+            let indexPositionCount = delegate?.paginationView(self, positionCountAtIndex: index)
+        else {
+            return sourceIndex
+        }
+
+        return scheduleLoadPages(
+            from: index,
+            upToPositionCount: positionCount - indexPositionCount,
+            direction: direction
+        )
+    }
+
+    private enum PageIndexDirection: Int {
+        case forward = 1
+        case backward = -1
+    }
+}
+
+extension ContinuousPaginationView: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard !isAdjustingContentOffset else {
+            return
+        }
+
+        updateCurrentIndexFromViewport()
+        delegate?.paginationViewDidUpdateViews(self)
+    }
+
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        scrollAnimationContinuation?.resume()
+        scrollAnimationContinuation = nil
+    }
+}

--- a/Sources/Navigator/EPUB/EPUBFixedSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBFixedSpreadView.swift
@@ -21,13 +21,14 @@ final class EPUBFixedSpreadView: EPUBSpreadView {
     required init(
         viewModel: EPUBNavigatorViewModel,
         spread: EPUBSpread,
+        scrollMode: ScrollMode,
         scripts: [WKUserScript],
         animatedLoad: Bool
     ) {
         var scripts = scripts
         scripts.append(WKUserScript(source: Self.fixedScript, injectionTime: .atDocumentStart, forMainFrameOnly: false))
 
-        super.init(viewModel: viewModel, spread: spread, scripts: scripts, animatedLoad: animatedLoad)
+        super.init(viewModel: viewModel, spread: spread, scrollMode: scrollMode, scripts: scripts, animatedLoad: animatedLoad)
     }
 
     override func setupWebView() {

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -539,6 +539,11 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             return true
         }
 
+        if await paginationView.go(to: direction, options: options, readingProgression: viewModel.readingProgression) {
+            on(.moved)
+            return true
+        }
+
         let isRTL = (viewModel.readingProgression == .rtl)
         let delta = isRTL ? -1 : 1
         let moved: Bool = await {
@@ -558,25 +563,71 @@ open class EPUBNavigatorViewController: InputObservableViewController,
 
     // MARK: - Pagination and spreads
 
-    private var paginationView: PaginationView?
+    private var paginationView: (UIView & PaginationContainerView)?
 
-    private func makePaginationView(hasPositions: Bool) -> PaginationView {
-        let view = PaginationView(
-            frame: .zero,
-            preloadPreviousPositionCount: hasPositions ? config.preloadPreviousPositionCount : 0,
-            preloadNextPositionCount: hasPositions ? config.preloadNextPositionCount : 0,
-            isScrollEnabled: isPaginationViewScrollingEnabled
-        )
+    private var usesContinuousVerticalScrolling: Bool {
+        publication.metadata.epubLayout == .reflowable
+            && settings.scroll
+            && !settings.verticalText
+    }
+
+    private var spreadScrollMode: EPUBSpreadView.ScrollMode {
+        if usesContinuousVerticalScrolling {
+            return .continuous
+        } else if settings.scroll {
+            return .perSpread
+        } else {
+            return .paginated
+        }
+    }
+
+    private func makePaginationView(hasPositions: Bool) -> UIView & PaginationContainerView {
+        let preloadPrevious = hasPositions ? config.preloadPreviousPositionCount : 0
+        let preloadNext = hasPositions ? config.preloadNextPositionCount : 0
+        let view: UIView & PaginationContainerView = if usesContinuousVerticalScrolling {
+            ContinuousPaginationView(
+                frame: .zero,
+                preloadPreviousPositionCount: preloadPrevious,
+                preloadNextPositionCount: preloadNext,
+                isScrollEnabled: isPaginationViewScrollingEnabled
+            )
+        } else {
+            PaginationView(
+                frame: .zero,
+                preloadPreviousPositionCount: preloadPrevious,
+                preloadNextPositionCount: preloadNext,
+                isScrollEnabled: isPaginationViewScrollingEnabled
+            )
+        }
         view.delegate = self
         view.backgroundColor = .clear
         return view
     }
 
     private func invalidatePaginationView() {
-        guard let paginationView = paginationView else {
+        guard isViewLoaded else {
             return
         }
 
+        let currentContainer = paginationView
+        let containerNeedsReplacement = currentContainer.map {
+            ($0 is ContinuousPaginationView) != usesContinuousVerticalScrolling
+        } ?? true
+
+        if containerNeedsReplacement {
+            let newContainer = makePaginationView(hasPositions: !positionsByReadingOrder.isEmpty)
+            newContainer.frame = view.bounds
+            newContainer.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+            newContainer.isUserInteractionEnabled = (state == .idle)
+
+            currentContainer?.removeFromSuperview()
+            paginationView = newContainer
+            view.addSubview(newContainer)
+        }
+
+        guard let paginationView = paginationView else {
+            return
+        }
         paginationView.isScrollEnabled = isPaginationViewScrollingEnabled
         reloadSpreads()
     }
@@ -644,7 +695,8 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             initialIndex,
             location: PageLocation(locator),
             pageCount: spreads.count,
-            readingProgression: viewModel.readingProgression
+            readingProgression: viewModel.readingProgression,
+            navigateToLocationAfterReload: true
         )
 
         on(.loaded)
@@ -663,10 +715,40 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             .first { $0.spread.contains(index: index) }
     }
 
+    private func visibleSpreadViews() -> [(index: Int, spreadView: EPUBSpreadView, visibleRect: CGRect)] {
+        guard let paginationView = paginationView else {
+            return []
+        }
+
+        let viewportRect = paginationView.viewportRect
+
+        return paginationView.loadedViews
+            .sorted { $0.key < $1.key }
+            .compactMap { index, view in
+                guard let spreadView = view as? EPUBSpreadView else {
+                    return nil
+                }
+
+                let visibleRect = spreadView.frame.intersection(viewportRect)
+                guard !visibleRect.isNull, !visibleRect.isEmpty else {
+                    return nil
+                }
+
+                return (
+                    index: index,
+                    spreadView: spreadView,
+                    visibleRect: spreadView.convert(visibleRect, from: paginationView)
+                )
+            }
+    }
+
     // MARK: - Navigator
 
     private var isPaginationViewScrollingEnabled: Bool {
-        !(config.disablePageTurnsWhileScrolling && settings.scroll)
+        if usesContinuousVerticalScrolling {
+            return true
+        }
+        return !(config.disablePageTurnsWhileScrolling && settings.scroll)
     }
 
     public var presentation: VisualNavigatorPresentation {
@@ -691,13 +773,23 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             return (pendingLocator, nil)
         }
 
-        guard let spreadView = paginationView?.currentView as? EPUBSpreadView else {
+        let visibleSpreads = visibleSpreadViews()
+        guard
+            let firstVisibleSpread = visibleSpreads.first,
+            let lastVisibleSpread = visibleSpreads.last
+        else {
             return (nil, nil)
         }
 
+        let progressions = visibleSpreads.reduce(into: [ReadingOrder.Index: ClosedRange<Double>]()) { progressions, item in
+            for index in item.spreadView.spread.readingOrderIndices {
+                progressions[index] = item.spreadView.progression(in: index, visibleRect: item.visibleRect)
+            }
+        }
+
         let (locator, viewport) = await EPUBViewportAndLocationCalculator.compute(
-            readingOrderIndices: spreadView.spread.readingOrderIndices,
-            progression: { spreadView.progression(in: $0) },
+            readingOrderIndices: firstVisibleSpread.spreadView.spread.readingOrderIndices.lowerBound ... lastVisibleSpread.spreadView.spread.readingOrderIndices.upperBound,
+            progression: { progressions[$0] ?? 0 ... 0 },
             readingOrder: readingOrder,
             positionsByReadingOrder: positionsByReadingOrder,
             tableOfContentsTitleByHref: tableOfContentsTitleByHref,
@@ -707,10 +799,10 @@ open class EPUBNavigatorViewController: InputObservableViewController,
     }
 
     public func firstVisibleElementLocator() async -> Locator? {
-        guard let spreadView = paginationView?.currentView as? EPUBSpreadView else {
+        guard let firstVisibleSpread = visibleSpreadViews().first else {
             return nil
         }
-        return await spreadView.findFirstVisibleElementLocator()
+        return await firstVisibleSpread.spreadView.firstVisibleElementLocator(in: firstVisibleSpread.visibleRect)
     }
 
     /// Last current location notified to the delegate.
@@ -748,6 +840,27 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             on(.jump(locator))
         else {
             return false
+        }
+
+        let requiresPreciseContinuousAnchor =
+            locator.locations.progression == nil
+            || !locator.locations.fragments.isEmpty
+            || locator.locations["cssSelector"] != nil
+            || locator.text.highlight != nil
+
+        // Explicit TOC and deep-link jumps in continuous mode should rebuild
+        // the vertical window around the destination before resolving the
+        // in-resource offset. Reusing the current window can leave us with a
+        // stale web view / height cache, which makes fragment-only jumps look
+        // like no-ops after the first navigation.
+        if usesContinuousVerticalScrolling, spreadIndex != currentSpreadIndex || requiresPreciseContinuousAnchor {
+            paginationView.reloadAtIndex(
+                spreadIndex,
+                location: .locator(locator),
+                pageCount: spreads.count,
+                readingProgression: viewModel.readingProgression,
+                navigateToLocationAfterReload: false
+            )
         }
 
         let success = await paginationView.goToIndex(spreadIndex, location: .locator(locator), options: options)
@@ -1266,12 +1379,13 @@ extension EPUBNavigatorViewController: EditingActionsControllerDelegate {
 }
 
 extension EPUBNavigatorViewController: PaginationViewDelegate {
-    func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) -> (UIView & PageView)? {
+    func paginationView(_ paginationView: any PaginationContainerView, pageViewAtIndex index: Int) -> (UIView & PageView)? {
         let spread = spreads[index]
         let spreadViewType = (publication.metadata.layout == .fixed) ? EPUBFixedSpreadView.self : EPUBReflowableSpreadView.self
         let spreadView = spreadViewType.init(
             viewModel: viewModel,
             spread: spread,
+            scrollMode: spreadScrollMode,
             scripts: [],
             animatedLoad: false
         )
@@ -1283,14 +1397,14 @@ extension EPUBNavigatorViewController: PaginationViewDelegate {
         return spreadView
     }
 
-    func paginationViewDidUpdateViews(_ paginationView: PaginationView) {
+    func paginationViewDidUpdateViews(_ paginationView: any PaginationContainerView) {
         // Note that you should set the delegate before you load views
         // otherwise, when open the publication, you may miss the first
         // invocation.
         updateCurrentLocation()
     }
 
-    func paginationView(_ paginationView: PaginationView, positionCountAtIndex index: Int) -> Int {
+    func paginationView(_ paginationView: any PaginationContainerView, positionCountAtIndex index: Int) -> Int {
         spreads[index].positionCount(in: readingOrder, positionsByReadingOrder: positionsByReadingOrder)
     }
 }

--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -14,20 +14,414 @@ import WebKit
 final class EPUBReflowableSpreadView: EPUBSpreadView {
     private var topConstraint: NSLayoutConstraint!
     private var bottomConstraint: NSLayoutConstraint!
+    private var webViewHeightConstraint: NSLayoutConstraint!
+    private var contentInsets: UIEdgeInsets = .zero
+    private var measuredDocumentHeight: CGFloat?
+    private var documentHeightTask: Task<Void, Never>?
 
     private static let reflowableScript = loadScript(named: "readium-reflowable")
+    private static let continuousScript = """
+        (function () {
+          if (window.readiumContinuous) {
+            return;
+          }
+
+          function escapeCssIdentifier(value) {
+            if (window.CSS && typeof window.CSS.escape === "function") {
+              return window.CSS.escape(value);
+            }
+            return String(value).replace(/([^a-zA-Z0-9_-])/g, "\\\\$1");
+          }
+
+          function cssSelectorForElement(element) {
+            if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+              return "body";
+            }
+
+            if (element.id) {
+              return "#" + escapeCssIdentifier(element.id);
+            }
+
+            var segments = [];
+            var current = element;
+            while (current && current.nodeType === Node.ELEMENT_NODE && current !== document.documentElement) {
+              var selector = current.nodeName.toLowerCase();
+              if (current.id) {
+                selector += "#" + escapeCssIdentifier(current.id);
+                segments.unshift(selector);
+                break;
+              }
+
+              var position = 1;
+              var sibling = current.previousElementSibling;
+              while (sibling) {
+                if (sibling.nodeName === current.nodeName) {
+                  position += 1;
+                }
+                sibling = sibling.previousElementSibling;
+              }
+
+              selector += ":nth-of-type(" + position + ")";
+              segments.unshift(selector);
+              current = current.parentElement;
+            }
+
+            if (segments.length === 0) {
+              return "body";
+            }
+            return segments.join(" > ");
+          }
+
+          function makeRectJSON(rect) {
+            return {
+              x: rect.x,
+              y: rect.y,
+              width: rect.width,
+              height: rect.height,
+              top: rect.top,
+              right: rect.right,
+              bottom: rect.bottom,
+              left: rect.left,
+            };
+          }
+
+          function rangeForText(root, highlight, before, after) {
+            var target = String(highlight || "").trim();
+            if (!target) {
+              return null;
+            }
+
+            var searchRoot = root || document.body;
+            var walker = document.createTreeWalker(searchRoot, NodeFilter.SHOW_TEXT, {
+              acceptNode: function (node) {
+                return node.textContent && node.textContent.trim()
+                  ? NodeFilter.FILTER_ACCEPT
+                  : NodeFilter.FILTER_REJECT;
+              },
+            });
+
+            var matches = [];
+            var node;
+            while ((node = walker.nextNode())) {
+              var text = node.textContent || "";
+              var index = text.indexOf(target);
+              while (index >= 0) {
+                matches.push({ node: node, index: index, text: text });
+                index = text.indexOf(target, index + 1);
+              }
+            }
+
+            if (matches.length === 0) {
+              return null;
+            }
+
+            function score(match) {
+              var points = 0;
+              if (before && match.text.slice(Math.max(0, match.index - before.length), match.index).indexOf(before) >= 0) {
+                points += 1;
+              }
+              if (after && match.text.slice(match.index + target.length, match.index + target.length + after.length).indexOf(after) >= 0) {
+                points += 1;
+              }
+              return points;
+            }
+
+            var best = matches[0];
+            var bestScore = score(best);
+            for (var i = 1; i < matches.length; i += 1) {
+              var candidateScore = score(matches[i]);
+              if (candidateScore > bestScore) {
+                best = matches[i];
+                bestScore = candidateScore;
+              }
+            }
+
+            var range = document.createRange();
+            range.setStart(best.node, best.index);
+            range.setEnd(best.node, best.index + target.length);
+            return range;
+          }
+
+          function rectFromRange(range) {
+            if (!range) {
+              return null;
+            }
+
+            var rects = range.getClientRects();
+            if (rects && rects.length > 0) {
+              return rects[0];
+            }
+
+            return range.getBoundingClientRect();
+          }
+
+          function rectFromNode(node) {
+            if (!node) {
+              return null;
+            }
+
+            if (node.nodeType === Node.TEXT_NODE) {
+              var textRange = document.createRange();
+              textRange.selectNodeContents(node);
+              return rectFromRange(textRange);
+            }
+
+            if (node.nodeType !== Node.ELEMENT_NODE) {
+              return null;
+            }
+
+            var rects = node.getClientRects();
+            if (rects && rects.length > 0) {
+              return rects[0];
+            }
+
+            for (var i = 0; i < node.childNodes.length; i += 1) {
+              var childRect = rectFromNode(node.childNodes[i]);
+              if (childRect) {
+                return childRect;
+              }
+            }
+
+            return node.getBoundingClientRect();
+          }
+
+          function fragmentCandidates(fragment) {
+            var value = String(fragment || "").trim();
+            if (!value) {
+              return [];
+            }
+
+            if (value.charAt(0) === "#") {
+              value = value.slice(1);
+            }
+
+            var candidates = [value];
+            try {
+              var decoded = decodeURIComponent(value);
+              if (decoded && candidates.indexOf(decoded) < 0) {
+                candidates.push(decoded);
+              }
+            } catch (_) {}
+
+            return candidates;
+          }
+
+          function elementFromFragment(fragment) {
+            var candidates = fragmentCandidates(fragment);
+
+            for (var i = 0; i < candidates.length; i += 1) {
+              var element = document.getElementById(candidates[i]);
+              if (element) {
+                return element;
+              }
+            }
+
+            for (var j = 0; j < candidates.length; j += 1) {
+              var namedElements = document.getElementsByName(candidates[j]);
+              for (var k = 0; k < namedElements.length; k += 1) {
+                return namedElements[k];
+              }
+            }
+
+            return null;
+          }
+
+          function findHeadingByTitle(title) {
+            var target = String(title || "").trim();
+            if (!target) {
+              return null;
+            }
+
+            var headings = document.querySelectorAll("h1, h2, h3, h4, h5, h6");
+            for (var i = 0; i < headings.length; i += 1) {
+              var text = String(headings[i].textContent || "").trim();
+              if (text === target) {
+                return headings[i];
+              }
+            }
+
+            for (var j = 0; j < headings.length; j += 1) {
+              var partial = String(headings[j].textContent || "").trim();
+              if (partial && partial.indexOf(target) >= 0) {
+                return headings[j];
+              }
+            }
+
+            return null;
+          }
+
+          function rectFromLocator(locator) {
+            try {
+              var locations = locator && locator.locations ? locator.locations : {};
+              var text = locator && locator.text ? locator.text : {};
+              var root = document.body;
+              var element = null;
+
+              if (locations.cssSelector) {
+                element = document.querySelector(locations.cssSelector);
+                if (element) {
+                  root = element;
+                }
+              }
+
+              if (!element && Array.isArray(locations.fragments)) {
+                for (var i = 0; i < locations.fragments.length; i += 1) {
+                  element = elementFromFragment(locations.fragments[i]);
+                  if (element) {
+                    break;
+                  }
+                }
+              }
+
+              if (element) {
+                return rectFromNode(element);
+              }
+
+              if (locator && locator.title) {
+                element = findHeadingByTitle(locator.title);
+                if (element) {
+                  return rectFromNode(element);
+                }
+              }
+
+              if (text && text.highlight) {
+                return rectFromRange(rangeForText(root, text.highlight, text.before, text.after));
+              }
+            } catch (_) {}
+
+            return null;
+          }
+
+          function documentTopOffset() {
+            var root = document.body || document.documentElement;
+            if (!root) {
+              return 0;
+            }
+            return root.getBoundingClientRect().top;
+          }
+
+          function shouldIgnoreElement(element) {
+            var style = getComputedStyle(element);
+            if (!style) {
+              return false;
+            }
+
+            if (style.getPropertyValue("display") !== "block") {
+              return true;
+            }
+            return style.getPropertyValue("opacity") === "0";
+          }
+
+          function isElementVisibleInRect(element, rect) {
+            if (element === document.body || element === document.documentElement) {
+              return true;
+            }
+
+            var elementRect = element.getBoundingClientRect();
+            return (
+              elementRect.bottom > rect.top &&
+              elementRect.top < rect.bottom &&
+              elementRect.right > rect.left &&
+              elementRect.left < rect.right
+            );
+          }
+
+          function findElementInRect(rootElement, rect) {
+            for (var i = 0; i < rootElement.children.length; i += 1) {
+              var child = rootElement.children[i];
+              if (!shouldIgnoreElement(child) && isElementVisibleInRect(child, rect)) {
+                return findElementInRect(child, rect);
+              }
+            }
+            return rootElement;
+          }
+
+          function contentHeight() {
+            var root = document.scrollingElement || document.documentElement || document.body;
+            return Math.max(
+              root ? root.scrollHeight : 0,
+              root ? root.offsetHeight : 0,
+              document.documentElement ? document.documentElement.scrollHeight : 0,
+              document.documentElement ? document.documentElement.offsetHeight : 0,
+              document.body ? document.body.scrollHeight : 0,
+              document.body ? document.body.offsetHeight : 0
+            );
+          }
+
+          window.readiumContinuous = {
+            contentHeight: contentHeight,
+            locatorRect: function (locator) {
+              var rect = rectFromLocator(locator);
+              return rect ? makeRectJSON(rect) : null;
+            },
+            locatorYOffset: function (locator) {
+              var rect = rectFromLocator(locator);
+              if (!rect) {
+                return null;
+              }
+              return rect.top - documentTopOffset();
+            },
+            findFirstVisibleLocatorInRect: function (rect) {
+              var visibleRect = rect || {
+                top: 0,
+                left: 0,
+                right: window.innerWidth,
+                bottom: window.innerHeight,
+              };
+              var element = findElementInRect(document.body, visibleRect);
+              return {
+                href: "#",
+                type: "application/xhtml+xml",
+                locations: {
+                  cssSelector: cssSelectorForElement(element),
+                },
+                text: {
+                  highlight: (element.textContent || "").trim(),
+                },
+              };
+            },
+            notifyLayoutChange: function () {
+              webkit.messageHandlers.continuousContentLayoutChanged.postMessage({});
+            },
+          };
+
+          window.addEventListener("load", function () {
+            var pendingNotification;
+            function notify() {
+              if (pendingNotification) {
+                cancelAnimationFrame(pendingNotification);
+              }
+              pendingNotification = requestAnimationFrame(function () {
+                window.readiumContinuous.notifyLayoutChange();
+              });
+            }
+
+            notify();
+            var observer = new ResizeObserver(notify);
+            observer.observe(document.documentElement);
+            observer.observe(document.body);
+          });
+        })();
+        """
+
+    private var isContinuousScrolling: Bool {
+        scrollMode == .continuous
+    }
 
     required init(
         viewModel: EPUBNavigatorViewModel,
         spread: EPUBSpread,
+        scrollMode: ScrollMode,
         scripts: [WKUserScript],
         animatedLoad: Bool
     ) {
         super.init(
             viewModel: viewModel,
             spread: spread,
+            scrollMode: scrollMode,
             scripts: [
                 WKUserScript(source: Self.reflowableScript, injectionTime: .atDocumentStart, forMainFrameOnly: false),
+                WKUserScript(source: Self.continuousScript, injectionTime: .atDocumentStart, forMainFrameOnly: false),
             ],
             animatedLoad: animatedLoad
         )
@@ -35,6 +429,9 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
 
     override func clear() {
         super.clear()
+
+        documentHeightTask?.cancel()
+        documentHeightTask = nil
 
         // Clean up go to continuations.
         for continuation in goToContinuations {
@@ -54,13 +451,16 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
         scrollView.alwaysBounceVertical = false
         scrollView.alwaysBounceHorizontal = false
 
-        scrollView.isPagingEnabled = !viewModel.scroll
+        scrollView.isPagingEnabled = (scrollMode == .paginated)
+        scrollView.isScrollEnabled = !isContinuousScrolling
 
         webView.translatesAutoresizingMaskIntoConstraints = false
         topConstraint = webView.topAnchor.constraint(equalTo: topAnchor)
         topConstraint.priority = .defaultHigh
         bottomConstraint = webView.bottomAnchor.constraint(equalTo: bottomAnchor)
         bottomConstraint.priority = .defaultHigh
+        webViewHeightConstraint = webView.heightAnchor.constraint(equalToConstant: 1)
+        webViewHeightConstraint.priority = .required
         NSLayoutConstraint.activate([
             topConstraint, bottomConstraint,
             webView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -90,24 +490,41 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
     override func applySettings() {
         super.applySettings()
 
-        // Disables paginated mode if scroll is on.
-        scrollView.isPagingEnabled = !viewModel.scroll
+        scrollView.isPagingEnabled = (scrollMode == .paginated)
+        scrollView.isScrollEnabled = !isContinuousScrolling
 
         updateContentInset()
+        if isContinuousScrolling {
+            scheduleDocumentHeightUpdate()
+        }
     }
 
     private func updateContentInset() {
-        let contentInset = delegate?.spreadViewContentInset(self) ?? .zero
+        contentInsets = delegate?.spreadViewContentInset(self) ?? .zero
 
-        if viewModel.scroll {
+        if isContinuousScrolling {
+            topConstraint.constant = contentInsets.top
+            bottomConstraint.isActive = false
+            webViewHeightConstraint.isActive = true
+            webViewHeightConstraint.constant = measuredDocumentHeight ?? estimatedDocumentHeight
+            scrollView.contentInset = .zero
+        } else if viewModel.scroll {
             topConstraint.constant = 0
+            bottomConstraint.isActive = true
+            webViewHeightConstraint.isActive = false
             bottomConstraint.constant = 0
-            scrollView.contentInset = contentInset
+            scrollView.contentInset = contentInsets
 
         } else {
-            topConstraint.constant = contentInset.top
-            bottomConstraint.constant = -contentInset.bottom
+            topConstraint.constant = contentInsets.top
+            bottomConstraint.isActive = true
+            webViewHeightConstraint.isActive = false
+            bottomConstraint.constant = -contentInsets.bottom
             scrollView.contentInset = .zero
+        }
+
+        if isContinuousScrolling {
+            onPreferredHeightChange?()
         }
     }
 
@@ -144,17 +561,48 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
         return progression
     }
 
+    override func progression(in index: ReadingOrder.Index, visibleRect: CGRect) -> ClosedRange<Double> {
+        guard
+            isContinuousScrolling,
+            spread.first.index == index
+        else {
+            return progression(in: index)
+        }
+
+        let documentHeight = measuredDocumentHeight ?? 0
+        guard documentHeight > 0 else {
+            return 0 ... 0
+        }
+
+        let contentRect = CGRect(
+            x: webView.frame.minX,
+            y: webView.frame.minY,
+            width: webView.frame.width,
+            height: documentHeight
+        )
+        let intersection = visibleRect.intersection(contentRect)
+        guard !intersection.isNull, !intersection.isEmpty else {
+            return 0 ... 0
+        }
+
+        let first = min(max((intersection.minY - contentRect.minY) / documentHeight, 0), 1)
+        let last = min(max((intersection.maxY - contentRect.minY) / documentHeight, first), 1)
+        return first ... last
+    }
+
     override func spreadDidLoad() async {
         let link = spread.first.link
         if let linkJSON = try? link.jsonString() {
             await evaluateScript("readium.link = \(linkJSON);")
         }
 
-        // TODO: Better solution for delaying scrolling to pending location
-        // This delay is used to wait for the web view pagination to settle and give the CSS and webview time to layout
-        // correctly before attempting to scroll to the target progression, otherwise we might end up at the wrong spot.
-        // 0.2 seconds seems like a good value for it to work on an iPhone 5s.
         try? await Task.sleep(seconds: 0.2)
+
+        if isContinuousScrolling {
+            await updateDocumentHeight()
+            didCompleteGoTo()
+            return
+        }
 
         let location = pendingLocation
         await go(to: location.location, animated: location.animated)
@@ -166,7 +614,7 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
     }
 
     override func go(to direction: EPUBSpreadView.Direction, options: NavigatorGoOptions) async -> Bool {
-        guard !viewModel.scroll else {
+        guard !viewModel.scroll, !isContinuousScrolling else {
             return await super.go(to: direction, options: options)
         }
 
@@ -235,6 +683,11 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
             return
         }
 
+        if isContinuousScrolling {
+            didCompleteGoTo()
+            return
+        }
+
         switch location {
         case let .locator(locator):
             await go(to: locator, animated: animated)
@@ -258,6 +711,173 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
             cont.resume()
         }
         goToContinuations.removeAll()
+    }
+
+    private var estimatedDocumentHeight: CGFloat {
+        max(bounds.height - contentInsets.top - contentInsets.bottom, 1)
+    }
+
+    override func preferredHeight(for width: CGFloat) -> CGFloat {
+        guard isContinuousScrolling else {
+            return super.preferredHeight(for: width)
+        }
+        let documentHeight = measuredDocumentHeight ?? estimatedDocumentHeight
+        return max(contentInsets.top + documentHeight + contentInsets.bottom, 1)
+    }
+
+    override func targetYOffset(for location: PageLocation, viewportHeight: CGFloat) async -> CGFloat? {
+        guard isContinuousScrolling else {
+            return await super.targetYOffset(for: location, viewportHeight: viewportHeight)
+        }
+
+        let pageHeight = preferredHeight(for: bounds.width)
+        let maxOffset = max(pageHeight - viewportHeight, 0)
+
+        switch location {
+        case .start:
+            return 0
+        case .end:
+            return maxOffset
+        case let .locator(locator):
+            for attempt in 0 ..< 6 {
+                if let offset = await locatorYOffset(for: locator) {
+                    return min(max(contentInsets.top + offset, 0), maxOffset)
+                }
+
+                guard attempt < 5 else {
+                    break
+                }
+
+                await updateDocumentHeight()
+                try? await Task.sleep(seconds: 0.05)
+            }
+
+            if let progression = locator.locations.progression {
+                let documentHeight = measuredDocumentHeight ?? estimatedDocumentHeight
+                return min(max(contentInsets.top + documentHeight * progression, 0), maxOffset)
+            }
+
+            return 0
+        }
+    }
+
+    override func firstVisibleElementLocator(in visibleRect: CGRect) async -> Locator? {
+        guard isContinuousScrolling else {
+            return await super.firstVisibleElementLocator(in: visibleRect)
+        }
+
+        let webViewVisibleRect = convert(visibleRect, to: webView)
+        guard let rectJSON = jsonString(for: webViewVisibleRect) else {
+            return nil
+        }
+
+        let result = await evaluateScript("readiumContinuous.findFirstVisibleLocatorInRect(\(rectJSON));")
+        do {
+            let link = spread.first.link
+            guard
+                let json = try JSONValue(result.get()),
+                let locator = try Locator(json: json)
+            else {
+                return nil
+            }
+            return locator.copy(href: link.url(), mediaType: link.mediaType ?? .xhtml)
+
+        } catch {
+            log(.error, error)
+            return nil
+        }
+    }
+
+    private func scheduleDocumentHeightUpdate(delay: TimeInterval = 0.05) {
+        guard isContinuousScrolling else {
+            return
+        }
+
+        documentHeightTask?.cancel()
+        documentHeightTask = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            if delay > 0 {
+                try? await Task.sleep(seconds: delay)
+            }
+            await self.updateDocumentHeight()
+        }
+    }
+
+    private func updateDocumentHeight() async {
+        guard isContinuousScrolling else {
+            return
+        }
+
+        let result = await evaluateScript("readiumContinuous.contentHeight();")
+        guard
+            case let .success(value) = result,
+            let number = value as? NSNumber
+        else {
+            return
+        }
+
+        let height = max(CGFloat(truncating: number), 1)
+        guard abs((measuredDocumentHeight ?? 0) - height) > 0.5 else {
+            return
+        }
+
+        measuredDocumentHeight = height
+        webViewHeightConstraint.constant = height
+        setNeedsLayout()
+        onPreferredHeightChange?()
+    }
+
+    private func locatorYOffset(for locator: Locator) async -> CGFloat? {
+        guard let locatorJSON = try? locator.jsonString() else {
+            return nil
+        }
+
+        let result = await evaluateScript("readiumContinuous.locatorYOffset(\(locatorJSON));")
+        guard
+            case let .success(value) = result,
+            let number = value as? NSNumber
+        else {
+            return nil
+        }
+
+        let offset = CGFloat(truncating: number)
+        return offset.isFinite ? offset : nil
+    }
+
+    private func locatorRect(for locator: Locator) async -> CGRect? {
+        guard let locatorJSON = try? locator.jsonString() else {
+            return nil
+        }
+
+        let result = await evaluateScript("readiumContinuous.locatorRect(\(locatorJSON));")
+        guard case let .success(value) = result else {
+            return nil
+        }
+
+        return CGRect(json: value)
+    }
+
+    private func jsonString(for rect: CGRect) -> String? {
+        let json: [String: CGFloat] = [
+            "top": rect.minY,
+            "left": rect.minX,
+            "bottom": rect.maxY,
+            "right": rect.maxX,
+            "width": rect.width,
+            "height": rect.height,
+            "x": rect.minX,
+            "y": rect.minY,
+        ]
+
+        guard
+            let data = try? JSONSerialization.data(withJSONObject: json),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            return nil
+        }
+        return string
     }
 
     private var goToContinuations: [CheckedContinuation<Void, Never>] = []
@@ -415,6 +1035,9 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
     override func registerJSMessages() {
         super.registerJSMessages()
         registerJSMessage(named: "progressionChanged") { [weak self] in self?.progressionDidChange($0) }
+        registerJSMessage(named: "continuousContentLayoutChanged") { [weak self] _ in
+            self?.scheduleDocumentHeightUpdate(delay: 0)
+        }
     }
 
     // MARK: - WKNavigationDelegate

--- a/Sources/Navigator/EPUB/EPUBSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBSpreadView.swift
@@ -42,10 +42,17 @@ protocol EPUBSpreadViewDelegate: AnyObject {
     func spreadViewDidTerminate()
 }
 
-class EPUBSpreadView: UIView, Loggable, PageView {
+class EPUBSpreadView: UIView, Loggable, ContinuousPageView {
+    enum ScrollMode {
+        case paginated
+        case perSpread
+        case continuous
+    }
+
     weak var delegate: EPUBSpreadViewDelegate?
     let viewModel: EPUBNavigatorViewModel
     let spread: EPUBSpread
+    let scrollMode: ScrollMode
     private(set) var focusedResource: ReadingOrder.Index?
 
     let webView: WebView
@@ -54,6 +61,8 @@ class EPUBSpreadView: UIView, Loggable, PageView {
 
     /// If YES, the content will be faded in once loaded.
     let animatedLoad: Bool
+
+    var onPreferredHeightChange: (() -> Void)?
 
     weak var activityIndicatorView: UIActivityIndicatorView?
     private var activityIndicatorStopWorkItem: DispatchWorkItem?
@@ -64,11 +73,13 @@ class EPUBSpreadView: UIView, Loggable, PageView {
     required init(
         viewModel: EPUBNavigatorViewModel,
         spread: EPUBSpread,
+        scrollMode: ScrollMode,
         scripts: [WKUserScript],
         animatedLoad: Bool
     ) {
         self.viewModel = viewModel
         self.spread = spread
+        self.scrollMode = scrollMode
         self.animatedLoad = animatedLoad
 
         let config = WKWebViewConfiguration()
@@ -378,8 +389,20 @@ class EPUBSpreadView: UIView, Loggable, PageView {
         0 ... 1
     }
 
+    func progression(in index: ReadingOrder.Index, visibleRect: CGRect) -> ClosedRange<Double> {
+        progression(in: index)
+    }
+
     func go(to location: PageLocation, animated: Bool) async {
         fatalError("go(to:) must be implemented in subclasses")
+    }
+
+    func preferredHeight(for width: CGFloat) -> CGFloat {
+        max(bounds.height, 1)
+    }
+
+    func targetYOffset(for location: PageLocation, viewportHeight: CGFloat) async -> CGFloat? {
+        nil
     }
 
     enum Direction: CustomStringConvertible {
@@ -416,6 +439,10 @@ class EPUBSpreadView: UIView, Loggable, PageView {
             log(.error, error)
             return nil
         }
+    }
+
+    func firstVisibleElementLocator(in visibleRect: CGRect) async -> Locator? {
+        await findFirstVisibleElementLocator()
     }
 
     // MARK: - JS Messages

--- a/Sources/Navigator/Toolkit/PaginationView.swift
+++ b/Sources/Navigator/Toolkit/PaginationView.swift
@@ -29,23 +29,80 @@ enum PageLocation: Equatable {
     }
 }
 
-protocol PageView {
+protocol PageView: AnyObject {
     /// Moves the page to the given internal location.
     func go(to location: PageLocation, animated: Bool) async
 }
 
-protocol PaginationViewDelegate: AnyObject {
-    /// Creates the page view for the page at given index.
-    func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) -> (UIView & PageView)?
+protocol ContinuousPageView: PageView {
+    var onPreferredHeightChange: (() -> Void)? { get set }
 
-    /// Called when the page views were updated.
-    func paginationViewDidUpdateViews(_ paginationView: PaginationView)
+    /// Returns the height the page needs to render all of its content for the
+    /// given width.
+    func preferredHeight(for width: CGFloat) -> CGFloat
 
-    /// Returns the number of positions (as in `Publication.positionList`) in the page view at given index.
-    func paginationView(_ paginationView: PaginationView, positionCountAtIndex index: Int) -> Int
+    /// Returns the vertical offset to the given internal location when the
+    /// page is embedded in a continuous vertical scroll container.
+    func targetYOffset(for location: PageLocation, viewportHeight: CGFloat) async -> CGFloat?
 }
 
-final class PaginationView: UIView, Loggable {
+extension ContinuousPageView {
+    func targetYOffset(for location: PageLocation, viewportHeight: CGFloat) async -> CGFloat? {
+        nil
+    }
+}
+
+protocol PaginationViewDelegate: AnyObject {
+    /// Creates the page view for the page at given index.
+    func paginationView(_ paginationView: any PaginationContainerView, pageViewAtIndex index: Int) -> (UIView & PageView)?
+
+    /// Called when the page views were updated.
+    func paginationViewDidUpdateViews(_ paginationView: any PaginationContainerView)
+
+    /// Returns the number of positions (as in `Publication.positionList`) in the page view at given index.
+    func paginationView(_ paginationView: any PaginationContainerView, positionCountAtIndex index: Int) -> Int
+}
+
+protocol PaginationContainerView: AnyObject {
+    var delegate: PaginationViewDelegate? { get set }
+    var pageCount: Int { get }
+    var currentIndex: Int { get }
+    var loadedViews: [Int: UIView & PageView] { get }
+    var isScrollEnabled: Bool { get set }
+
+    /// Visible content rect expressed in the container's coordinate space.
+    var viewportRect: CGRect { get }
+
+    var currentView: (UIView & PageView)? { get }
+
+    func reloadAtIndex(
+        _ index: Int,
+        location: PageLocation,
+        pageCount: Int,
+        readingProgression: ReadingProgression,
+        navigateToLocationAfterReload: Bool
+    )
+    func goToIndex(_ index: Int, location: PageLocation, options: NavigatorGoOptions) async -> Bool
+    func go(to direction: EPUBSpreadView.Direction, options: NavigatorGoOptions, readingProgression: ReadingProgression) async -> Bool
+}
+
+extension PaginationContainerView {
+    func reloadAtIndex(_ index: Int, location: PageLocation, pageCount: Int, readingProgression: ReadingProgression) {
+        reloadAtIndex(
+            index,
+            location: location,
+            pageCount: pageCount,
+            readingProgression: readingProgression,
+            navigateToLocationAfterReload: true
+        )
+    }
+
+    func go(to direction: EPUBSpreadView.Direction, options: NavigatorGoOptions, readingProgression: ReadingProgression) async -> Bool {
+        false
+    }
+}
+
+final class PaginationView: UIView, Loggable, PaginationContainerView {
     weak var delegate: PaginationViewDelegate?
 
     /// Total number of page views to be paginated.
@@ -76,6 +133,10 @@ final class PaginationView: UIView, Loggable {
     /// Return the currently presented page view from the Views array.
     var currentView: (UIView & PageView)? {
         loadedViews[currentIndex]
+    }
+
+    var viewportRect: CGRect {
+        CGRect(origin: scrollView.contentOffset, size: scrollView.bounds.size)
     }
 
     /// Loaded page views in reading order.
@@ -193,7 +254,13 @@ final class PaginationView: UIView, Loggable {
     ///   - location: Location to be displayed in the page.
     ///   - pageCount: Total number of pages in the pagination view.
     ///   - readingProgression: Direction of reading progression.
-    func reloadAtIndex(_ index: Int, location: PageLocation, pageCount: Int, readingProgression: ReadingProgression) {
+    func reloadAtIndex(
+        _ index: Int,
+        location: PageLocation,
+        pageCount: Int,
+        readingProgression: ReadingProgression,
+        navigateToLocationAfterReload _: Bool
+    ) {
         precondition(pageCount >= 1)
         precondition(0 ..< pageCount ~= index)
 

--- a/TestApp/Sources/Reader/Common/ReaderViewController.swift
+++ b/TestApp/Sources/Reader/Common/ReaderViewController.swift
@@ -24,6 +24,7 @@ class ReaderViewController<N: Navigator>: UIViewController,
     private let bookmarks: BookmarkRepository
 
     var subscriptions = Set<AnyCancellable>()
+    private var outlineSubscription: AnyCancellable?
 
     private(set) var searchViewModel: SearchViewModel?
     private var searchViewController: UIHostingController<SearchView>?
@@ -73,6 +74,13 @@ class ReaderViewController<N: Navigator>: UIViewController,
         if #available(iOS 18.0, *) {
             tabBarController?.isTabBarHidden = false
         }
+
+        Task { [weak self] in
+            guard let self else {
+                return
+            }
+            await self.persistProgress(using: await self.locatorForProgressPersistence())
+        }
     }
 
     // MARK: - Navigation bar
@@ -102,12 +110,8 @@ class ReaderViewController<N: Navigator>: UIViewController,
     // MARK: - NavigatorDelegate
 
     func navigator(_ navigator: Navigator, locationDidChange locator: Locator) {
-        Task {
-            do {
-                try await books.saveProgress(for: bookId, locator: locator)
-            } catch {
-                moduleDelegate?.presentError(UserError(error), from: self)
-            }
+        Task { [weak self] in
+            await self?.persistProgress(using: locator)
         }
     }
 
@@ -127,6 +131,42 @@ class ReaderViewController<N: Navigator>: UIViewController,
         log(.error, "Failed to load resource at \(href): \(error)")
     }
 
+    func locatorForProgressPersistence() async -> Locator? {
+        let coarseLocator = navigator.currentLocation
+
+        guard var locator = await (navigator as? VisualNavigator)?.firstVisibleElementLocator() ?? coarseLocator else {
+            return nil
+        }
+
+        if
+            let coarseLocator,
+            coarseLocator.href.isEquivalentTo(locator.href)
+        {
+            locator = locator.copy(
+                title: locator.title ?? coarseLocator.title,
+                locations: { locations in
+                    locations.progression = locations.progression ?? coarseLocator.locations.progression
+                    locations.totalProgression = locations.totalProgression ?? coarseLocator.locations.totalProgression
+                    locations.position = locations.position ?? coarseLocator.locations.position
+                }
+            )
+        }
+
+        return locator
+    }
+
+    func persistProgress(using locator: Locator?) async {
+        guard let locator else {
+            return
+        }
+
+        do {
+            try await books.saveProgress(for: bookId, locator: locator)
+        } catch {
+            moduleDelegate?.presentError(UserError(error), from: self)
+        }
+    }
+
     // MARK: - Locations
 
     var currentBookmark: Bookmark? {
@@ -144,14 +184,21 @@ class ReaderViewController<N: Navigator>: UIViewController,
             return
         }
 
-        locatorPublisher
+        outlineSubscription = locatorPublisher
             .sink(receiveValue: { [weak self] locator in
                 Task {
-                    await self?.navigator.go(to: locator, options: NavigatorGoOptions(animated: false))
-                    self?.dismiss(animated: true)
+                    guard let self else {
+                        return
+                    }
+
+                    let didNavigate = await self.navigator.go(to: locator, options: NavigatorGoOptions(animated: false))
+                    if didNavigate {
+                        self.dismiss(animated: true)
+                    } else {
+                        self.log(.error, "Failed to navigate to outline locator \(locator)")
+                    }
                 }
             })
-            .store(in: &subscriptions)
     }
 
     // MARK: - User Preferences

--- a/TestApp/Sources/Reader/EPUB/EPUBViewController.swift
+++ b/TestApp/Sources/Reader/EPUB/EPUBViewController.swift
@@ -151,6 +151,32 @@ class EPUBViewController: VisualReaderViewController<EPUBNavigatorViewController
         let match = noterefTitleRegex.firstMatch(in: title, range: range)
         return match != nil
     }
+
+    override func locatorForProgressPersistence() async -> Locator? {
+        let currentLocator = navigator.currentLocation
+
+        guard let visibleLocator = await navigator.firstVisibleElementLocator() else {
+            return currentLocator
+        }
+
+        guard let currentLocator else {
+            return visibleLocator
+        }
+
+        return currentLocator.copy(
+            href: visibleLocator.href,
+            mediaType: visibleLocator.mediaType,
+            locations: { locations in
+                locations.fragments = visibleLocator.locations.fragments
+                for (key, value) in visibleLocator.locations.otherLocations {
+                    locations.otherLocations[key] = value
+                }
+            },
+            text: { text in
+                text = visibleLocator.text
+            }
+        )
+    }
 }
 
 extension EPUBViewController: EPUBNavigatorDelegate {

--- a/Tests/NavigatorTests/Toolkit/ContinuousPaginationViewTests.swift
+++ b/Tests/NavigatorTests/Toolkit/ContinuousPaginationViewTests.swift
@@ -1,0 +1,213 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumNavigator
+import ReadiumShared
+import Testing
+import UIKit
+
+@Suite struct ContinuousPaginationViewTests {
+    @MainActor
+    @Test("goToIndex end aligns the trailing edge of a tall page")
+    func goToIndexEnd() async {
+        let delegate = TestPaginationDelegate(pageHeights: [600, 500])
+        let paginationView = makePaginationView(
+            delegate: delegate,
+            frame: CGRect(x: 0, y: 0, width: 320, height: 400)
+        )
+
+        paginationView.reloadAtIndex(0, location: .end, pageCount: 2, readingProgression: .ltr)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(abs(paginationView.viewportRect.minY - 200) < 0.5)
+    }
+
+    @MainActor
+    @Test("forward navigation scrolls by one viewport and updates the first visible page")
+    func goForward() async {
+        let delegate = TestPaginationDelegate(pageHeights: [100, 320, 320])
+        let paginationView = makePaginationView(
+            delegate: delegate,
+            frame: CGRect(x: 0, y: 0, width: 320, height: 150)
+        )
+
+        paginationView.reloadAtIndex(0, location: .start, pageCount: 3, readingProgression: .ltr)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let moved = await paginationView.go(
+            to: .right,
+            options: NavigatorGoOptions(animated: false),
+            readingProgression: .ltr
+        )
+
+        #expect(moved)
+        #expect(abs(paginationView.viewportRect.minY - 150) < 0.5)
+        #expect(paginationView.currentIndex == 1)
+    }
+
+    @MainActor
+    @Test("reloadAtIndex immediately anchors a far chapter before delayed page loads finish")
+    func reloadAtIndexAnchorsFarChapterImmediately() async {
+        let delegate = TestPaginationDelegate(
+            pageHeights: [100, 100, 100, 100, 100],
+            loadDelayNanoseconds: 200_000_000
+        )
+        let paginationView = makePaginationView(
+            delegate: delegate,
+            frame: CGRect(x: 0, y: 0, width: 320, height: 100)
+        )
+
+        paginationView.reloadAtIndex(4, location: .start, pageCount: 5, readingProgression: .ltr)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(abs(paginationView.viewportRect.minY - 400) < 0.5)
+    }
+
+    @MainActor
+    @Test("explicit jump cancels stale reload navigation")
+    func explicitJumpCancelsStaleReloadNavigation() async {
+        let delegate = TestPaginationDelegate(
+            pageHeights: [100, 100, 100, 100],
+            loadDelayNanoseconds: 200_000_000
+        )
+        let paginationView = makePaginationView(
+            delegate: delegate,
+            frame: CGRect(x: 0, y: 0, width: 320, height: 100)
+        )
+
+        paginationView.reloadAtIndex(3, location: .start, pageCount: 4, readingProgression: .ltr)
+        let didJump = await paginationView.goToIndex(1, location: .start, options: .none)
+        try? await Task.sleep(nanoseconds: 250_000_000)
+
+        #expect(didJump)
+        #expect(abs(paginationView.viewportRect.minY - 100) < 0.5)
+        #expect(paginationView.currentIndex == 1)
+    }
+
+    @MainActor
+    @Test("locator jumps wait briefly for delayed target offsets")
+    func locatorJumpWaitsForDelayedOffset() async {
+        let delegate = TestPaginationDelegate(
+            pageHeights: [400],
+            locatorTargetOffset: 180,
+            locatorFailuresBeforeSuccess: 2
+        )
+        let paginationView = makePaginationView(
+            delegate: delegate,
+            frame: CGRect(x: 0, y: 0, width: 320, height: 100)
+        )
+
+        paginationView.reloadAtIndex(0, location: .start, pageCount: 1, readingProgression: .ltr)
+        let locator = Locator(href: "chapter.xhtml", mediaType: .xhtml)
+        let didJump = await paginationView.goToIndex(0, location: .locator(locator), options: .none)
+
+        #expect(didJump)
+        #expect(abs(paginationView.viewportRect.minY - 180) < 0.5)
+    }
+}
+
+@MainActor
+private func makePaginationView(delegate: TestPaginationDelegate, frame: CGRect) -> ContinuousPaginationView {
+    let paginationView = ContinuousPaginationView(
+        frame: frame,
+        preloadPreviousPositionCount: 1,
+        preloadNextPositionCount: 1,
+        isScrollEnabled: true
+    )
+    paginationView.delegate = delegate
+    paginationView.frame = frame
+    paginationView.layoutIfNeeded()
+    return paginationView
+}
+
+private final class TestPaginationDelegate: PaginationViewDelegate {
+    let pageHeights: [CGFloat]
+    let loadDelayNanoseconds: UInt64
+    let locatorTargetOffset: CGFloat?
+    let locatorFailuresBeforeSuccess: Int
+
+    init(
+        pageHeights: [CGFloat],
+        loadDelayNanoseconds: UInt64 = 0,
+        locatorTargetOffset: CGFloat? = nil,
+        locatorFailuresBeforeSuccess: Int = 0
+    ) {
+        self.pageHeights = pageHeights
+        self.loadDelayNanoseconds = loadDelayNanoseconds
+        self.locatorTargetOffset = locatorTargetOffset
+        self.locatorFailuresBeforeSuccess = locatorFailuresBeforeSuccess
+    }
+
+    func paginationView(_ paginationView: any PaginationContainerView, pageViewAtIndex index: Int) -> (UIView & PageView)? {
+        TestContinuousPageView(
+            height: pageHeights[index],
+            loadDelayNanoseconds: loadDelayNanoseconds,
+            locatorTargetOffset: locatorTargetOffset,
+            locatorFailuresBeforeSuccess: locatorFailuresBeforeSuccess
+        )
+    }
+
+    func paginationViewDidUpdateViews(_ paginationView: any PaginationContainerView) {}
+
+    func paginationView(_ paginationView: any PaginationContainerView, positionCountAtIndex index: Int) -> Int {
+        1
+    }
+}
+
+private final class TestContinuousPageView: UIView, ContinuousPageView {
+    var onPreferredHeightChange: (() -> Void)?
+    let height: CGFloat
+    let loadDelayNanoseconds: UInt64
+    let locatorTargetOffset: CGFloat?
+    var remainingLocatorFailures: Int
+
+    init(
+        height: CGFloat,
+        loadDelayNanoseconds: UInt64 = 0,
+        locatorTargetOffset: CGFloat? = nil,
+        locatorFailuresBeforeSuccess: Int = 0
+    ) {
+        self.height = height
+        self.loadDelayNanoseconds = loadDelayNanoseconds
+        self.locatorTargetOffset = locatorTargetOffset
+        remainingLocatorFailures = locatorFailuresBeforeSuccess
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func go(to location: PageLocation, animated: Bool) async {
+        guard loadDelayNanoseconds > 0 else {
+            return
+        }
+        try? await Task.sleep(nanoseconds: loadDelayNanoseconds)
+    }
+
+    func preferredHeight(for width: CGFloat) -> CGFloat {
+        height
+    }
+
+    func targetYOffset(for location: PageLocation, viewportHeight: CGFloat) async -> CGFloat? {
+        switch location {
+        case .start:
+            return 0
+        case .end:
+            return max(height - viewportHeight, 0)
+        case let .locator(locator):
+            if let locatorTargetOffset {
+                if remainingLocatorFailures > 0 {
+                    remainingLocatorFailures -= 1
+                    return nil
+                }
+                return locatorTargetOffset
+            }
+            let progression = locator.locations.progression ?? 0
+            return height * progression
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add true continuous vertical scrolling for reflowable EPUBs when `EPUBPreferences.scroll` is enabled.

Instead of keeping each spread in the horizontal pagination container, scroll mode now stacks spreads vertically in a dedicated continuous container, so readers can move through chapters without horizontal page turns.

  ## Scope

applies only to reflowable EPUBs in scroll mode.

keeps existing paginated behavior unchanged when scroll mode is disabled.

does not affect fixed-layout EPUBs.

  ## Notes

This introduces `ContinuousPaginationView` and updates reflowable spread navigation, height measurement, and location/viewport calculation to work in a multi-spread continuous flow.