### PR TITLE
Fix decoration positions with paragraph indent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ All notable changes to this project will be documented in this file. Take a look
     * Fixed screen glitches when turning with animations disabled.
     * A slide animation is now used when navigating between adjacent resources.
 * The EPUB navigator now reports a continuous `locator.locations.totalProgression` value, interpolated from the actual scroll position within the resource's global progression range. Previously, the value was quantized to the nearest position in the position list.
-* Fixed a race condition in `EPUBNavigatorViewController` where rapidly calling `apply(decorations:in:)` for the same group could cause multiple highlights to appear simultaneously.
+* Fixed a race condition in `EPUBNavigatorViewController` where rapidly calling `apply(decorations:in:)` for the same group could cause multiple decorations to appear simultaneously.
+* [#721](https://github.com/readium/swift-toolkit/issues/721) Fix position of EPUB decorations when using the paragraph indent preference.
 
 #### Streamer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ All notable changes to this project will be documented in this file. Take a look
     * A slide animation is now used when navigating between adjacent resources.
 * The EPUB navigator now reports a continuous `locator.locations.totalProgression` value, interpolated from the actual scroll position within the resource's global progression range. Previously, the value was quantized to the nearest position in the position list.
 * Fixed a race condition in `EPUBNavigatorViewController` where rapidly calling `apply(decorations:in:)` for the same group could cause multiple decorations to appear simultaneously.
-* [#721](https://github.com/readium/swift-toolkit/issues/721) Fix position of EPUB decorations when using the paragraph indent preference.
+* [#721](https://github.com/readium/swift-toolkit/issues/721) Fixed position of EPUB decorations when using the paragraph indent preference.
 
 #### Streamer
 

--- a/Sources/Navigator/EPUB/Assets/Static/readium-css/ReadiumCSS-after.css
+++ b/Sources/Navigator/EPUB/Assets/Static/readium-css/ReadiumCSS-after.css
@@ -761,8 +761,7 @@ body {
 
 /* If there are inline-block elements in paragraphs, text-indent will inherit so we must reset it */
 
-:root[style*="readium-advanced-on"][style*="--USER__paraIndent"] p *,
-:root[style*="readium-advanced-on"][style*="--USER__paraIndent"] p:first-letter {
+:root[style*="readium-advanced-on"][style*="--USER__paraIndent"] p * {
   text-indent: 0 !important;
 }
 

--- a/Sources/Navigator/EPUB/Assets/Static/readium-css/rtl/ReadiumCSS-after.css
+++ b/Sources/Navigator/EPUB/Assets/Static/readium-css/rtl/ReadiumCSS-after.css
@@ -640,8 +640,7 @@ body {
 
 /* If there are inline-block elements in paragraphs, text-indent will inherit so we must reset it */
 
-:root[style*="readium-advanced-on"][style*="--USER__paraIndent"] p *,
-:root[style*="readium-advanced-on"][style*="--USER__paraIndent"] p:first-letter {
+:root[style*="readium-advanced-on"][style*="--USER__paraIndent"] p * {
   text-indent: 0 !important;
 }
 


### PR DESCRIPTION
### Fixed

#### Navigator

* [#721](https://github.com/readium/swift-toolkit/issues/721) Fix position of EPUB decorations when using the paragraph indent preference.