### PR TITLE
Add `ViewportObservingNavigator` protocol with PDF viewport support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All notable changes to this project will be documented in this file. Take a look
 * Added support for SVG covers in `ResourceCoverService`. SVG images can now be used as publication covers and are rendered to bitmaps (contributed by [@grighakobian](https://github.com/readium/swift-toolkit/pull/751)).
 * `Publication` has a new experimental `coverData(accepting:)` API that returns the raw bytes and media type of the cover, useful for storing the original cover without re-encoding.
 
+#### Navigator
+
+* New `ViewportObservingNavigator` protocol, implemented by both the EPUB and PDF navigators, which exposes information about the current visible portion of the publication (e.g. progression and position ranges).
+    * The EPUB navigator's `Viewport` type is now a deprecated typealias for `NavigatorViewport`.
+
 ### Removed
 
 * Carthage is no longer a supported distribution method. Please migrate to Swift Package Manager or CocoaPods.

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -11,26 +11,23 @@ import SwiftSoup
 import UIKit
 import WebKit
 
-@MainActor public protocol EPUBNavigatorDelegate: VisualNavigatorDelegate, SelectableNavigatorDelegate {
-    /// Called when the viewport is updated.
-    func navigator(_ navigator: EPUBNavigatorViewController, viewportDidChange viewport: EPUBNavigatorViewController.Viewport?)
-
+@MainActor public protocol EPUBNavigatorDelegate: VisualNavigatorDelegate, SelectableNavigatorDelegate,
+    ViewportObservingNavigatorDelegate
+{
     // MARK: - WebView Customization
 
     func navigator(_ navigator: EPUBNavigatorViewController, setupUserScripts userContentController: WKUserContentController)
 }
 
 public extension EPUBNavigatorDelegate {
-    func navigator(_ navigator: EPUBNavigatorViewController, viewportDidChange viewport: EPUBNavigatorViewController.Viewport?) {}
-
     func navigator(_ navigator: EPUBNavigatorViewController, setupUserScripts userContentController: WKUserContentController) {}
 }
 
 public typealias EPUBContentInsets = (top: CGFloat, bottom: CGFloat)
 
 open class EPUBNavigatorViewController: InputObservableViewController,
-    VisualNavigator, SelectableNavigator, DecorableNavigator,
-    Configurable, Loggable
+    VisualNavigator, ViewportObservingNavigator, SelectableNavigator,
+    DecorableNavigator, Configurable, Loggable
 {
     public enum EPUBError: Error {
         /// The provided publication is restricted. Check that any DRM was
@@ -139,7 +136,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
     public weak var delegate: EPUBNavigatorDelegate?
 
     /// Information about the visible portion of the publication, when rendered.
-    public private(set) var viewport: Viewport? {
+    public private(set) var viewport: NavigatorViewport? {
         didSet {
             if oldValue != viewport {
                 delegate?.navigator(self, viewportDidChange: viewport)
@@ -147,18 +144,8 @@ open class EPUBNavigatorViewController: InputObservableViewController,
         }
     }
 
-    /// Information about the visible portion of the publication.
-    public struct Viewport: Equatable {
-        /// Visible reading order resources.
-        public var readingOrder: [AnyURL]
-
-        /// Range of visible scroll progressions for each visible reading order
-        /// resource.
-        public var progressions: [AnyURL: ClosedRange<Double>]
-
-        /// Range of visible positions.
-        public var positions: ClosedRange<Int>?
-    }
+    @available(*, deprecated, renamed: "NavigatorViewport")
+    public typealias Viewport = NavigatorViewport
 
     /// Navigation state.
     private enum State: Equatable {
@@ -679,7 +666,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
         )
     }
 
-    private func computeCurrentLocationAndViewport() async -> (Locator?, Viewport?) {
+    private func computeCurrentLocationAndViewport() async -> (Locator?, NavigatorViewport?) {
         if case .initializing = state {
             assertionFailure("Cannot update current location when initializing the navigator")
             return (nil, nil)

--- a/Sources/Navigator/EPUB/EPUBViewportAndLocationCalculator.swift
+++ b/Sources/Navigator/EPUB/EPUBViewportAndLocationCalculator.swift
@@ -34,25 +34,23 @@ enum EPUBViewportAndLocationCalculator {
         positionsByReadingOrder: [[Locator]],
         tableOfContentsTitleByHref: [AnyURL: String],
         fallbackLocator: (Link) async -> Locator?
-    ) async -> (locator: Locator?, viewport: EPUBNavigatorViewController.Viewport) {
-        let visibleReadingOrder: [(index: Int, href: AnyURL)] = readingOrderIndices
-            .map { ($0, readingOrder[$0].url()) }
-
-        var viewport = EPUBNavigatorViewController.Viewport(
-            readingOrder: visibleReadingOrder.map(\.href),
-            progressions: visibleReadingOrder.reduce(into: [:]) { acc, i in
-                acc[i.href] = progression(i.index)
-            },
-            positions: nil
-        )
-
+    ) async -> (locator: Locator?, viewport: NavigatorViewport) {
         let firstIndex = readingOrderIndices.lowerBound
         let lastIndex = readingOrderIndices.upperBound
         let firstProgressionInFirstResource = min(max(progression(firstIndex).lowerBound, 0.0), 1.0)
         let lastProgressionInLastResource = min(max(progression(lastIndex).upperBound, 0.0), 1.0)
 
+        let visibleResources: [NavigatorViewport.Resource] = readingOrderIndices
+            .map { index in
+                NavigatorViewport.Resource(
+                    href: readingOrder[index].url(),
+                    progression: progression(index)
+                )
+            }
+
         let link = readingOrder[firstIndex]
         let locator: Locator?
+        var positions: ClosedRange<Int>? = nil
 
         if
             // The positions are not always available, for example a Readium
@@ -81,18 +79,17 @@ enum EPUBViewportAndLocationCalculator {
                     Int(ceil(lastProgressionInLastResource * Double(positionsOfLastResource.count - 1))) - 1
                 )
 
-            // Compute a continuous totalProgression by linearly interpolating
-            // the resource-level progression within the resource's global
-            // range. The resource's range spans from the totalProgression of
-            // its first position to the totalProgression of the next resource's
-            // first position (or 1.0 for the last resource).
-            let resourceTotalProgressionStart = positionsOfFirstResource.first?.locations.totalProgression ?? 0.0
-            let resourceTotalProgressionEnd = positionsByReadingOrder.getOrNil(firstIndex + 1)?
-                .first?.locations.totalProgression ?? 1.0
-            let continuousTotalProgression =
-                resourceTotalProgressionStart
-                    + firstProgressionInFirstResource
-                    * (resourceTotalProgressionEnd - resourceTotalProgressionStart)
+            // Compute the total progression range by linearly interpolating
+            // each resource-level progression within the resource's global
+            // range. The lower bound becomes the locator's totalProgression.
+            let firstHref = readingOrder[firstIndex].url()
+            let lastHref = readingOrder[lastIndex].url()
+            let totalProgressionRange = ViewportProgressionCalculator.totalProgressionRange(
+                firstResource: (href: firstHref, progression: progression(firstIndex)),
+                lastResource: (href: lastHref, progression: progression(lastIndex)),
+                readingOrder: readingOrder,
+                positionsByReadingOrder: positionsByReadingOrder
+            ) ?? (firstProgressionInFirstResource ... firstProgressionInFirstResource)
 
             // Build the locator from the nearest position, then override
             // progression fields with the actual continuous scroll values.
@@ -100,7 +97,7 @@ enum EPUBViewportAndLocationCalculator {
                 title: tableOfContentsTitleByHref[link.url()],
                 locations: {
                     $0.progression = firstProgressionInFirstResource
-                    $0.totalProgression = continuousTotalProgression
+                    $0.totalProgression = totalProgressionRange.lowerBound
                 }
             )
 
@@ -108,15 +105,30 @@ enum EPUBViewportAndLocationCalculator {
                 let firstPosition = locator?.locations.position,
                 let lastPosition = positionsOfLastResource[lastPositionIndex].locations.position
             {
-                viewport.positions = firstPosition ... lastPosition
+                positions = firstPosition ... lastPosition
             }
+
+            let viewport = NavigatorViewport(
+                resources: visibleResources,
+                progression: totalProgressionRange,
+                positions: positions
+            )
+            return (locator, viewport)
 
         } else {
             locator = await fallbackLocator(link)?.copy(
                 locations: { $0.progression = firstProgressionInFirstResource }
             )
-        }
 
-        return (locator, viewport)
+            let fallbackProgression = locator?.locations.totalProgression
+                .map { $0 ... $0 } ?? 0.0 ... 0.0
+
+            let viewport = NavigatorViewport(
+                resources: visibleResources,
+                progression: fallbackProgression,
+                positions: nil
+            )
+            return (locator, viewport)
+        }
     }
 }

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -9,7 +9,9 @@ import PDFKit
 import ReadiumShared
 import UIKit
 
-public protocol PDFNavigatorDelegate: VisualNavigatorDelegate, SelectableNavigatorDelegate {
+public protocol PDFNavigatorDelegate: VisualNavigatorDelegate,
+    SelectableNavigatorDelegate, ViewportObservingNavigatorDelegate
+{
     /// Called after the `PDFDocumentView` is created.
     ///
     /// Override to customize its behavior.
@@ -23,7 +25,8 @@ public extension PDFNavigatorDelegate {
 /// A view controller used to render a PDF `Publication`.
 open class PDFNavigatorViewController:
     InputObservableViewController,
-    VisualNavigator, SelectableNavigator, Configurable, Loggable
+    VisualNavigator, ViewportObservingNavigator, SelectableNavigator,
+    Configurable, Loggable
 {
     public struct Configuration {
         /// Initial set of setting preferences.
@@ -239,6 +242,7 @@ open class PDFNavigatorViewController:
         }
 
         currentResourceIndex = nil
+        viewport = nil
         let pdfView = PDFDocumentView(
             frame: view.bounds,
             editingActions: editingActions,
@@ -396,6 +400,7 @@ open class PDFNavigatorViewController:
             return
         }
         delegate?.navigator(self, locationDidChange: locator)
+        updateViewport()
     }
 
     @objc private func visiblePagesDidChange() {
@@ -405,6 +410,7 @@ open class PDFNavigatorViewController:
         if !settings.scroll {
             updateScaleFactors(zoomToFit: true)
         }
+        updateViewport()
     }
 
     @discardableResult
@@ -580,6 +586,76 @@ open class PDFNavigatorViewController:
             initialPreferences: preferences,
             metadata: publication.metadata,
             defaults: config.defaults
+        )
+    }
+    
+    // MARK: - ViewportObservingNavigator
+
+    public private(set) var viewport: NavigatorViewport? {
+        didSet {
+            guard oldValue != viewport else { return }
+            delegate?.navigator(self, viewportDidChange: viewport)
+        }
+    }
+
+    private func updateViewport() {
+        guard
+            let pdfView = pdfView,
+            let currentResourceIndex = currentResourceIndex,
+            let positionsByReadingOrder = positionsByReadingOrder,
+            publication.readingOrder.indices.contains(currentResourceIndex),
+            let document = pdfView.document
+        else {
+            viewport = nil
+            return
+        }
+
+        let visiblePageNumbers = pdfView.visiblePages
+            .compactMap { $0.pageRef?.pageNumber }
+            .sorted()
+
+        guard
+            let firstPage = visiblePageNumbers.first,
+            let lastPage = visiblePageNumbers.last
+        else {
+            return
+        }
+
+        let pageCount = document.pageCount
+        // Progression within the PDF document (0–1), from the start of the
+        // first visible page to the end of the last visible page.
+        // The end of page N equals the start of page N+1, so that consecutive
+        // viewports share the same boundary value.
+        let resourceProgressionLow = pageCount > 1 ? Double(firstPage - 1) / Double(pageCount - 1) : 0.0
+        let resourceProgressionHigh = pageCount > 1 ? min(1.0, Double(lastPage) / Double(pageCount - 1)) : 1.0
+        let resourceProgression = resourceProgressionLow ... resourceProgressionHigh
+
+        let href = publication.readingOrder[currentResourceIndex].url()
+
+        let resourcePositions = positionsByReadingOrder.getOrNil(currentResourceIndex) ?? []
+        let positionRange: ClosedRange<Int>? = resourcePositions.isEmpty ? nil : {
+            let firstPos = resourcePositions.getOrNil(firstPage - 1)?.locations.position
+            let lastPos = resourcePositions.getOrNil(lastPage - 1)?.locations.position
+            guard let fp = firstPos, let lp = lastPos else { return nil }
+            return fp ... lp
+        }()
+
+        let totalProgression = ViewportProgressionCalculator.totalProgressionRange(
+            firstResource: (href: href, progression: resourceProgression),
+            lastResource: (href: href, progression: resourceProgression),
+            readingOrder: publication.readingOrder,
+            positionsByReadingOrder: positionsByReadingOrder
+        ) ?? (resourceProgressionLow ... resourceProgressionHigh)
+
+        viewport = NavigatorViewport(
+            resources: [
+                NavigatorViewport.Resource(
+                    href: href,
+                    progression: resourceProgression
+                ),
+            ],
+            progression: totalProgression,
+            positions: positionRange
         )
     }
 

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -396,11 +396,9 @@ open class PDFNavigatorViewController:
     }
 
     @objc private func pageDidChange() {
-        let (locator, newViewport) = computeLocatorAndViewport()
-        if let locator {
+        if let locator = currentPosition {
             delegate?.navigator(self, locationDidChange: locator)
         }
-        viewport = newViewport
     }
 
     @objc private func visiblePagesDidChange() {

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -396,11 +396,11 @@ open class PDFNavigatorViewController:
     }
 
     @objc private func pageDidChange() {
-        guard let locator = currentPosition else {
-            return
+        let (locator, newViewport) = computeLocatorAndViewport()
+        if let locator {
+            delegate?.navigator(self, locationDidChange: locator)
         }
-        delegate?.navigator(self, locationDidChange: locator)
-        updateViewport()
+        viewport = newViewport
     }
 
     @objc private func visiblePagesDidChange() {
@@ -410,7 +410,8 @@ open class PDFNavigatorViewController:
         if !settings.scroll {
             updateScaleFactors(zoomToFit: true)
         }
-        updateViewport()
+
+        viewport = computeLocatorAndViewport().viewport
     }
 
     @discardableResult
@@ -553,17 +554,16 @@ open class PDFNavigatorViewController:
             let pdfView = pdfView,
             let currentResourceIndex = currentResourceIndex,
             let pageNumber = pdfView.currentPage?.pageRef?.pageNumber,
-            publication.readingOrder.indices.contains(currentResourceIndex),
             let positionsByReadingOrder = positionsByReadingOrder
         else {
             return nil
         }
-        let positions = positionsByReadingOrder[currentResourceIndex]
-        guard positions.count > 0, 1 ... positions.count ~= pageNumber else {
-            return nil
-        }
-
-        return positions[pageNumber - 1]
+        return PDFViewportCalculator.computeLocator(
+            currentPageNumber: pageNumber,
+            currentResourceIndex: currentResourceIndex,
+            readingOrder: publication.readingOrder,
+            positionsByReadingOrder: positionsByReadingOrder
+        )
     }
 
     // MARK: - Configurable
@@ -588,7 +588,7 @@ open class PDFNavigatorViewController:
             defaults: config.defaults
         )
     }
-    
+
     // MARK: - ViewportObservingNavigator
 
     public private(set) var viewport: NavigatorViewport? {
@@ -598,65 +598,41 @@ open class PDFNavigatorViewController:
         }
     }
 
-    private func updateViewport() {
+    private func computeLocatorAndViewport() -> (locator: Locator?, viewport: NavigatorViewport?) {
         guard
             let pdfView = pdfView,
             let currentResourceIndex = currentResourceIndex,
             let positionsByReadingOrder = positionsByReadingOrder,
-            publication.readingOrder.indices.contains(currentResourceIndex),
-            let document = pdfView.document
+            let document = pdfView.document,
+            let currentPageNumber = pdfView.currentPage?.pageRef?.pageNumber
         else {
-            viewport = nil
-            return
+            return (nil, nil)
         }
 
-        let visiblePageNumbers = pdfView.visiblePages
-            .compactMap { $0.pageRef?.pageNumber }
-            .sorted()
+        let visiblePageNumbers = extractVisiblePageNumbers(from: pdfView) ?? (currentPageNumber ... currentPageNumber)
 
-        guard
-            let firstPage = visiblePageNumbers.first,
-            let lastPage = visiblePageNumbers.last
-        else {
-            return
-        }
-
-        let pageCount = document.pageCount
-        // Progression within the PDF document (0–1), from the start of the
-        // first visible page to the end of the last visible page.
-        // The end of page N equals the start of page N+1, so that consecutive
-        // viewports share the same boundary value.
-        let resourceProgressionLow = pageCount > 1 ? Double(firstPage - 1) / Double(pageCount - 1) : 0.0
-        let resourceProgressionHigh = pageCount > 1 ? min(1.0, Double(lastPage) / Double(pageCount - 1)) : 1.0
-        let resourceProgression = resourceProgressionLow ... resourceProgressionHigh
-
-        let href = publication.readingOrder[currentResourceIndex].url()
-
-        let resourcePositions = positionsByReadingOrder.getOrNil(currentResourceIndex) ?? []
-        let positionRange: ClosedRange<Int>? = resourcePositions.isEmpty ? nil : {
-            let firstPos = resourcePositions.getOrNil(firstPage - 1)?.locations.position
-            let lastPos = resourcePositions.getOrNil(lastPage - 1)?.locations.position
-            guard let fp = firstPos, let lp = lastPos else { return nil }
-            return fp ... lp
-        }()
-
-        let totalProgression = ViewportProgressionCalculator.totalProgressionRange(
-            firstResource: (href: href, progression: resourceProgression),
-            lastResource: (href: href, progression: resourceProgression),
+        return PDFViewportCalculator.compute(
+            currentPageNumber: currentPageNumber,
+            visiblePageNumbers: visiblePageNumbers,
+            pageCount: document.pageCount,
+            currentResourceIndex: currentResourceIndex,
             readingOrder: publication.readingOrder,
             positionsByReadingOrder: positionsByReadingOrder
-        ) ?? (resourceProgressionLow ... resourceProgressionHigh)
-
-        viewport = NavigatorViewport(
-            resources: [
-                NavigatorViewport.Resource(
-                    href: href,
-                    progression: resourceProgression
-                ),
-            ],
-            progression: totalProgression,
-            positions: positionRange
         )
+    }
+
+    private func extractVisiblePageNumbers(from pdfView: PDFDocumentView) -> ClosedRange<Int>? {
+        let sorted = pdfView.visiblePages
+            .compactMap { $0.pageRef?.pageNumber }
+            .sorted()
+        guard
+            let first = sorted.first,
+            let last = sorted.last
+        else {
+            return nil
+        }
+
+        return first ... last
     }
 
     // MARK: - SelectableNavigator

--- a/Sources/Navigator/PDF/PDFViewportCalculator.swift
+++ b/Sources/Navigator/PDF/PDFViewportCalculator.swift
@@ -1,0 +1,103 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import ReadiumShared
+
+/// Computes the current `Locator` and `NavigatorViewport` from the focused and
+/// visible pages in a PDF document.
+enum PDFViewportCalculator {
+    /// Returns the position locator for the given 1-based page number, or
+    /// `nil` when `currentResourceIndex` is out of bounds or no positions are
+    /// available for the page.
+    static func computeLocator(
+        currentPageNumber: Int,
+        currentResourceIndex: Int,
+        readingOrder: [Link],
+        positionsByReadingOrder: [[Locator]]
+    ) -> Locator? {
+        guard readingOrder.indices.contains(currentResourceIndex) else {
+            return nil
+        }
+
+        let resourcePositions = positionsByReadingOrder.getOrNil(currentResourceIndex) ?? []
+        return resourcePositions.getOrNil(currentPageNumber - 1)
+    }
+
+    /// Computes the locator and viewport for the currently visible PDF pages.
+    ///
+    /// - Parameters:
+    ///   - currentPageNumber: 1-based page number of the focused page (used
+    ///     for the locator).
+    ///   - visiblePageNumbers: 1-based page numbers of the first and last
+    ///     visible pages (inclusive). First equals last for a single visible
+    ///     page.
+    ///   - pageCount: Total number of pages in the PDF document.
+    ///   - currentResourceIndex: Index into `readingOrder` for the loaded PDF.
+    ///   - readingOrder: The publication's reading order links.
+    ///   - positionsByReadingOrder: Positions grouped by reading-order index.
+    ///     May be empty if positions are unavailable.
+    /// - Returns: `(nil, nil)` when `currentResourceIndex` is out of bounds.
+    static func compute(
+        currentPageNumber: Int,
+        visiblePageNumbers: ClosedRange<Int>,
+        pageCount: Int,
+        currentResourceIndex: Int,
+        readingOrder: [Link],
+        positionsByReadingOrder: [[Locator]]
+    ) -> (locator: Locator?, viewport: NavigatorViewport?) {
+        guard readingOrder.indices.contains(currentResourceIndex) else {
+            return (nil, nil)
+        }
+
+        let resourcePositions = positionsByReadingOrder.getOrNil(currentResourceIndex) ?? []
+
+        let locator = computeLocator(
+            currentPageNumber: currentPageNumber,
+            currentResourceIndex: currentResourceIndex,
+            readingOrder: readingOrder,
+            positionsByReadingOrder: positionsByReadingOrder
+        )
+
+        let firstPage = visiblePageNumbers.lowerBound
+        let lastPage = visiblePageNumbers.upperBound
+
+        // Intra-resource progression (0–1). The end of page N equals the start
+        // of page N+1, so that consecutive viewports share the same boundary
+        // value.
+        let resourceProgressionLow = pageCount > 1 ? Double(firstPage - 1) / Double(pageCount - 1) : 0.0
+        let resourceProgressionHigh = pageCount > 1 ? min(1.0, Double(lastPage) / Double(pageCount - 1)) : 1.0
+        let resourceProgression = resourceProgressionLow ... resourceProgressionHigh
+
+        let href = readingOrder[currentResourceIndex].url()
+
+        // Map 1-based page numbers to positions (0-based index = page - 1).
+        let positionRange: ClosedRange<Int>? = resourcePositions.isEmpty ? nil : {
+            let firstPos = resourcePositions.getOrNil(firstPage - 1)?.locations.position
+            let lastPos = resourcePositions.getOrNil(lastPage - 1)?.locations.position
+            guard let fp = firstPos, let lp = lastPos else { return nil }
+            return fp ... lp
+        }()
+
+        let totalProgression = ViewportProgressionCalculator.totalProgressionRange(
+            firstResource: (href: href, progression: resourceProgression),
+            lastResource: (href: href, progression: resourceProgression),
+            readingOrder: readingOrder,
+            positionsByReadingOrder: positionsByReadingOrder
+        ) ?? (resourceProgressionLow ... resourceProgressionHigh)
+
+        let viewport = NavigatorViewport(
+            resources: [
+                NavigatorViewport.Resource(
+                    href: href,
+                    progression: resourceProgression
+                ),
+            ],
+            progression: totalProgression,
+            positions: positionRange
+        )
+        return (locator, viewport)
+    }
+}

--- a/Sources/Navigator/PDF/PDFViewportCalculator.swift
+++ b/Sources/Navigator/PDF/PDFViewportCalculator.swift
@@ -77,7 +77,7 @@ enum PDFViewportCalculator {
         let positionRange: ClosedRange<Int>? = resourcePositions.isEmpty ? nil : {
             let firstPos = resourcePositions.getOrNil(firstPage - 1)?.locations.position
             let lastPos = resourcePositions.getOrNil(lastPage - 1)?.locations.position
-            guard let fp = firstPos, let lp = lastPos else { return nil }
+            guard let fp = firstPos, let lp = lastPos, fp <= lp else { return nil }
             return fp ... lp
         }()
 

--- a/Sources/Navigator/Viewport/ViewportObservingNavigator.swift
+++ b/Sources/Navigator/Viewport/ViewportObservingNavigator.swift
@@ -27,7 +27,6 @@ public extension ViewportObservingNavigatorDelegate {
 
 /// Information about the visible portion of a publication.
 public struct NavigatorViewport: Equatable {
-    
     /// Visible reading order resources, in reading order.
     public var resources: [Resource]
 
@@ -72,7 +71,9 @@ public struct NavigatorViewport: Equatable {
 
     /// Visible reading order resource HREFs.
     @available(*, deprecated, message: "Use resources instead")
-    public var readingOrder: [AnyURL] { resources.map(\.href) }
+    public var readingOrder: [AnyURL] {
+        resources.map(\.href)
+    }
 
     /// Range of visible scroll progressions for each visible reading order resource.
     @available(*, deprecated, message: "Use resources instead")

--- a/Sources/Navigator/Viewport/ViewportObservingNavigator.swift
+++ b/Sources/Navigator/Viewport/ViewportObservingNavigator.swift
@@ -1,0 +1,82 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import ReadiumShared
+
+/// A navigator that exposes information about its currently visible portion
+/// of the publication.
+public protocol ViewportObservingNavigator: VisualNavigator {
+    /// Information about the visible portion of the publication, when rendered.
+    /// `nil` while the navigator is still initializing.
+    var viewport: NavigatorViewport? { get }
+}
+
+/// Delegate for receiving viewport updates from any
+/// ``ViewportObservingNavigator``.
+@MainActor public protocol ViewportObservingNavigatorDelegate: AnyObject {
+    /// Called when the viewport is updated.
+    func navigator(_ navigator: any ViewportObservingNavigator, viewportDidChange viewport: NavigatorViewport?)
+}
+
+public extension ViewportObservingNavigatorDelegate {
+    func navigator(_ navigator: any ViewportObservingNavigator, viewportDidChange viewport: NavigatorViewport?) {}
+}
+
+/// Information about the visible portion of a publication.
+public struct NavigatorViewport: Equatable {
+    
+    /// Visible reading order resources, in reading order.
+    public var resources: [Resource]
+
+    /// Range of visible total progression in the publication (0.0–1.0).
+    ///
+    /// The lower bound is the progression at the top of the visible area, while
+    /// the upper bound is at the bottom.
+    public var progression: ClosedRange<Double>
+
+    /// Range of visible positions in the publication's position list.
+    /// `nil` if positions are not available for this publication.
+    public var positions: ClosedRange<Int>?
+
+    public init(
+        resources: [Resource],
+        progression: ClosedRange<Double>,
+        positions: ClosedRange<Int>? = nil
+    ) {
+        self.resources = resources
+        self.progression = progression
+        self.positions = positions
+    }
+
+    /// A visible reading order resource inside the viewport.
+    public struct Resource: Equatable {
+        /// HREF of the reading order resource.
+        public var href: AnyURL
+
+        /// Range of visible scroll progression (0.0–1.0) inside the resource.
+        ///
+        /// For fixed-layout or page-based content where the resource is fully
+        /// visible, this is `0.0...1.0`.
+        public var progression: ClosedRange<Double>
+
+        public init(href: AnyURL, progression: ClosedRange<Double>) {
+            self.href = href
+            self.progression = progression
+        }
+    }
+
+    // MARK: - Deprecated
+
+    /// Visible reading order resource HREFs.
+    @available(*, deprecated, message: "Use resources instead")
+    public var readingOrder: [AnyURL] { resources.map(\.href) }
+
+    /// Range of visible scroll progressions for each visible reading order resource.
+    @available(*, deprecated, message: "Use resources instead")
+    public var progressions: [AnyURL: ClosedRange<Double>] {
+        Dictionary(resources.map { ($0.href, $0.progression) }, uniquingKeysWith: { $1 })
+    }
+}

--- a/Sources/Navigator/Viewport/ViewportProgressionCalculator.swift
+++ b/Sources/Navigator/Viewport/ViewportProgressionCalculator.swift
@@ -1,0 +1,86 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import ReadiumShared
+
+/// Computes total publication progression from resource-level progressions and
+/// the publication's position list.
+enum ViewportProgressionCalculator {
+    
+    /// Returns the visible total progression range across one or two visible
+    /// resources, or `nil` when the resources cannot be found in the reading
+    /// order or the position list is unavailable.
+    ///
+    /// Algorithm:
+    ///   1. Find each resource's index in the reading order.
+    ///   2. Derive the resource's total progression window:
+    ///      `[resourceStart, nextResourceStart ?? 1.0]`.
+    ///   3. Linearly interpolate the intra-resource progression within that
+    ///      window to produce a global total progression value.
+    ///   4. Return `lower...upper`, clamped so that `lower <= upper`.
+    ///
+    /// - Parameters:
+    ///   - firstResource: The first (topmost) visible resource and its
+    ///     intra-resource progression range. The lower bound is used for the
+    ///     output range's lower bound.
+    ///   - lastResource: The last (bottommost) visible resource and its
+    ///     intra-resource progression range. The upper bound is used for the
+    ///     output range's upper bound. May be the same as `firstResource`.
+    ///   - readingOrder: The publication's reading order links.
+    ///   - positionsByReadingOrder: Positions grouped by reading-order index.
+    static func totalProgressionRange(
+        firstResource: (href: AnyURL, progression: ClosedRange<Double>),
+        lastResource: (href: AnyURL, progression: ClosedRange<Double>),
+        readingOrder: [Link],
+        positionsByReadingOrder: [[Locator]]
+    ) -> ClosedRange<Double>? {
+        guard
+            let lower = totalProgression(
+                for: firstResource.href,
+                resourceProgression: firstResource.progression.lowerBound,
+                readingOrder: readingOrder,
+                positionsByReadingOrder: positionsByReadingOrder
+            ),
+            let upper = totalProgression(
+                for: lastResource.href,
+                resourceProgression: lastResource.progression.upperBound,
+                readingOrder: readingOrder,
+                positionsByReadingOrder: positionsByReadingOrder
+            )
+        else {
+            return nil
+        }
+
+        // Guard against floating-point drift producing an invalid range.
+        return min(lower, upper) ... max(lower, upper)
+    }
+
+    /// Maps an intra-resource progression (0.0–1.0) to a global total
+    /// progression by linearly interpolating within the resource's global range.
+    ///
+    /// The resource range spans from the `totalProgression` of the resource's
+    /// first position to the `totalProgression` of the next resource's first
+    /// position (or 1.0 for the last resource).
+    private static func totalProgression(
+        for href: AnyURL,
+        resourceProgression: Double,
+        readingOrder: [Link],
+        positionsByReadingOrder: [[Locator]]
+    ) -> Double? {
+        guard
+            let index = readingOrder.firstIndexWithHREF(href),
+            let resourceStart = positionsByReadingOrder.getOrNil(index)?
+                .first?.locations.totalProgression
+        else {
+            return nil
+        }
+
+        let resourceEnd = positionsByReadingOrder.getOrNil(index + 1)?
+            .first?.locations.totalProgression ?? 1.0
+
+        return resourceStart + resourceProgression * (resourceEnd - resourceStart)
+    }
+}

--- a/Sources/Navigator/Viewport/ViewportProgressionCalculator.swift
+++ b/Sources/Navigator/Viewport/ViewportProgressionCalculator.swift
@@ -9,7 +9,6 @@ import ReadiumShared
 /// Computes total publication progression from resource-level progressions and
 /// the publication's position list.
 enum ViewportProgressionCalculator {
-    
     /// Returns the visible total progression range across one or two visible
     /// resources, or `nil` when the resources cannot be found in the reading
     /// order or the position list is unavailable.
@@ -73,7 +72,7 @@ enum ViewportProgressionCalculator {
         guard
             let index = readingOrder.firstIndexWithHREF(href),
             let resourceStart = positionsByReadingOrder.getOrNil(index)?
-                .first?.locations.totalProgression
+            .first?.locations.totalProgression
         else {
             return nil
         }

--- a/Tests/NavigatorTests/EPUB/EPUBViewportAndLocationCalculatorTests.swift
+++ b/Tests/NavigatorTests/EPUB/EPUBViewportAndLocationCalculatorTests.swift
@@ -9,8 +9,8 @@ import ReadiumShared
 import Testing
 
 @Suite enum EPUBViewportAndLocationCalculatorTests {
-    @Suite("Viewport") struct ViewportSuite {
-        @Test("builds reading order URLs from a single-resource spread")
+    @Suite struct Viewport {
+        @Test("builds resource list from a single-resource spread")
         func singleResourceReadingOrder() async {
             let ro = makeReadingOrder(count: 2)
             let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
@@ -21,7 +21,7 @@ import Testing
                 tableOfContentsTitleByHref: [:],
                 fallbackLocator: noFallback
             )
-            #expect(viewport.readingOrder == [ro[0].url()])
+            #expect(viewport.resources.map(\.href) == [ro[0].url()])
         }
 
         @Test("records progression range for the visible resource")
@@ -35,7 +35,7 @@ import Testing
                 tableOfContentsTitleByHref: [:],
                 fallbackLocator: noFallback
             )
-            #expect(viewport.progressions[ro[0].url()] == 0.25 ... 0.75)
+            #expect(viewport.resources.first(where: { $0.href.string == ro[0].href })?.progression == 0.25 ... 0.75)
         }
 
         @Test("includes both resources for a two-index spread")
@@ -49,13 +49,26 @@ import Testing
                 tableOfContentsTitleByHref: [:],
                 fallbackLocator: noFallback
             )
-            #expect(viewport.readingOrder == [ro[0].url(), ro[1].url()])
-            #expect(viewport.progressions[ro[0].url()] == 0.0 ... 1.0)
-            #expect(viewport.progressions[ro[1].url()] == 0.0 ... 1.0)
+            #expect(viewport.resources.map(\.href) == [ro[0].url(), ro[1].url()])
+            #expect(viewport.resources.first(where: { $0.href.string == ro[0].href })?.progression == 0.0 ... 1.0)
+            #expect(viewport.resources.first(where: { $0.href.string == ro[1].href })?.progression == 0.0 ... 1.0)
+        }
+
+        @Test("total progression range lower bound matches locator totalProgression")
+        func totalProgressionLowerBoundMatchesLocator() async {
+            let (locator, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.5 ... 0.75 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(viewport.progression.lowerBound == locator?.locations.totalProgression)
         }
     }
 
-    @Suite("Locator - positions available") struct LocatorWithPositionsSuite {
+    @Suite("Locator - positions available") struct LocatorWithPositions {
         // 2 resources × 4 positions = 8 total.
         // Resource 0: totalProgression 0/8 … 3/8; resource 1: 4/8 … 7/8.
         // resourceTotalProgressionEnd for resource 0 = 4/8 = 0.5.
@@ -103,7 +116,7 @@ import Testing
         @Test("totalProgression interpolates linearly mid-resource")
         func totalProgressionInterpolation() async {
             // At 0.5 progression in resource 0:
-            // continuousTotalProgression = 0.0 + 0.5 * (0.5 - 0.0) = 0.25
+            // totalProgression = 0.0 + 0.5 * (0.5 - 0.0) = 0.25
             let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
                 readingOrderIndices: 0 ... 0,
                 progression: { _ in 0.5 ... 0.5 },
@@ -186,7 +199,7 @@ import Testing
         }
     }
 
-    @Suite("Viewport positions - positions available") struct ViewportPositionsSuite {
+    @Suite("Viewport positions - positions available") struct ViewportPositions {
         @Test("positions range is single position when viewing start of resource")
         func singlePositionAtStart() async {
             let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
@@ -256,7 +269,59 @@ import Testing
         }
     }
 
-    @Suite("Locator - no positions (fallback)") struct FallbackSuite {
+    @Suite("Viewport progression - positions available") struct ViewportProgression {
+        // 2 resources × 4 positions = 8 total.
+        // Resource 0 total progression window: 0.0 … 0.5
+        // Resource 1 total progression window: 0.5 … 1.0
+
+        @Test("progression lower bound is 0.0 when scrolled to start")
+        func progressionAtStart() async {
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 0,
+                progression: { _ in 0.0 ... 0.5 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            // lower = 0.0 + 0.0 * 0.5 = 0.0
+            // upper = 0.0 + 0.5 * 0.5 = 0.25
+            #expect(viewport.progression.lowerBound == 0.0)
+            #expect(viewport.progression.upperBound == 0.25)
+        }
+
+        @Test("progression upper bound is 1.0 when scrolled to end of last resource")
+        func progressionAtEnd() async {
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 1 ... 1,
+                progression: { _ in 0.5 ... 1.0 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            // lower = 0.5 + 0.5 * 0.5 = 0.75
+            // upper = 0.5 + 1.0 * 0.5 = 1.0
+            #expect(viewport.progression.upperBound == 1.0)
+        }
+
+        @Test("progression spans both resources in a two-index FXL spread")
+        func progressionSpansBothResources() async {
+            // Resource 0 visible fully, resource 1 visible fully.
+            // lower = 0.0 (start of resource 0), upper = 1.0 (end of resource 1)
+            let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
+                readingOrderIndices: 0 ... 1,
+                progression: { _ in 0.0 ... 1.0 },
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 1),
+                tableOfContentsTitleByHref: [:],
+                fallbackLocator: noFallback
+            )
+            #expect(viewport.progression == 0.0 ... 1.0)
+        }
+    }
+
+    @Suite("Locator - no positions (fallback)") struct Fallback {
         @Test("uses fallback locator when positionsByReadingOrder is empty")
         func useFallback() async {
             let ro = makeReadingOrder(count: 1)
@@ -319,12 +384,12 @@ import Testing
         }
     }
 
-    @Suite("Two-index spread (FXL)") struct TwoIndexSpreadSuite {
+    @Suite("Two-index spread (FXL)") struct TwoIndexSpread {
         @Test("totalProgression is computed from the first resource's range")
         func totalProgressionUsesFirstResource() async {
             // FXL: progression always returns 0...1, so firstProgression=0.0.
             // Resource 0 range: 0/2 = 0.0 … 1/2 = 0.5.
-            // continuousTotalProgression = 0.0 + 0.0 * (0.5 - 0.0) = 0.0
+            // totalProgression = 0.0 + 0.0 * (0.5 - 0.0) = 0.0
             let (locator, _) = await EPUBViewportAndLocationCalculator.compute(
                 readingOrderIndices: 0 ... 1,
                 progression: { _ in 0.0 ... 1.0 },
@@ -350,7 +415,7 @@ import Testing
             #expect(viewport.positions == 1 ... 2)
         }
 
-        @Test("viewport progressions contains an entry for each visible resource")
+        @Test("viewport resources contains an entry for each visible resource")
         func viewportContainsBothResources() async {
             let ro = makeReadingOrder(count: 2)
             let (_, viewport) = await EPUBViewportAndLocationCalculator.compute(
@@ -361,8 +426,8 @@ import Testing
                 tableOfContentsTitleByHref: [:],
                 fallbackLocator: noFallback
             )
-            #expect(viewport.progressions[ro[0].url()] == 0.1 ... 0.9)
-            #expect(viewport.progressions[ro[1].url()] == 0.2 ... 0.8)
+            #expect(viewport.resources.first(where: { $0.href.string == ro[0].href })?.progression == 0.1 ... 0.9)
+            #expect(viewport.resources.first(where: { $0.href.string == ro[1].href })?.progression == 0.2 ... 0.8)
         }
     }
 }

--- a/Tests/NavigatorTests/PDF/PDFViewportCalculatorTests.swift
+++ b/Tests/NavigatorTests/PDF/PDFViewportCalculatorTests.swift
@@ -1,0 +1,327 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumNavigator
+import ReadiumShared
+import Testing
+
+@Suite enum PDFViewportCalculatorTests {
+    // Layout used by most multi-resource tests:
+    // 2 resources × 4 pages = 8 total positions.
+    // Resource 0 total progression window: 0.0 … 0.5
+    // Resource 1 total progression window: 0.5 … 1.0
+
+    @Suite("Locator") struct Locator {
+        // 1 resource, 4 pages, positions available.
+
+        @Test("first page returns position 1")
+        func locatorForFirstPage() {
+            let locator = PDFViewportCalculator.computeLocator(
+                currentPageNumber: 1,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            #expect(locator?.locations.position == 1)
+        }
+
+        @Test("last page returns last position")
+        func locatorForLastPage() {
+            let locator = PDFViewportCalculator.computeLocator(
+                currentPageNumber: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            #expect(locator?.locations.position == 4)
+        }
+
+        @Test("middle page returns its position")
+        func locatorForMiddlePage() {
+            let locator = PDFViewportCalculator.computeLocator(
+                currentPageNumber: 2,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            #expect(locator?.locations.position == 2)
+        }
+
+        @Test("returns nil when no positions available")
+        func locatorIsNilWhenNoPositions() {
+            let locator = PDFViewportCalculator.computeLocator(
+                currentPageNumber: 1,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: []
+            )
+            #expect(locator == nil)
+        }
+
+        @Test("returns nil when resource index is out of bounds")
+        func locatorIsNilWhenOutOfBounds() {
+            let locator = PDFViewportCalculator.computeLocator(
+                currentPageNumber: 1,
+                currentResourceIndex: 5,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            #expect(locator == nil)
+        }
+    }
+
+    @Suite("Resource progression") struct ResourceProgression {
+        // 1 resource, 4 pages. Progression formula:
+        //   low  = (firstPage - 1) / (pageCount - 1)
+        //   high = min(1.0, lastPage / (pageCount - 1))
+
+        @Test("first page only — progression starts at 0")
+        func firstPageOnly() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 1,
+                visiblePageNumbers: 1 ... 1,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            // low  = (1 - 1) / 3 = 0.0
+            // high = min(1.0, 1 / 3) ≈ 0.333…
+            #expect(viewport?.resources.first?.progression.lowerBound == 0.0)
+            #expect(viewport?.resources.first?.progression.upperBound == 1.0 / 3.0)
+        }
+
+        @Test("last page only — progression ends at 1")
+        func lastPageOnly() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 4,
+                visiblePageNumbers: 4 ... 4,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            // low  = (4 - 1) / 3 = 1.0
+            // high = min(1.0, 4 / 3) = 1.0
+            #expect(viewport?.resources.first?.progression == 1.0 ... 1.0)
+        }
+
+        @Test("all pages visible — full 0…1 range")
+        func fullDocument() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 1,
+                visiblePageNumbers: 1 ... 4,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            #expect(viewport?.resources.first?.progression == 0.0 ... 1.0)
+        }
+
+        @Test("middle pages — progression is an interior range")
+        func middlePages() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 2,
+                visiblePageNumbers: 2 ... 3,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            // low  = (2 - 1) / 3 = 1/3
+            // high = min(1.0, 3 / 3) = 1.0
+            #expect(viewport?.resources.first?.progression.lowerBound == 1.0 / 3.0)
+            #expect(viewport?.resources.first?.progression.upperBound == 1.0)
+        }
+
+        @Test("single-page document — progression is always 0…1")
+        func singlePageDocument() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 1,
+                visiblePageNumbers: 1 ... 1,
+                pageCount: 1,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 1)
+            )
+            #expect(viewport?.resources.first?.progression == 0.0 ... 1.0)
+        }
+    }
+
+    @Suite("Viewport positions") struct ViewportPositions {
+        // 1 resource, 4 pages.
+
+        @Test("first page maps to first position")
+        func firstPageMapsToFirstPosition() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 1,
+                visiblePageNumbers: 1 ... 1,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            #expect(viewport?.positions == 1 ... 1)
+        }
+
+        @Test("last page maps to last position")
+        func lastPageMapsToLastPosition() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 4,
+                visiblePageNumbers: 4 ... 4,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            #expect(viewport?.positions == 4 ... 4)
+        }
+
+        @Test("multiple visible pages produce a position range")
+        func multipleVisiblePages() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 1,
+                visiblePageNumbers: 1 ... 4,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            #expect(viewport?.positions == 1 ... 4)
+        }
+
+        @Test("positions is nil when positionsByReadingOrder is empty")
+        func noPositionsAvailableReturnsNil() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 1,
+                visiblePageNumbers: 1 ... 1,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: []
+            )
+            #expect(viewport?.positions == nil)
+        }
+    }
+
+    @Suite("Viewport progression") struct ViewportProgression {
+        // 2 resources × 4 pages = 8 total positions.
+        // Resource 0 total progression window: 0.0 … 0.5
+        // Resource 1 total progression window: 0.5 … 1.0
+
+        @Test("first page of document — lower bound is 0.0")
+        func atStartOfDocument() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 1,
+                visiblePageNumbers: 1 ... 1,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, pagesPerResource: 4)
+            )
+            // resourceProgression = 0.0 … 1/3
+            // totalProgression lower = 0.0 + 0.0   * 0.5 = 0.0
+            // totalProgression upper = 0.0 + (1/3) * 0.5 ≈ 0.1667
+            #expect(viewport?.progression.lowerBound == 0.0)
+            #expect(viewport?.progression.upperBound == (1.0 / 3.0) * 0.5)
+        }
+
+        @Test("last page of first resource — upper bound is 0.5")
+        func atEndOfFirstResource() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 4,
+                visiblePageNumbers: 4 ... 4,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, pagesPerResource: 4)
+            )
+            // resourceProgression = 1.0 … 1.0
+            // totalProgression = 0.0 + 1.0 * 0.5 = 0.5
+            #expect(viewport?.progression == 0.5 ... 0.5)
+        }
+
+        @Test("last page of publication — upper bound is 1.0")
+        func atEndOfPublication() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 4,
+                visiblePageNumbers: 4 ... 4,
+                pageCount: 4,
+                currentResourceIndex: 1,
+                readingOrder: makeReadingOrder(count: 2),
+                positionsByReadingOrder: makePositions(resourceCount: 2, pagesPerResource: 4)
+            )
+            // Resource 1, page 4/4 → resourceProgression = 1.0 … 1.0
+            // totalProgression = 0.5 + 1.0 * 0.5 = 1.0
+            #expect(viewport?.progression == 1.0 ... 1.0)
+        }
+
+        @Test("falls back to resource progression when no positions available")
+        func fallsBackToResourceProgressionWhenNoPositions() {
+            let (_, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 1,
+                visiblePageNumbers: 1 ... 2,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: []
+            )
+            // No positions → fallback = resourceProgression
+            // low  = (1 - 1) / 3 = 0.0
+            // high = min(1.0, 2 / 3) ≈ 0.667
+            #expect(viewport?.progression.lowerBound == 0.0)
+            #expect(viewport?.progression.upperBound == 2.0 / 3.0)
+        }
+    }
+
+    @Suite("Nil result") struct NilResult {
+        @Test("out-of-bounds resource index returns (nil, nil) from compute")
+        func outOfBoundsResourceIndexReturnsNilPair() {
+            let (locator, viewport) = PDFViewportCalculator.compute(
+                currentPageNumber: 1,
+                visiblePageNumbers: 1 ... 1,
+                pageCount: 4,
+                currentResourceIndex: 5,
+                readingOrder: makeReadingOrder(count: 1),
+                positionsByReadingOrder: makePositions(resourceCount: 1, pagesPerResource: 4)
+            )
+            #expect(locator == nil)
+            #expect(viewport == nil)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+/// Builds a reading order of `count` links with hrefs "doc1.pdf", "doc2.pdf", …
+private func makeReadingOrder(count: Int) -> [Link] {
+    (1 ... count).map { Link(href: "doc\($0).pdf", mediaType: .pdf) }
+}
+
+/// Builds positions for `resourceCount` resources, each with `pagesPerResource` pages.
+/// `totalProgression` is distributed evenly across the whole publication;
+/// position numbers are 1-based and sequential.
+private func makePositions(resourceCount: Int, pagesPerResource: Int) -> [[Locator]] {
+    let total = resourceCount * pagesPerResource
+
+    return (0 ..< resourceCount).map { r in
+        (0 ..< pagesPerResource).map { p in
+            let absoluteIndex = r * pagesPerResource + p
+            return Locator(
+                href: AnyURL(string: "doc\(r + 1).pdf")!,
+                mediaType: .pdf,
+                locations: .init(
+                    progression: pagesPerResource > 1
+                        ? Double(p) / Double(pagesPerResource - 1)
+                        : 0.0,
+                    totalProgression: Double(absoluteIndex) / Double(total),
+                    position: absoluteIndex + 1
+                )
+            )
+        }
+    }
+}

--- a/Tests/NavigatorTests/PDF/PDFViewportCalculatorTests.swift
+++ b/Tests/NavigatorTests/PDF/PDFViewportCalculatorTests.swift
@@ -278,6 +278,51 @@ import Testing
         }
     }
 
+    /// The locator's totalProgression intentionally differs from
+    /// viewport.progression.lowerBound for most pages. The positions service
+    /// uses (page-1)/total (N equal slots), while the viewport calculator uses
+    /// (page-1)/(pageCount-1) (N-1 intervals, so consecutive viewports share
+    /// boundary values). Unlike EPUB — where positions are coarse snapshots and
+    /// the continuous scroll value is more accurate — PDF pages are the natural
+    /// discrete unit, so the position-based value is kept as-is in the locator.
+    @Suite("Locator vs viewport progression") struct LocatorVsViewportProgression {
+        @Test("locator totalProgression is position-based, not viewport-based")
+        func locatorAndViewportProgressionDiffer() {
+            // 1 resource, 4 pages.
+            // Positions (totalProgression = absoluteIndex / total = index/4):
+            //   page 1 → 0/4 = 0.0,  page 2 → 1/4 = 0.25,
+            //   page 3 → 2/4 = 0.5,  page 4 → 3/4 = 0.75
+            // Viewport lower bound (resourceProgression = (page-1)/(pageCount-1)):
+            //   page 2 → 1/3 ≈ 0.333,  page 4 → 1.0
+            let positions = makePositions(resourceCount: 1, pagesPerResource: 4)
+            let readingOrder = makeReadingOrder(count: 1)
+
+            // Page 2: locator at 0.25, viewport lower bound at 1/3.
+            let (locator2, viewport2) = PDFViewportCalculator.compute(
+                currentPageNumber: 2,
+                visiblePageNumbers: 2 ... 2,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: readingOrder,
+                positionsByReadingOrder: positions
+            )
+            #expect(locator2?.locations.totalProgression == 0.25)
+            #expect(viewport2?.progression.lowerBound == 1.0 / 3.0)
+
+            // Last page: locator at 0.75, viewport lower bound at 1.0.
+            let (locator4, viewport4) = PDFViewportCalculator.compute(
+                currentPageNumber: 4,
+                visiblePageNumbers: 4 ... 4,
+                pageCount: 4,
+                currentResourceIndex: 0,
+                readingOrder: readingOrder,
+                positionsByReadingOrder: positions
+            )
+            #expect(locator4?.locations.totalProgression == 0.75)
+            #expect(viewport4?.progression.lowerBound == 1.0)
+        }
+    }
+
     @Suite("Nil result") struct NilResult {
         @Test("out-of-bounds resource index returns (nil, nil) from compute")
         func outOfBoundsResourceIndexReturnsNilPair() {

--- a/Tests/NavigatorTests/Viewport/ViewportProgressionCalculatorTests.swift
+++ b/Tests/NavigatorTests/Viewport/ViewportProgressionCalculatorTests.swift
@@ -1,0 +1,141 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumNavigator
+import ReadiumShared
+import Testing
+
+@Suite("ViewportProgressionCalculator") struct ViewportProgressionCalculatorTests {
+    // Layout used by most tests:
+    // 2 resources × 4 positions = 8 total.
+    // Resource 0 total progression window: 0.0 … 0.5
+    // Resource 1 total progression window: 0.5 … 1.0
+
+    @Test("single resource, partial scroll — interpolates within window")
+    func singleResourcePartialScroll() {
+        // Resource 0, 50% through → totalProgression = 0.0 + 0.5 * 0.5 = 0.25
+        let result = ViewportProgressionCalculator.totalProgressionRange(
+            firstResource: (href: url("chap1.html"), progression: 0.5 ... 0.5),
+            lastResource: (href: url("chap1.html"), progression: 0.5 ... 0.5),
+            readingOrder: makeReadingOrder(count: 2),
+            positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4)
+        )
+        #expect(result == 0.25 ... 0.25)
+    }
+
+    @Test("single resource, range — lower and upper interpolated independently")
+    func singleResourceRange() {
+        // lower: resource 0 at 0.0 → 0.0 + 0.0 * 0.5 = 0.0
+        // upper: resource 0 at 0.5 → 0.0 + 0.5 * 0.5 = 0.25
+        let result = ViewportProgressionCalculator.totalProgressionRange(
+            firstResource: (href: url("chap1.html"), progression: 0.0 ... 0.5),
+            lastResource: (href: url("chap1.html"), progression: 0.0 ... 0.5),
+            readingOrder: makeReadingOrder(count: 2),
+            positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4)
+        )
+        #expect(result == 0.0 ... 0.25)
+    }
+
+    @Test("two-resource spread — range spans both resource windows")
+    func twoResourceSpread() {
+        // lower: resource 0 at 0.0 → 0.0
+        // upper: resource 1 at 1.0 → 0.5 + 1.0 * 0.5 = 1.0
+        let result = ViewportProgressionCalculator.totalProgressionRange(
+            firstResource: (href: url("chap1.html"), progression: 0.0 ... 1.0),
+            lastResource: (href: url("chap2.html"), progression: 0.0 ... 1.0),
+            readingOrder: makeReadingOrder(count: 2),
+            positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4)
+        )
+        #expect(result == 0.0 ... 1.0)
+    }
+
+    @Test("last resource uses 1.0 as window end")
+    func lastResourceUsesOneAsWindowEnd() {
+        // Single resource publication — window is 0.0 … 1.0.
+        // At 75% → 0.0 + 0.75 * 1.0 = 0.75
+        let result = ViewportProgressionCalculator.totalProgressionRange(
+            firstResource: (href: url("chap1.html"), progression: 0.75 ... 0.75),
+            lastResource: (href: url("chap1.html"), progression: 0.75 ... 0.75),
+            readingOrder: makeReadingOrder(count: 1),
+            positionsByReadingOrder: makePositions(resourceCount: 1, positionsPerResource: 4)
+        )
+        #expect(result == 0.75 ... 0.75)
+    }
+
+    @Test("start of publication is 0.0")
+    func startOfPublication() {
+        let result = ViewportProgressionCalculator.totalProgressionRange(
+            firstResource: (href: url("chap1.html"), progression: 0.0 ... 0.0),
+            lastResource: (href: url("chap1.html"), progression: 0.0 ... 0.0),
+            readingOrder: makeReadingOrder(count: 2),
+            positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4)
+        )
+        #expect(result == 0.0 ... 0.0)
+    }
+
+    @Test("end of publication is 1.0")
+    func endOfPublication() {
+        let result = ViewportProgressionCalculator.totalProgressionRange(
+            firstResource: (href: url("chap2.html"), progression: 1.0 ... 1.0),
+            lastResource: (href: url("chap2.html"), progression: 1.0 ... 1.0),
+            readingOrder: makeReadingOrder(count: 2),
+            positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4)
+        )
+        #expect(result == 1.0 ... 1.0)
+    }
+
+    @Test("returns nil when positions are empty")
+    func noPositionsReturnsNil() {
+        let result = ViewportProgressionCalculator.totalProgressionRange(
+            firstResource: (href: url("chap1.html"), progression: 0.5 ... 0.5),
+            lastResource: (href: url("chap1.html"), progression: 0.5 ... 0.5),
+            readingOrder: makeReadingOrder(count: 2),
+            positionsByReadingOrder: []
+        )
+        #expect(result == nil)
+    }
+
+    @Test("returns nil when href not found in reading order")
+    func unknownHrefReturnsNil() {
+        let result = ViewportProgressionCalculator.totalProgressionRange(
+            firstResource: (href: url("unknown.html"), progression: 0.5 ... 0.5),
+            lastResource: (href: url("unknown.html"), progression: 0.5 ... 0.5),
+            readingOrder: makeReadingOrder(count: 2),
+            positionsByReadingOrder: makePositions(resourceCount: 2, positionsPerResource: 4)
+        )
+        #expect(result == nil)
+    }
+}
+
+// MARK: - Helpers
+
+private func url(_ string: String) -> AnyURL {
+    AnyURL(string: string)!
+}
+
+private func makeReadingOrder(count: Int) -> [Link] {
+    (1 ... count).map { Link(href: "chap\($0).html", mediaType: .html) }
+}
+
+private func makePositions(resourceCount: Int, positionsPerResource: Int) -> [[Locator]] {
+    let total = resourceCount * positionsPerResource
+    return (0 ..< resourceCount).map { r in
+        (0 ..< positionsPerResource).map { p in
+            let absoluteIndex = r * positionsPerResource + p
+            return Locator(
+                href: AnyURL(string: "chap\(r + 1).html")!,
+                mediaType: .html,
+                locations: .init(
+                    progression: positionsPerResource > 1
+                        ? Double(p) / Double(positionsPerResource - 1)
+                        : 0.0,
+                    totalProgression: Double(absoluteIndex) / Double(total),
+                    position: absoluteIndex + 1
+                )
+            )
+        }
+    }
+}

--- a/docs/Migration Guide.md
+++ b/docs/Migration Guide.md
@@ -2,9 +2,23 @@
 
 All migration steps necessary in reading apps to upgrade to major versions of the Swift Readium toolkit will be documented in this file.
 
-<!-- ## Unreleased -->
+## Unreleased
 
-## 3.8.0
+### Deprecated Viewport Method in `EPUBNavigatorDelegate`
+
+The following delegate method was removed from `EPUBNavigatorDelegate`.
+
+```swift
+func navigator(_ navigator: EPUBNavigatorViewController, viewportDidChange viewport: NavigatorViewport?)
+```
+
+The protocol now only inherits from `ViewportObservingNavigatorDelegate` the generic version:
+
+```swift
+func navigator(_ navigator: any ViewportObservingNavigator, viewportDidChange viewport: NavigatorViewport?)
+```
+
+If your delegate implementation used the concrete `EPUBNavigatorViewController` signature, it will no longer be called. Update your delegate to implement the generic method instead.
 
 ### Migrating to `JSONValue` for JSON Parsing
 
@@ -44,6 +58,8 @@ The free functions `serializeJSONString` and `serializeJSONData` have been repla
 +let data = locator.jsonData()
 ```
 
+
+## 3.8.0
 
 ### Removing the HTTP Server from the EPUB Navigator
 


### PR DESCRIPTION
Introduces a shared `ViewportObservingNavigator` protocol so clients can observe the visible portion of a publication uniformly across EPUB and PDF navigators. The new `NavigatorViewport` struct exposes both the positions range and the total progression range.

## Changelog

### Added

#### Navigator

* New `ViewportObservingNavigator` protocol, implemented by both the EPUB and PDF navigators, which exposes information about the current visible portion of the publication (e.g. progression and position ranges).
    * The EPUB navigator's `Viewport` type is now a deprecated typealias for `NavigatorViewport`.