### PR TITLE
Support `shouldNavigateToLink` and `didJumpTo` for PDF internal links

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,3 +1,4 @@
 --swiftversion 5.6
 --header "//\n//  Copyright {year} Readium Foundation. All rights reserved.\n//  Use of this source code is governed by the BSD-style license\n//  available in the top-level LICENSE file of the project.\n//"
 --stripunusedargs closure-only
+--disable redundantSendable,noForceUnwrapInTests

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/nicklockwood/SwiftFormat",
         "state": {
           "branch": null,
-          "revision": "22a472ced4c621a0e41b982a6f32dec868d09392",
-          "version": "0.59.1"
+          "revision": "397309e73621d6355d3a7fb832ca233ac9dd5254",
+          "version": "0.61.0"
         }
       }
     ]

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     name: "BuildTools",
     platforms: [.macOS(.v10_11)],
     dependencies: [
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.59.1"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.61.0"),
     ],
     targets: [
         .target(name: "BuildTools", path: "", exclude: ["Sources"]),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 * New `ViewportObservingNavigator` protocol, implemented by both the EPUB and PDF navigators, which exposes information about the current visible portion of the publication (e.g. progression and position ranges).
     * The EPUB navigator's `Viewport` type is now a deprecated typealias for `NavigatorViewport`.
+* The PDF navigator now calls `VisualNavigatorDelegate.navigator(_:shouldNavigateToLink:)` and `NavigatorDelegate.navigator(_:didJumpTo:)` when the user taps an internal link, matching the behavior of the EPUB navigator.
 
 ### Removed
 

--- a/Sources/Navigator/PDF/PDFDocumentView.swift
+++ b/Sources/Navigator/PDF/PDFDocumentView.swift
@@ -7,7 +7,7 @@
 import Foundation
 import PDFKit
 
-protocol PDFDocumentViewDelegate: AnyObject {
+@MainActor protocol PDFDocumentViewDelegate: AnyObject {
     func pdfDocumentViewContentInset(_ pdfDocumentView: PDFDocumentView) -> UIEdgeInsets?
 
     /// Called before PDFKit navigates to an internal link destination.

--- a/Sources/Navigator/PDF/PDFDocumentView.swift
+++ b/Sources/Navigator/PDF/PDFDocumentView.swift
@@ -9,6 +9,14 @@ import PDFKit
 
 protocol PDFDocumentViewDelegate: AnyObject {
     func pdfDocumentViewContentInset(_ pdfDocumentView: PDFDocumentView) -> UIEdgeInsets?
+
+    /// Called before PDFKit navigates to an internal link destination.
+    ///
+    /// Return false to prevent navigation.
+    func pdfDocumentView(_ pdfDocumentView: PDFDocumentView, shouldGoTo destination: PDFDestination) -> Bool
+
+    /// Called after PDFKit navigates to an internal link destination.
+    func pdfDocumentView(_ pdfDocumentView: PDFDocumentView, didGoTo destination: PDFDestination)
 }
 
 public final class PDFDocumentView: PDFView {
@@ -37,6 +45,16 @@ public final class PDFDocumentView: PDFView {
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override public func go(to destination: PDFDestination) {
+        guard documentViewDelegate?.pdfDocumentView(self, shouldGoTo: destination) ?? true else {
+            return
+        }
+
+        super.go(to: destination)
+
+        documentViewDelegate?.pdfDocumentView(self, didGoTo: destination)
     }
 
     override public func safeAreaInsetsDidChange() {

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -549,8 +549,7 @@ open class PDFNavigatorViewController:
     private func locator(to pageNumber: Int) -> Locator? {
         guard
             let currentResourceIndex = currentResourceIndex,
-            let readingOrderLink = publication.readingOrder.getOrNil(currentResourceIndex),
-            let mediaType = readingOrderLink.mediaType
+            let readingOrderLink = publication.readingOrder.getOrNil(currentResourceIndex)
         else {
             return nil
         }
@@ -558,7 +557,7 @@ open class PDFNavigatorViewController:
         let href = readingOrderLink.url().removingFragment()
         return Locator(
             href: href,
-            mediaType: mediaType,
+            mediaType: readingOrderLink.mediaType ?? .pdf,
             locations: .init(
                 fragments: ["page=\(pageNumber)"]
             )
@@ -570,8 +569,12 @@ open class PDFNavigatorViewController:
             return nil
         }
 
-        let pageNumber = document.index(for: page) + 1
-        return locator(to: pageNumber)
+        let index = document.index(for: page)
+        guard index != NSNotFound else {
+            return nil
+        }
+
+        return locator(to: index + 1)
     }
 
     private func link(to page: PDFPage) -> Link? {

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -548,7 +548,6 @@ open class PDFNavigatorViewController:
 
     private func locator(to pageNumber: Int) -> Locator? {
         guard
-            let document = pdfView?.document,
             let currentResourceIndex = currentResourceIndex,
             let readingOrderLink = publication.readingOrder.getOrNil(currentResourceIndex),
             let mediaType = readingOrderLink.mediaType
@@ -580,12 +579,8 @@ open class PDFNavigatorViewController:
             return nil
         }
 
-        var href = locator.href.string
-        if let fragment = locator.locations.fragments.first {
-            href += "#\(fragment)"
-        }
-
-        return Link(href: href, mediaType: locator.mediaType)
+        let href = locator.href.replacingFragment(locator.locations.fragments.first)
+        return Link(href: href.string, mediaType: locator.mediaType)
     }
 
     /// Returns the position locator of the current page.

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -546,6 +546,48 @@ open class PDFNavigatorViewController:
         return position
     }
 
+    private func locator(to pageNumber: Int) -> Locator? {
+        guard
+            let document = pdfView?.document,
+            let currentResourceIndex = currentResourceIndex,
+            let readingOrderLink = publication.readingOrder.getOrNil(currentResourceIndex),
+            let mediaType = readingOrderLink.mediaType
+        else {
+            return nil
+        }
+
+        let href = readingOrderLink.url().removingFragment()
+        return Locator(
+            href: href,
+            mediaType: mediaType,
+            locations: .init(
+                fragments: ["page=\(pageNumber)"]
+            )
+        )
+    }
+
+    private func locator(to page: PDFPage) -> Locator? {
+        guard let document = pdfView?.document else {
+            return nil
+        }
+
+        let pageNumber = document.index(for: page) + 1
+        return locator(to: pageNumber)
+    }
+
+    private func link(to page: PDFPage) -> Link? {
+        guard let locator = locator(to: page) else {
+            return nil
+        }
+
+        var href = locator.href.string
+        if let fragment = locator.locations.fragments.first {
+            href += "#\(fragment)"
+        }
+
+        return Link(href: href, mediaType: locator.mediaType)
+    }
+
     /// Returns the position locator of the current page.
     private var currentPosition: Locator? {
         guard
@@ -782,8 +824,6 @@ open class PDFNavigatorViewController:
 
 extension PDFNavigatorViewController: PDFViewDelegate {
     public func pdfViewWillClick(onLink sender: PDFView, with url: URL) {
-        log(.debug, "Click URL: \(url)")
-
         let url = url.addingSchemeWhenMissing("http")
         delegate?.navigator(self, presentExternalURL: url)
     }
@@ -796,6 +836,28 @@ extension PDFNavigatorViewController: PDFViewDelegate {
 extension PDFNavigatorViewController: PDFDocumentViewDelegate {
     func pdfDocumentViewContentInset(_ pdfDocumentView: PDFDocumentView) -> UIEdgeInsets? {
         delegate?.navigatorContentInset(self)
+    }
+
+    func pdfDocumentView(_ pdfDocumentView: PDFDocumentView, shouldGoTo destination: PDFDestination) -> Bool {
+        guard
+            let page = destination.page,
+            let link = link(to: page)
+        else {
+            return true
+        }
+
+        return delegate?.navigator(self, shouldNavigateToLink: link) ?? true
+    }
+
+    func pdfDocumentView(_ pdfDocumentView: PDFDocumentView, didGoTo destination: PDFDestination) {
+        guard
+            let page = destination.page,
+            let locator = locator(to: page)
+        else {
+            return
+        }
+
+        delegate?.navigator(self, didJumpTo: locator)
     }
 }
 

--- a/Sources/Shared/Toolkit/URL/URLProtocol.swift
+++ b/Sources/Shared/Toolkit/URL/URLProtocol.swift
@@ -136,10 +136,12 @@ public extension URLProtocol {
     func replacingFragment(_ fragment: String?) -> Self {
         if let url = url.copy({ $0.fragment = fragment }) {
             return Self(url: url)!
-        } else if fragment == nil, let withoutFragment = string.components(separatedBy: "#").first {
-            return Self(string: withoutFragment)!
         } else {
-            return self
+            var base = string.components(separatedBy: "#").first ?? string
+            if let fragment = fragment, !fragment.isEmpty {
+                base += "#" + fragment
+            }
+            return Self(string: base) ?? self
         }
     }
 

--- a/Sources/Shared/Toolkit/URL/URLProtocol.swift
+++ b/Sources/Shared/Toolkit/URL/URLProtocol.swift
@@ -128,9 +128,15 @@ public extension URLProtocol {
 
     /// Creates a copy of this URL after removing its fragment portion.
     func removingFragment() -> Self {
-        if let url = url.copy({ $0.fragment = nil }) {
+        replacingFragment(nil)
+    }
+
+    /// Creates a copy of this URL after replacing its fragment with the given
+    /// value, or removing it when `fragment` is `nil`.
+    func replacingFragment(_ fragment: String?) -> Self {
+        if let url = url.copy({ $0.fragment = fragment }) {
             return Self(url: url)!
-        } else if let withoutFragment = string.components(separatedBy: "#").first {
+        } else if fragment == nil, let withoutFragment = string.components(separatedBy: "#").first {
             return Self(string: withoutFragment)!
         } else {
             return self

--- a/TestApp/Sources/OPDS/OPDSFeeds/OPDSFeedView.swift
+++ b/TestApp/Sources/OPDS/OPDSFeeds/OPDSFeedView.swift
@@ -86,8 +86,6 @@ struct OPDSFeedView: View {
     private func facetDestinationView() -> some View {
         if let url = facetNavigationURL {
             OPDSFeedView(feedURL: url, delegate: delegate)
-        } else {
-            EmptyView()
         }
     }
 

--- a/Tests/InternalTests/Extensions/RangeTests.swift
+++ b/Tests/InternalTests/Extensions/RangeTests.swift
@@ -8,8 +8,8 @@ import Foundation
 @testable import ReadiumInternal
 import Testing
 
-@Suite struct RangeTests {
-    @Suite struct HTTPByteRangeParsing {
+enum RangeTests {
+    struct HTTPByteRangeParsing {
         let totalLength: UInt64 = 10000
 
         // MARK: - Closed range: bytes=N-M

--- a/Tests/InternalTests/Extensions/URLTests.swift
+++ b/Tests/InternalTests/Extensions/URLTests.swift
@@ -4,6 +4,7 @@
 //  available in the top-level LICENSE file of the project.
 //
 
+import Foundation
 @testable import ReadiumInternal
 import Testing
 

--- a/Tests/InternalTests/Extensions/URLTests.swift
+++ b/Tests/InternalTests/Extensions/URLTests.swift
@@ -5,17 +5,20 @@
 //
 
 @testable import ReadiumInternal
-import XCTest
+import Testing
 
-class URLTests: XCTestCase {
-    func testAddingSchemeWhenMissing() {
-        XCTAssertEqual(
-            URL(string: "//www.google.com/path")?.addingSchemeWhenMissing("test"),
-            URL(string: "test://www.google.com/path")
-        )
-        XCTAssertEqual(
-            URL(string: "http://www.google.com/path")?.addingSchemeWhenMissing("test"),
-            URL(string: "http://www.google.com/path")
-        )
+@Suite enum URLTests {
+    @Suite("addingSchemeWhenMissing") struct AddingSchemeWhenMissing {
+        @Test("adds scheme to schemeless URL")
+        func addingSchemeWhenMissing() {
+            #expect(
+                URL(string: "//www.google.com/path")?.addingSchemeWhenMissing("test")
+                    == URL(string: "test://www.google.com/path")
+            )
+            #expect(
+                URL(string: "http://www.google.com/path")?.addingSchemeWhenMissing("test")
+                    == URL(string: "http://www.google.com/path")
+            )
+        }
     }
 }

--- a/Tests/InternalTests/Extensions/URLTests.swift
+++ b/Tests/InternalTests/Extensions/URLTests.swift
@@ -8,7 +8,7 @@ import Foundation
 @testable import ReadiumInternal
 import Testing
 
-@Suite enum URLTests {
+enum URLTests {
     @Suite("addingSchemeWhenMissing") struct AddingSchemeWhenMissing {
         @Test("adds scheme to schemeless URL")
         func addingSchemeWhenMissing() {

--- a/Tests/LCPTests/Repositories/Keychain/LCPKeychainLicenseRepositoryTests.swift
+++ b/Tests/LCPTests/Repositories/Keychain/LCPKeychainLicenseRepositoryTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import ReadiumShared
 import Testing
 
-@Suite struct LCPKeychainLicenseRepositoryTests {
+struct LCPKeychainLicenseRepositoryTests {
     let repository: LCPKeychainLicenseRepository
 
     init() throws {

--- a/Tests/LCPTests/Repositories/Keychain/LCPKeychainPassphraseRepositoryTests.swift
+++ b/Tests/LCPTests/Repositories/Keychain/LCPKeychainPassphraseRepositoryTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import ReadiumShared
 import Testing
 
-@Suite struct LCPKeychainPassphraseRepositoryTests {
+struct LCPKeychainPassphraseRepositoryTests {
     let repository: LCPKeychainPassphraseRepository
 
     init() throws {

--- a/Tests/NavigatorTests/EPUB/EPUBSpreadTests.swift
+++ b/Tests/NavigatorTests/EPUB/EPUBSpreadTests.swift
@@ -8,7 +8,7 @@
 import ReadiumShared
 import Testing
 
-@Suite enum EPUBSpreadTests {
+enum EPUBSpreadTests {
     @Suite("Single pages") struct SinglePages {
         @Test("with an empty reading order")
         func emptyReadingOrder() {
@@ -268,8 +268,8 @@ import Testing
         }
     }
 
-    @Suite enum Properties {
-        @Suite struct SingleSpread {
+    enum Properties {
+        struct SingleSpread {
             @Test func readingOrderIndices() {
                 let spread = EPUBSpread.single(EPUBSingleSpread(
                     resource: EPUBSpreadResource(index: 3, link: link("p.html"))
@@ -294,7 +294,7 @@ import Testing
             }
         }
 
-        @Suite struct DoubleSpread {
+        struct DoubleSpread {
             @Test func readingOrderIndices() {
                 let spread = EPUBSpread.double(EPUBDoubleSpread(
                     first: EPUBSpreadResource(index: 2, link: link("p1.html")),
@@ -345,7 +345,7 @@ import Testing
         }
     }
 
-    @Suite struct PositionCount {
+    struct PositionCount {
         @Test("for a single spread")
         func single() {
             let readingOrder: ReadingOrder = [
@@ -404,7 +404,7 @@ import Testing
         }
     }
 
-    @Suite struct FirstIndexWithReadingOrderIndex {
+    struct FirstIndexWithReadingOrderIndex {
         @Test("finds the spread index containing a reading order index")
         func findsSpreadIndex() {
             let spreads: [EPUBSpread] = [

--- a/Tests/NavigatorTests/EPUB/EPUBViewportAndLocationCalculatorTests.swift
+++ b/Tests/NavigatorTests/EPUB/EPUBViewportAndLocationCalculatorTests.swift
@@ -8,8 +8,8 @@
 import ReadiumShared
 import Testing
 
-@Suite enum EPUBViewportAndLocationCalculatorTests {
-    @Suite struct Viewport {
+enum EPUBViewportAndLocationCalculatorTests {
+    struct Viewport {
         @Test("builds resource list from a single-resource spread")
         func singleResourceReadingOrder() async {
             let ro = makeReadingOrder(count: 2)

--- a/Tests/NavigatorTests/PDF/PDFViewportCalculatorTests.swift
+++ b/Tests/NavigatorTests/PDF/PDFViewportCalculatorTests.swift
@@ -8,7 +8,7 @@
 import ReadiumShared
 import Testing
 
-@Suite enum PDFViewportCalculatorTests {
+enum PDFViewportCalculatorTests {
     // Layout used by most multi-resource tests:
     // 2 resources × 4 pages = 8 total positions.
     // Resource 0 total progression window: 0.0 … 0.5

--- a/Tests/SharedTests/Publication/Extensions/EPUB/Metadata+EPUBTests.swift
+++ b/Tests/SharedTests/Publication/Extensions/EPUB/Metadata+EPUBTests.swift
@@ -7,7 +7,7 @@
 import ReadiumShared
 import Testing
 
-@Suite enum MetadataEPUBTests {
+enum MetadataEPUBTests {
     @Suite("EPUBMediaOverlay") enum EPUBMediaOverlayTests {
         @Suite("JSON parsing") struct JSONParsing {
             @Test("full content")

--- a/Tests/SharedTests/Publication/GuidedNavigation/GuidedNavigationDocumentTests.swift
+++ b/Tests/SharedTests/Publication/GuidedNavigation/GuidedNavigationDocumentTests.swift
@@ -7,7 +7,7 @@
 @testable import ReadiumShared
 import Testing
 
-@Suite enum GuidedNavigationDocumentTests {
+enum GuidedNavigationDocumentTests {
     @Suite("Parsing") struct Parsing {
         @Test("minimal JSON with just guided")
         func minimalJSON() throws {

--- a/Tests/SharedTests/Publication/GuidedNavigation/GuidedNavigationObjectTests.swift
+++ b/Tests/SharedTests/Publication/GuidedNavigation/GuidedNavigationObjectTests.swift
@@ -7,7 +7,7 @@
 @testable import ReadiumShared
 import Testing
 
-@Suite enum GuidedNavigationObjectTests {
+enum GuidedNavigationObjectTests {
     @Suite("Parsing") struct Parsing {
         @Test("minimal JSON with only textref")
         func minimalTextref() throws {

--- a/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
@@ -13,8 +13,8 @@ private let coverURL = fixtures.url(for: "cover.jpg")
 private let cover = UIImage(contentsOfFile: coverURL.path)!
 private let cover2 = UIImage(data: fixtures.data(at: "cover2.jpg"))!
 
-@Suite struct CoverServiceTests {
-    @Suite struct PublicationHelpers {
+enum CoverServiceTests {
+    struct PublicationHelpers {
         @Test func coverDelegatesToCustomService() async throws {
             let pub = makePublication { _ in TestCoverService(cover: cover2) }
             let image = try await pub.cover().get()

--- a/Tests/SharedTests/Publication/Services/Cover/ResourceCoverServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Cover/ResourceCoverServiceTests.swift
@@ -13,7 +13,7 @@ private let coverURL = fixtures.url(for: "cover.jpg")
 private let cover = UIImage(contentsOfFile: coverURL.path)!
 private let cover2 = UIImage(data: fixtures.data(at: "cover2.jpg"))!
 
-@Suite struct ResourceCoverServiceTests {
+enum ResourceCoverServiceTests {
     @Suite("cover()") struct Cover {
         @Test func prioritizesExplicitCoverLinkOverReadingOrder() async throws {
             let pub = makePublication(

--- a/Tests/SharedTests/Toolkit/Data/ReadResultTests.swift
+++ b/Tests/SharedTests/Toolkit/Data/ReadResultTests.swift
@@ -8,7 +8,7 @@ import Foundation
 @testable import ReadiumShared
 import Testing
 
-@Suite enum ReadResultDataTests {
+enum ReadResultDataTests {
     static let accessError: ReadError = .access(.fileSystem(.fileNotFound(nil)))
 
     @Suite("decode") struct Decode {
@@ -86,7 +86,7 @@ import Testing
     }
 }
 
-@Suite enum ReadResultOptionalDataTests {
+enum ReadResultOptionalDataTests {
     static let accessError: ReadError = .access(.fileSystem(.fileNotFound(nil)))
 
     @Suite("decode") struct Decode {

--- a/Tests/SharedTests/Toolkit/Extensions/UIImageTests.swift
+++ b/Tests/SharedTests/Toolkit/Extensions/UIImageTests.swift
@@ -16,7 +16,7 @@ private let squareImage = UIImage(contentsOfFile: fixtures.url(for: "readium.png
 /// cc-a-shared-culture.jpg is 376×500
 private let portraitImage = UIImage(contentsOfFile: fixtures.url(for: "cc-a-shared-culture.jpg").path)!
 
-@Suite struct UIImageTests {
+enum UIImageTests {
     @Suite("scaleToFit(maxSize:)") struct ScaleToFit {
         /// The early-return code path is image-agnostic; one set of cases is enough.
         @Test func returnsSelfWhenFits() {

--- a/Tests/SharedTests/Toolkit/JSONValueTests.swift
+++ b/Tests/SharedTests/Toolkit/JSONValueTests.swift
@@ -8,7 +8,7 @@ import Foundation
 @testable import ReadiumShared
 import Testing
 
-@Suite struct JSONValueTests {
+enum JSONValueTests {
     /// Shared helper used by Decode suites.
     private struct StringItem: JSONValueDecodable, Equatable {
         let value: String
@@ -23,7 +23,7 @@ import Testing
         }
     }
 
-    @Suite struct JSONValueEncodableConformances {
+    struct JSONValueEncodableConformances {
         @Test func string() {
             #expect("hello".jsonValue == .string("hello"))
         }
@@ -84,7 +84,7 @@ import Testing
         }
     }
 
-    @Suite struct JSONValueDecodableConformances {
+    struct JSONValueDecodableConformances {
         @Test func string() throws {
             #expect(try String(json: JSONValue.string("hello")) == "hello")
             #expect(try String(json: JSONValue.integer(42)) == nil)
@@ -115,7 +115,7 @@ import Testing
 
     /// All tests are per-accessor: each verifies the happy path and
     /// representative nil cases for one accessor property.
-    @Suite struct Accessors {
+    struct Accessors {
         @Test func bool() {
             #expect(JSONValue.bool(true).bool == true)
             #expect(JSONValue.bool(false).bool == false)
@@ -158,7 +158,7 @@ import Testing
         }
     }
 
-    @Suite struct FromAny {
+    struct FromAny {
         /// nil input → failable init returns nil (not .null)
         @Test func nilReturnsNil() {
             #expect(JSONValue(nil) == nil)
@@ -245,7 +245,7 @@ import Testing
         }
     }
 
-    @Suite struct AnyConversion {
+    struct AnyConversion {
         @Test func primitives() {
             #expect(JSONValue.null.any is NSNull)
             #expect(JSONValue.bool(true).any as? Bool == true)
@@ -260,7 +260,7 @@ import Testing
         }
     }
 
-    @Suite struct LiteralConformance {
+    struct LiteralConformance {
         @Test func scalarLiterals() {
             #expect(nil as JSONValue == .null)
             #expect(true as JSONValue == .bool(true))
@@ -275,7 +275,7 @@ import Testing
         }
     }
 
-    @Suite struct NonNegative {
+    struct NonNegative {
         @Test func fromInteger() {
             #expect(JSONValue.integer(42).nonNegative() == Int(42))
             #expect(JSONValue.integer(42).nonNegative() == UInt64(42))
@@ -307,7 +307,7 @@ import Testing
         }
     }
 
-    @Suite struct DecodeSingle {
+    struct DecodeSingle {
         @Test func decodesValidValue() throws {
             let result: StringItem? = try JSONValue.string("hello").decode()
             #expect(result == StringItem(value: "hello"))
@@ -339,7 +339,7 @@ import Testing
         }
     }
 
-    @Suite struct DecodeArray {
+    struct DecodeArray {
         @Test func decodesArray() {
             let json = JSONValue.array([.string("a"), .string("b"), .string("c")])
             let result: [StringItem] = json.decode()
@@ -376,7 +376,7 @@ import Testing
         }
     }
 
-    @Suite struct Decode {
+    struct Decode {
         @Test func decodesValidElements() {
             let array: [JSONValue] = [.string("a"), .string("b"), .string("c")]
             let result: [StringItem] = array.decode()
@@ -395,7 +395,7 @@ import Testing
         }
     }
 
-    @Suite struct DictionaryInit {
+    struct DictionaryInit {
         @Test func jsonObjectIsIdentity() {
             let dict: [String: JSONValue] = ["a": .integer(1), "b": .bool(false)]
             #expect(dict.jsonObject == dict)
@@ -427,7 +427,7 @@ import Testing
         }
     }
 
-    @Suite struct Pop {
+    struct Pop {
         @Test func presentKeyReturnsValueAndRemovesIt() {
             var dict: [String: JSONValue] = ["a": .integer(1), "b": .string("x")]
             let value = dict.pop("a")
@@ -443,7 +443,7 @@ import Testing
         }
     }
 
-    @Suite struct OrNullIfEmpty {
+    struct OrNullIfEmpty {
         @Test func emptyArrayReturnsNull() {
             #expect(([] as [String]).orNullIfEmpty == .null)
         }
@@ -462,7 +462,7 @@ import Testing
         }
     }
 
-    @Suite struct RawRepresentableConformances {
+    struct RawRepresentableConformances {
         private enum Color: String, JSONValueEncodable, JSONValueDecodable {
             case red, green, blue
         }
@@ -494,7 +494,7 @@ import Testing
         }
     }
 
-    @Suite struct DateParsing {
+    struct DateParsing {
         @Test func validISO8601StringReturnsDate() {
             let date = JSONValue.string("2019-03-12T07:58:31Z").date
             #expect(date != nil)
@@ -513,7 +513,7 @@ import Testing
         }
     }
 
-    @Suite struct Serialization {
+    struct Serialization {
         private let value: JSONValue = [
             "string": "hello",
             "int": 42,
@@ -562,7 +562,7 @@ import Testing
         }
     }
 
-    @Suite struct Deserialization {
+    struct Deserialization {
         @Test func initFromValidJSONData() throws {
             let data = #"{"key": "value", "count": 3}"#.data(using: .utf8)!
             let value = try JSONValue(jsonData: data)
@@ -672,8 +672,8 @@ import Testing
         }
     }
 
-    @Suite struct ReadResultExtensions {
-        @Suite struct NonOptionalData {
+    enum ReadResultExtensions {
+        struct NonOptionalData {
             @Test func asJSONValue() {
                 let data = #"{"foo": "bar"}"#.data(using: .utf8)!
                 let result: ReadResult<Data> = .success(data)
@@ -701,7 +701,7 @@ import Testing
             }
         }
 
-        @Suite struct OptionalData {
+        struct OptionalData {
             @Test func asJSONValue() {
                 let data = #"{"foo": "bar"}"#.data(using: .utf8)!
                 let result: ReadResult<Data?> = .success(data)

--- a/Tests/SharedTests/Toolkit/URITemplateTests.swift
+++ b/Tests/SharedTests/Toolkit/URITemplateTests.swift
@@ -7,8 +7,8 @@
 @testable import ReadiumShared
 import Testing
 
-@Suite struct URITemplateTests {
-    @Suite struct Parameters {
+enum URITemplateTests {
+    struct Parameters {
         @Test func simpleVariables() {
             #expect(URITemplate("{x,hello,y}").parameters == ["x", "hello", "y"])
         }
@@ -34,8 +34,8 @@ import Testing
         }
     }
 
-    @Suite struct Expand {
-        @Suite struct SimpleString {
+    enum Expand {
+        struct SimpleString {
             @Test func multipleVariables() {
                 #expect(
                     URITemplate("/url{x,hello,y}name{z,y,w}").expand(with: [
@@ -53,7 +53,7 @@ import Testing
             }
         }
 
-        @Suite struct FormQuery {
+        struct FormQuery {
             @Test func standardExpansion() {
                 #expect(
                     URITemplate("/url{?x,hello,y}name").expand(with: [
@@ -73,7 +73,7 @@ import Testing
             }
         }
 
-        @Suite struct FormContinuation {
+        struct FormContinuation {
             @Test func standardExpansion() {
                 #expect(
                     URITemplate("{&x,y}").expand(with: ["x": "a", "y": "b"]) == "&x=a&y=b"
@@ -99,7 +99,7 @@ import Testing
             }
         }
 
-        @Suite struct General {
+        struct General {
             @Test func noVariableTemplateUnchanged() {
                 #expect(URITemplate("/path").expand(with: ["search": "banana"]) == "/path")
             }

--- a/Tests/SharedTests/Toolkit/URL/Absolute URL/FileURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/Absolute URL/FileURLTests.swift
@@ -6,234 +6,260 @@
 
 import Foundation
 @testable import ReadiumShared
-import XCTest
+import Testing
 
-class FileURLTests: XCTestCase {
-    func testEquality() throws {
-        XCTAssertEqual(
-            FileURL(string: "file:///foo/bar"),
-            FileURL(string: "file:///foo/bar")
-        )
-        // Fragments are ignored.
-        XCTAssertEqual(
-            FileURL(string: "file:///foo/bar"),
-            FileURL(string: "file:///foo/bar#fragment")
-        )
-        XCTAssertNotEqual(
-            try XCTUnwrap(FileURL(string: "file:///foo/bar")),
-            try XCTUnwrap(FileURL(string: "file:///foo/baz"))
-        )
-        XCTAssertNotEqual(
-            try XCTUnwrap(FileURL(string: "file:///foo/bar")),
-            try XCTUnwrap(FileURL(string: "file:///foo/bar/"))
-        )
+@Suite enum FileURLTests {
+    @Suite struct Equality {
+        @Test("equal URLs compare as equal, fragments are ignored")
+        func equality() throws {
+            #expect(FileURL(string: "file:///foo/bar") == FileURL(string: "file:///foo/bar"))
+            // Fragments are ignored.
+            #expect(FileURL(string: "file:///foo/bar") == FileURL(string: "file:///foo/bar#fragment"))
+            #expect(
+                try #require(FileURL(string: "file:///foo/bar"))
+                    != #require(FileURL(string: "file:///foo/baz"))
+            )
+            #expect(
+                try #require(FileURL(string: "file:///foo/bar"))
+                    != #require(FileURL(string: "file:///foo/bar/"))
+            )
+        }
     }
 
-    // MARK: - URLProtocol
+    @Suite struct URLProtocolImplementation {
+        @Test("creates from Foundation URL")
+        func createFromURL() throws {
+            #expect(try FileURL(url: #require(URL(string: "file:///foo/bar")))?.string == "file:///foo/bar")
 
-    func testCreateFromURL() throws {
-        XCTAssertEqual(try FileURL(url: XCTUnwrap(URL(string: "file:///foo/bar")))?.string, "file:///foo/bar")
+            // Only valid for scheme `file`.
+            #expect(try FileURL(url: #require(URL(string: "http://domain.com"))) == nil)
+            #expect(try FileURL(url: #require(URL(string: "opds://domain.com"))) == nil)
+        }
 
-        // Only valid for scheme `file`.
-        XCTAssertNil(try FileURL(url: XCTUnwrap(URL(string: "http://domain.com"))))
-        XCTAssertNil(try FileURL(url: XCTUnwrap(URL(string: "opds://domain.com"))))
+        @Test("creates from percent-encoded string")
+        func createFromString() {
+            #expect(FileURL(string: "file:///foo/bar")?.string == "file:///foo/bar")
+
+            // Empty
+            #expect(FileURL(string: "") == nil)
+            #expect(FileURL(string: "file://") == nil)
+            #expect(FileURL(string: "file://#fragment") == nil)
+            // Not absolute
+            #expect(FileURL(string: "path") == nil)
+            // Only valid for scheme `file`.
+            #expect(FileURL(string: "http://domain.com") == nil)
+            #expect(FileURL(string: "opds://domain.com") == nil)
+            // Query and fragment are ignored.
+            #expect(FileURL(string: "file:///foo/bar?query#fragment")?.string == "file:///foo/bar")
+            // The path is standardized.
+            #expect(FileURL(string: "file:///foo/../bar/baz")?.string == "file:///bar/baz")
+        }
+
+        @Test("creates from an absolute file system path")
+        func createFromPath() {
+            // Empty
+            #expect(FileURL(path: "/", isDirectory: false) == nil)
+            // Absolute path
+            #expect(FileURL(path: "/foo/bar", isDirectory: false)?.string == "file:///foo/bar")
+            // Relative path
+            #expect(FileURL(path: "foo/bar", isDirectory: false) == nil)
+            // Containing special characters and ..
+            #expect(FileURL(path: "/foo/../bar baz", isDirectory: false)?.string == "file:///bar%20baz")
+            #expect(FileURL(path: "/../foo", isDirectory: false)?.string == "file:///foo")
+
+            // Is directory
+            #expect(FileURL(path: "/foo/bar/", isDirectory: false)?.string == "file:///foo/bar")
+            #expect(FileURL(path: "/foo/bar", isDirectory: true)?.string == "file:///foo/bar/")
+            #expect(FileURL(path: "/foo/bar/", isDirectory: true)?.string == "file:///foo/bar/")
+        }
+
+        @Test("url property returns Foundation URL")
+        func url() {
+            #expect(FileURL(string: "file:///foo/bar")?.url == URL(string: "file:///foo/bar"))
+        }
+
+        @Test("string property returns percent-encoded string")
+        func string() {
+            #expect(FileURL(string: "file:///foo/bar")?.string == "file:///foo/bar")
+        }
+
+        @Test("path is percent-decoded")
+        func path() {
+            #expect(FileURL(string: "file:///foo/bar%20baz")?.path == "/foo/bar baz")
+            #expect(FileURL(string: "file:///foo/bar%20baz/")?.path == "/foo/bar baz/")
+        }
+
+        @Test("appendingPath appends a decoded path segment")
+        func appendingPath() throws {
+            var base = try #require(FileURL(string: "file:///foo/bar"))
+            #expect(base.appendingPath("", isDirectory: false).string == "file:///foo/bar")
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "file:///foo/bar/baz/quz")
+            #expect(base.appendingPath("/baz/quz", isDirectory: false).string == "file:///foo/bar/baz/quz")
+            // The path is supposed to be decoded
+            #expect(base.appendingPath("baz quz", isDirectory: false).string == "file:///foo/bar/baz%20quz")
+            #expect(base.appendingPath("baz%20quz", isDirectory: false).string == "file:///foo/bar/baz%2520quz")
+            // Directory
+            #expect(base.appendingPath("baz/quz", isDirectory: true).string == "file:///foo/bar/baz/quz/")
+            #expect(base.appendingPath("baz/quz/", isDirectory: true).string == "file:///foo/bar/baz/quz/")
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "file:///foo/bar/baz/quz")
+            #expect(base.appendingPath("baz/quz/", isDirectory: false).string == "file:///foo/bar/baz/quz")
+
+            // With trailing slash.
+            base = try #require(FileURL(string: "file:///foo/bar/"))
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "file:///foo/bar/baz/quz")
+        }
+
+        @Test("pathSegments returns percent-decoded segments")
+        func pathSegments() {
+            #expect(FileURL(string: "file:///foo")?.pathSegments == ["foo"])
+            #expect(FileURL(string: "file:///foo/bar%20baz")?.pathSegments == ["foo", "bar baz"])
+            #expect(FileURL(string: "file:///foo/bar%20baz/")?.pathSegments == ["foo", "bar baz"])
+            #expect(FileURL(string: "file:///foo/bar?query#fragment")?.pathSegments == ["foo", "bar"])
+        }
+
+        @Test("lastPathSegment returns the last decoded segment")
+        func lastPathSegment() {
+            #expect(FileURL(string: "file:///foo/bar%20baz")?.lastPathSegment == "bar baz")
+            #expect(FileURL(string: "file:///foo/bar%20baz/")?.lastPathSegment == "bar baz")
+            #expect(FileURL(string: "file:///foo/bar?query#fragment")?.lastPathSegment == "bar")
+        }
+
+        @Test("removingLastPathSegment removes the last path segment")
+        func removingLastPathSegment() {
+            #expect(FileURL(string: "file:///")?.removingLastPathSegment().string == "file:///")
+            #expect(FileURL(string: "file:///foo")?.removingLastPathSegment().string == "file:///")
+            #expect(FileURL(string: "file:///foo/bar")?.removingLastPathSegment().string == "file:///foo/")
+        }
+
+        @Test("pathExtension returns the file extension")
+        func pathExtension() {
+            #expect(FileURL(string: "file:///foo/bar.txt")?.pathExtension == "txt")
+            #expect(FileURL(string: "file:///foo/bar")?.pathExtension == nil)
+            #expect(FileURL(string: "file:///foo/bar/")?.pathExtension == nil)
+            #expect(FileURL(string: "file:///foo/.hidden")?.pathExtension == nil)
+        }
+
+        @Test("replacingPathExtension replaces or removes the file extension")
+        func replacingPathExtension() {
+            #expect(FileURL(string: "file:///foo/bar")?.replacingPathExtension("xml").string == "file:///foo/bar.xml")
+            #expect(FileURL(string: "file:///foo/bar.txt")?.replacingPathExtension("xml").string == "file:///foo/bar.xml")
+            #expect(FileURL(string: "file:///foo/bar.txt")?.replacingPathExtension(nil).string == "file:///foo/bar")
+            #expect(FileURL(string: "file:///foo/bar/")?.replacingPathExtension("xml").string == "file:///foo/bar/")
+            #expect(FileURL(string: "file:///foo/bar/")?.replacingPathExtension(nil).string == "file:///foo/bar/")
+        }
+
+        @Test("query is always nil for file URLs")
+        func query() {
+            #expect(FileURL(string: "file:///foo/bar")?.query == nil)
+            #expect(FileURL(string: "file:///foo/bar?param=quz%20baz")?.query == nil)
+        }
+
+        @Test("removingQuery is a no-op for file URLs")
+        func removingQuery() {
+            #expect(FileURL(string: "file:///foo/bar")?.removingQuery() == FileURL(string: "file:///foo/bar"))
+            #expect(FileURL(string: "file:///foo/bar?param=quz%20baz")?.removingQuery() == FileURL(string: "file:///foo/bar"))
+        }
+
+        @Test("fragment is always nil for file URLs")
+        func fragment() {
+            // No fragment for a file URL.
+            #expect(FileURL(string: "file:///foo/bar")?.fragment == nil)
+            #expect(FileURL(string: "file:///foo/bar#quz%20baz")?.fragment == nil)
+        }
+
+        @Test("removingFragment is a no-op for file URLs")
+        func removingFragment() {
+            #expect(FileURL(string: "file:///foo/bar")?.removingFragment() == FileURL(string: "file:///foo/bar"))
+            #expect(FileURL(string: "file:///foo/bar#quz%20baz")?.removingFragment() == FileURL(string: "file:///foo/bar"))
+        }
+
+        @Test("replacingFragment has no effect since file URLs always strip fragments")
+        func replacingFragment() {
+            // FileURL strips fragments on creation, so replacingFragment has no visible effect.
+            #expect(FileURL(string: "file:///foo/bar")?.replacingFragment("baz").string == "file:///foo/bar")
+            #expect(FileURL(string: "file:///foo/bar#old")?.replacingFragment("new").string == "file:///foo/bar")
+            #expect(FileURL(string: "file:///foo/bar#quz%20baz")?.replacingFragment(nil) == FileURL(string: "file:///foo/bar"))
+        }
     }
 
-    func testCreateFromString() {
-        XCTAssertEqual(FileURL(string: "file:///foo/bar")?.string, "file:///foo/bar")
+    @Suite struct AbsoluteURLImplementation {
+        @Test("scheme is normalized to lowercase")
+        func scheme() {
+            #expect(FileURL(string: "file:///foo/bar")?.scheme == .file)
+            #expect(FileURL(string: "FILE:///foo/bar")?.scheme == .file)
+        }
 
-        // Empty
-        XCTAssertNil(FileURL(string: ""))
-        XCTAssertNil(FileURL(string: "file://"))
-        XCTAssertNil(FileURL(string: "file://#fragment"))
-        // Not absolute
-        XCTAssertNil(FileURL(string: "path"))
-        // Only valid for scheme `file`.
-        XCTAssertNil(FileURL(string: "http://domain.com"))
-        XCTAssertNil(FileURL(string: "opds://domain.com"))
-        // Query and fragment are ignored.
-        XCTAssertEqual(FileURL(string: "file:///foo/bar?query#fragment")?.string, "file:///foo/bar")
-        // The path is standardized.
-        XCTAssertEqual(FileURL(string: "file:///foo/../bar/baz")?.string, "file:///bar/baz")
-    }
+        @Test("host is always nil for file URLs")
+        func host() {
+            #expect(FileURL(string: "file:///foo/bar")?.host == nil)
+        }
 
-    func testCreateFromPath() {
-        // Empty
-        XCTAssertNil(FileURL(path: "/", isDirectory: false))
-        // Absolute path
-        XCTAssertEqual(FileURL(path: "/foo/bar", isDirectory: false)?.string, "file:///foo/bar")
-        // Relative path
-        XCTAssertNil(FileURL(path: "foo/bar", isDirectory: false))
-        // Containing special characters and ..
-        XCTAssertEqual(FileURL(path: "/foo/../bar baz", isDirectory: false)?.string, "file:///bar%20baz")
-        XCTAssertEqual(FileURL(path: "/../foo", isDirectory: false)?.string, "file:///foo")
+        @Test("origin is always nil for file URLs")
+        func origin() {
+            #expect(FileURL(string: "file:///foo/bar")?.origin == nil)
+        }
 
-        // Is directory
-        XCTAssertEqual(FileURL(path: "/foo/bar/", isDirectory: false)?.string, "file:///foo/bar")
-        XCTAssertEqual(FileURL(path: "/foo/bar", isDirectory: true)?.string, "file:///foo/bar/")
-        XCTAssertEqual(FileURL(path: "/foo/bar/", isDirectory: true)?.string, "file:///foo/bar/")
-    }
+        @Test("resolves absolute URL as-is")
+        func resolveAbsoluteURL() throws {
+            let base = try #require(FileURL(string: "file:///foo/bar"))
+            #expect(try base.resolve(#require(FileURL(string: "file:///foo")))?.string == "file:///foo")
+            #expect(try base.resolve(#require(HTTPURL(string: "http://domain.com")))?.string == "http://domain.com")
+            #expect(try base.resolve(#require(UnknownAbsoluteURL(string: "opds://other")))?.string == "opds://other")
+        }
 
-    func testURL() {
-        XCTAssertEqual(FileURL(string: "file:///foo/bar")?.url, URL(string: "file:///foo/bar"))
-    }
+        @Test("resolves relative URL against this base")
+        func resolveRelativeURL() throws {
+            var base = try #require(FileURL(string: "file:///foo/bar"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == FileURL(string: "file:///foo/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "../quz/baz"))) == FileURL(string: "file:///quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "/quz/baz"))) == FileURL(string: "file:///quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "#fragment"))) == FileURL(string: "file:///foo/bar#fragment"))
 
-    func testString() {
-        XCTAssertEqual(FileURL(string: "file:///foo/bar")?.string, "file:///foo/bar")
-    }
+            // With trailing slash
+            base = try #require(FileURL(string: "file:///foo/bar/"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == FileURL(string: "file:///foo/bar/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "../quz/baz"))) == FileURL(string: "file:///foo/quz/baz"))
+        }
 
-    func testPath() {
-        // Path is percent-decoded.
-        XCTAssertEqual(FileURL(string: "file:///foo/bar%20baz")?.path, "/foo/bar baz")
-        XCTAssertEqual(FileURL(string: "file:///foo/bar%20baz/")?.path, "/foo/bar baz/")
-    }
+        @Test("relativizes a URL against this base")
+        func relativize() throws {
+            var base = try #require(FileURL(string: "file:///foo"))
+            #expect(try base.relativize(#require(AnyURL(string: "file:///foo"))) == nil)
+            #expect(try base.relativize(#require(AnyURL(string: "file:///foo/quz/baz"))) == RelativeURL(string: "quz/baz"))
+            #expect(try base.relativize(#require(AnyURL(string: "file:///quz/baz"))) == nil)
 
-    func testAppendingPath() throws {
-        var base = try XCTUnwrap(FileURL(string: "file:///foo/bar"))
-        XCTAssertEqual(base.appendingPath("", isDirectory: false).string, "file:///foo/bar")
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "file:///foo/bar/baz/quz")
-        XCTAssertEqual(base.appendingPath("/baz/quz", isDirectory: false).string, "file:///foo/bar/baz/quz")
-        // The path is supposed to be decoded
-        XCTAssertEqual(base.appendingPath("baz quz", isDirectory: false).string, "file:///foo/bar/baz%20quz")
-        XCTAssertEqual(base.appendingPath("baz%20quz", isDirectory: false).string, "file:///foo/bar/baz%2520quz")
-        // Directory
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: true).string, "file:///foo/bar/baz/quz/")
-        XCTAssertEqual(base.appendingPath("baz/quz/", isDirectory: true).string, "file:///foo/bar/baz/quz/")
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "file:///foo/bar/baz/quz")
-        XCTAssertEqual(base.appendingPath("baz/quz/", isDirectory: false).string, "file:///foo/bar/baz/quz")
+            // With trailing slash
+            base = try #require(FileURL(string: "file:///foo/"))
+            #expect(try base.relativize(#require(AnyURL(string: "file:///foo/quz/baz"))) == RelativeURL(string: "quz/baz"))
+        }
 
-        // With trailing slash.
-        base = try XCTUnwrap(FileURL(string: "file:///foo/bar/"))
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "file:///foo/bar/baz/quz")
-    }
+        @Test("relative URL returns nil when relativized against a file base")
+        func relativizeRelativeURL() throws {
+            let base = try #require(FileURL(string: "file:///foo"))
+            #expect(try base.relativize(#require(RelativeURL(string: "foo/bar"))) == nil)
+        }
 
-    func testPathSegments() {
-        XCTAssertEqual(FileURL(string: "file:///foo")?.pathSegments, ["foo"])
-        XCTAssertEqual(FileURL(string: "file:///foo/bar%20baz")?.pathSegments, ["foo", "bar baz"])
-        XCTAssertEqual(FileURL(string: "file:///foo/bar%20baz/")?.pathSegments, ["foo", "bar baz"])
-        XCTAssertEqual(FileURL(string: "file:///foo/bar?query#fragment")?.pathSegments, ["foo", "bar"])
-    }
+        @Test("URL with different scheme returns nil when relativized")
+        func relativizeAbsoluteURLWithDifferentScheme() throws {
+            let base = try #require(FileURL(string: "file:///foo"))
+            #expect(try base.relativize(#require(HTTPURL(string: "https://host/foo/bar"))) == nil)
+            #expect(try base.relativize(#require(UnknownAbsoluteURL(string: "opds://host/foo/bar"))) == nil)
+        }
 
-    func testLastPathSegment() {
-        XCTAssertEqual(FileURL(string: "file:///foo/bar%20baz")?.lastPathSegment, "bar baz")
-        XCTAssertEqual(FileURL(string: "file:///foo/bar%20baz/")?.lastPathSegment, "bar baz")
-        XCTAssertEqual(FileURL(string: "file:///foo/bar?query#fragment")?.lastPathSegment, "bar")
-    }
+        @Test("isRelative is true for same scheme")
+        func isRelative() throws {
+            // Always relative if same scheme.
+            let url = try #require(FileURL(string: "file:///foo/bar"))
+            #expect(try url.isRelative(to: #require(FileURL(string: "file:///foo"))))
+            #expect(try url.isRelative(to: #require(FileURL(string: "file:///foo/bar"))))
+            #expect(try url.isRelative(to: #require(FileURL(string: "file:///foo/bar/baz"))))
+            #expect(try url.isRelative(to: #require(FileURL(string: "file:///bar"))))
 
-    func testRemovingLastPathSegment() {
-        XCTAssertEqual(FileURL(string: "file:///")?.removingLastPathSegment().string, "file:///")
-        XCTAssertEqual(FileURL(string: "file:///foo")?.removingLastPathSegment().string, "file:///")
-        XCTAssertEqual(FileURL(string: "file:///foo/bar")?.removingLastPathSegment().string, "file:///foo/")
-    }
-
-    func testPathExtension() {
-        XCTAssertEqual(FileURL(string: "file:///foo/bar.txt")?.pathExtension, "txt")
-        XCTAssertNil(FileURL(string: "file:///foo/bar")?.pathExtension)
-        XCTAssertNil(FileURL(string: "file:///foo/bar/")?.pathExtension)
-        XCTAssertNil(FileURL(string: "file:///foo/.hidden")?.pathExtension)
-    }
-
-    func testReplacingPathExtension() {
-        XCTAssertEqual(FileURL(string: "file:///foo/bar")?.replacingPathExtension("xml").string, "file:///foo/bar.xml")
-        XCTAssertEqual(FileURL(string: "file:///foo/bar.txt")?.replacingPathExtension("xml").string, "file:///foo/bar.xml")
-        XCTAssertEqual(FileURL(string: "file:///foo/bar.txt")?.replacingPathExtension(nil).string, "file:///foo/bar")
-        XCTAssertEqual(FileURL(string: "file:///foo/bar/")?.replacingPathExtension("xml").string, "file:///foo/bar/")
-        XCTAssertEqual(FileURL(string: "file:///foo/bar/")?.replacingPathExtension(nil).string, "file:///foo/bar/")
-    }
-
-    func testQuery() {
-        // No query for a file URL.
-        XCTAssertNil(FileURL(string: "file:///foo/bar")?.query)
-        XCTAssertNil(FileURL(string: "file:///foo/bar?param=quz%20baz")?.query)
-    }
-
-    func testRemovingQuery() {
-        XCTAssertEqual(FileURL(string: "file:///foo/bar")?.removingQuery(), FileURL(string: "file:///foo/bar"))
-        XCTAssertEqual(FileURL(string: "file:///foo/bar?param=quz%20baz")?.removingQuery(), FileURL(string: "file:///foo/bar"))
-    }
-
-    func testFragment() {
-        // No fragment for a file URL.
-        XCTAssertNil(FileURL(string: "file:///foo/bar")?.fragment)
-        XCTAssertNil(FileURL(string: "file:///foo/bar#quz%20baz")?.fragment)
-    }
-
-    func testRemovingFragment() {
-        XCTAssertEqual(FileURL(string: "file:///foo/bar")?.removingFragment(), FileURL(string: "file:///foo/bar"))
-        XCTAssertEqual(FileURL(string: "file:///foo/bar#quz%20baz")?.removingFragment(), FileURL(string: "file:///foo/bar"))
-    }
-
-    // MARK: - AbsoluteURL
-
-    func testScheme() {
-        XCTAssertEqual(FileURL(string: "file:///foo/bar")?.scheme, .file)
-        XCTAssertEqual(FileURL(string: "FILE:///foo/bar")?.scheme, .file)
-    }
-
-    func testHost() {
-        XCTAssertNil(FileURL(string: "file:///foo/bar")?.host)
-    }
-
-    func testOrigin() {
-        // Always null for a file URL.
-        XCTAssertNil(FileURL(string: "file:///foo/bar")?.origin)
-    }
-
-    func testResolveAbsoluteURL() throws {
-        let base = try XCTUnwrap(FileURL(string: "file:///foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(FileURL(string: "file:///foo")))?.string, "file:///foo")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(HTTPURL(string: "http://domain.com")))?.string, "http://domain.com")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(UnknownAbsoluteURL(string: "opds://other")))?.string, "opds://other")
-    }
-
-    func testResolveRelativeURL() throws {
-        var base = try XCTUnwrap(FileURL(string: "file:///foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), FileURL(string: "file:///foo/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "../quz/baz"))), FileURL(string: "file:///quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "/quz/baz"))), FileURL(string: "file:///quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "#fragment"))), FileURL(string: "file:///foo/bar#fragment"))
-
-        // With trailing slash
-        base = try XCTUnwrap(FileURL(string: "file:///foo/bar/"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), FileURL(string: "file:///foo/bar/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "../quz/baz"))), FileURL(string: "file:///foo/quz/baz"))
-    }
-
-    func testRelativize() throws {
-        var base = try XCTUnwrap(FileURL(string: "file:///foo"))
-
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "file:///foo"))))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "file:///foo/quz/baz"))), RelativeURL(string: "quz/baz"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "file:///quz/baz"))))
-
-        // With trailing slash
-        base = try XCTUnwrap(FileURL(string: "file:///foo/"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "file:///foo/quz/baz"))), RelativeURL(string: "quz/baz"))
-    }
-
-    func testRelativizeRelativeURL() throws {
-        let base = try XCTUnwrap(FileURL(string: "file:///foo"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(RelativeURL(string: "foo/bar"))))
-    }
-
-    func testRelativizeAbsoluteURLWithDifferentScheme() throws {
-        let base = try XCTUnwrap(FileURL(string: "file:///foo"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(HTTPURL(string: "https://host/foo/bar"))))
-        XCTAssertNil(try base.relativize(XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo/bar"))))
-    }
-
-    func testIsRelative() throws {
-        // Always relative if same scheme.
-        let url = try XCTUnwrap(FileURL(string: "file:///foo/bar"))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(FileURL(string: "file:///foo"))))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(FileURL(string: "file:///foo/bar"))))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(FileURL(string: "file:///foo/bar/baz"))))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(FileURL(string: "file:///bar"))))
-
-        // Different scheme
-        XCTAssertFalse(try url.isRelative(to: XCTUnwrap(UnknownAbsoluteURL(string: "other://host/foo"))))
-        XCTAssertFalse(try url.isRelative(to: XCTUnwrap(HTTPURL(string: "http://foo"))))
-        // Relative path
-        XCTAssertFalse(try url.isRelative(to: XCTUnwrap(RelativeURL(path: "foo/bar"))))
+            // Different scheme
+            #expect(try !url.isRelative(to: #require(UnknownAbsoluteURL(string: "other://host/foo"))))
+            #expect(try !url.isRelative(to: #require(HTTPURL(string: "http://foo"))))
+            // Relative path
+            #expect(try !url.isRelative(to: #require(RelativeURL(path: "foo/bar"))))
+        }
     }
 }

--- a/Tests/SharedTests/Toolkit/URL/Absolute URL/FileURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/Absolute URL/FileURLTests.swift
@@ -8,8 +8,8 @@ import Foundation
 @testable import ReadiumShared
 import Testing
 
-@Suite enum FileURLTests {
-    @Suite struct Equality {
+enum FileURLTests {
+    struct Equality {
         @Test("equal URLs compare as equal, fragments are ignored")
         func equality() throws {
             #expect(FileURL(string: "file:///foo/bar") == FileURL(string: "file:///foo/bar"))
@@ -26,7 +26,7 @@ import Testing
         }
     }
 
-    @Suite struct URLProtocolImplementation {
+    struct URLProtocolImplementation {
         @Test("creates from Foundation URL")
         func createFromURL() throws {
             #expect(try FileURL(url: #require(URL(string: "file:///foo/bar")))?.string == "file:///foo/bar")
@@ -182,7 +182,7 @@ import Testing
         }
     }
 
-    @Suite struct AbsoluteURLImplementation {
+    struct AbsoluteURLImplementation {
         @Test("scheme is normalized to lowercase")
         func scheme() {
             #expect(FileURL(string: "file:///foo/bar")?.scheme == .file)

--- a/Tests/SharedTests/Toolkit/URL/Absolute URL/HTTPURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/Absolute URL/HTTPURLTests.swift
@@ -6,222 +6,255 @@
 
 import Foundation
 @testable import ReadiumShared
-import XCTest
+import Testing
 
-class HTTPURLTests: XCTestCase {
-    func testEquality() throws {
-        XCTAssertEqual(
-            HTTPURL(string: "http://domain.com"),
-            HTTPURL(string: "http://domain.com")
-        )
-        XCTAssertNotEqual(
-            try XCTUnwrap(HTTPURL(string: "http://domain.com")),
-            try XCTUnwrap(HTTPURL(string: "http://domain.com#fragment"))
-        )
+@Suite enum HTTPURLTests {
+    @Suite struct Equality {
+        @Test("equal URLs compare as equal, fragments are significant")
+        func equality() throws {
+            #expect(HTTPURL(string: "http://domain.com") == HTTPURL(string: "http://domain.com"))
+            #expect(
+                try #require(HTTPURL(string: "http://domain.com"))
+                    != #require(HTTPURL(string: "http://domain.com#fragment"))
+            )
+        }
     }
 
-    // MARK: - URLProtocol
+    @Suite struct URLProtocolImplementation {
+        @Test("creates from Foundation URL")
+        func createFromURL() throws {
+            #expect(try HTTPURL(url: #require(URL(string: "http://domain.com")))?.string == "http://domain.com")
+            #expect(try HTTPURL(url: #require(URL(string: "https://domain.com")))?.string == "https://domain.com")
 
-    func testCreateFromURL() throws {
-        XCTAssertEqual(try HTTPURL(url: XCTUnwrap(URL(string: "http://domain.com")))?.string, "http://domain.com")
-        XCTAssertEqual(try HTTPURL(url: XCTUnwrap(URL(string: "https://domain.com")))?.string, "https://domain.com")
+            // Only valid for schemes `http` or `https`.
+            #expect(try HTTPURL(url: #require(URL(string: "file://domain.com"))) == nil)
+            #expect(try HTTPURL(url: #require(URL(string: "opds://domain.com"))) == nil)
+        }
 
-        // Only valid for schemes `http` or `https`.
-        XCTAssertNil(try HTTPURL(url: XCTUnwrap(URL(string: "file://domain.com"))))
-        XCTAssertNil(try HTTPURL(url: XCTUnwrap(URL(string: "opds://domain.com"))))
+        @Test("creates from percent-encoded string")
+        func createFromString() {
+            #expect(HTTPURL(string: "http://domain.com")?.string == "http://domain.com")
+
+            // Empty
+            #expect(HTTPURL(string: "")?.string == nil)
+            // Not absolute
+            #expect(HTTPURL(string: "path") == nil)
+            // Only valid for schemes `http` or `https`.
+            #expect(HTTPURL(string: "file://domain.com") == nil)
+            #expect(HTTPURL(string: "opds://domain.com") == nil)
+        }
+
+        @Test("url property returns Foundation URL")
+        func url() {
+            #expect(HTTPURL(string: "http://foo/bar?query#fragment")?.url == URL(string: "http://foo/bar?query#fragment"))
+        }
+
+        @Test("string property returns percent-encoded string")
+        func string() {
+            #expect(HTTPURL(string: "http://foo/bar?query#fragment")?.string == "http://foo/bar?query#fragment")
+        }
+
+        @Test("path is percent-decoded")
+        func path() {
+            #expect(HTTPURL(string: "http://host/foo/bar%20baz")?.path == "/foo/bar baz")
+            #expect(HTTPURL(string: "http://host/foo/bar%20baz/")?.path == "/foo/bar baz/")
+            #expect(HTTPURL(string: "http://host/foo/bar?query#fragment")?.path == "/foo/bar")
+            #expect(HTTPURL(string: "http://host#fragment")?.path == "")
+            #expect(HTTPURL(string: "http://host?query")?.path == "")
+        }
+
+        @Test("appendingPath appends a decoded path segment")
+        func appendingPath() throws {
+            var base = try #require(HTTPURL(string: "http://foo/bar"))
+            #expect(base.appendingPath("", isDirectory: false).string == "http://foo/bar")
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "http://foo/bar/baz/quz")
+            #expect(base.appendingPath("/baz/quz", isDirectory: false).string == "http://foo/bar/baz/quz")
+            // The path is supposed to be decoded
+            #expect(base.appendingPath("baz quz", isDirectory: false).string == "http://foo/bar/baz%20quz")
+            #expect(base.appendingPath("baz%20quz", isDirectory: false).string == "http://foo/bar/baz%2520quz")
+            // Directory
+            #expect(base.appendingPath("baz/quz", isDirectory: true).string == "http://foo/bar/baz/quz/")
+            #expect(base.appendingPath("baz/quz/", isDirectory: true).string == "http://foo/bar/baz/quz/")
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "http://foo/bar/baz/quz")
+            #expect(base.appendingPath("baz/quz/", isDirectory: false).string == "http://foo/bar/baz/quz")
+
+            // With trailing slash.
+            base = try #require(HTTPURL(string: "http://foo/bar/"))
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "http://foo/bar/baz/quz")
+        }
+
+        @Test("pathSegments returns percent-decoded segments")
+        func pathSegments() {
+            #expect(HTTPURL(string: "http://host/foo")?.pathSegments == ["foo"])
+            // Segments are percent-decoded.
+            #expect(HTTPURL(string: "http://host/foo/bar%20baz")?.pathSegments == ["foo", "bar baz"])
+            #expect(HTTPURL(string: "http://host/foo/bar%20baz/")?.pathSegments == ["foo", "bar baz"])
+            #expect(HTTPURL(string: "http://host/foo/bar?query#fragment")?.pathSegments == ["foo", "bar"])
+            #expect(HTTPURL(string: "http://host#fragment")?.pathSegments == [])
+            #expect(HTTPURL(string: "http://host?query")?.pathSegments == [])
+        }
+
+        @Test("lastPathSegment returns the last decoded segment")
+        func lastPathSegment() {
+            #expect(HTTPURL(string: "http://foo/bar%20baz")?.lastPathSegment == "bar baz")
+            #expect(HTTPURL(string: "http://foo/bar%20baz/")?.lastPathSegment == "bar baz")
+            #expect(HTTPURL(string: "http://foo/bar?query#fragment")?.lastPathSegment == "bar")
+            #expect(HTTPURL(string: "http://#fragment")?.lastPathSegment == nil)
+            #expect(HTTPURL(string: "http://?query")?.lastPathSegment == nil)
+        }
+
+        @Test("removingLastPathSegment removes the last path segment")
+        func removingLastPathSegment() {
+            #expect(HTTPURL(string: "http://")?.removingLastPathSegment().string == "http://")
+            #expect(HTTPURL(string: "http://foo")?.removingLastPathSegment().string == "http://foo")
+            #expect(HTTPURL(string: "http://foo/bar")?.removingLastPathSegment().string == "http://foo/")
+            #expect(HTTPURL(string: "http://foo/bar/baz")?.removingLastPathSegment().string == "http://foo/bar/")
+        }
+
+        @Test("pathExtension returns the file extension")
+        func pathExtension() {
+            #expect(HTTPURL(string: "http://foo/bar.txt")?.pathExtension == "txt")
+            #expect(HTTPURL(string: "http://foo/bar")?.pathExtension == nil)
+            #expect(HTTPURL(string: "http://foo/bar/")?.pathExtension == nil)
+            #expect(HTTPURL(string: "http://foo/.hidden")?.pathExtension == nil)
+        }
+
+        @Test("replacingPathExtension replaces or removes the file extension")
+        func replacingPathExtension() {
+            #expect(HTTPURL(string: "http://foo/bar")?.replacingPathExtension("xml").string == "http://foo/bar.xml")
+            #expect(HTTPURL(string: "http://foo/bar.txt")?.replacingPathExtension("xml").string == "http://foo/bar.xml")
+            #expect(HTTPURL(string: "http://foo/bar.txt")?.replacingPathExtension(nil).string == "http://foo/bar")
+            #expect(HTTPURL(string: "http://foo/bar/")?.replacingPathExtension("xml").string == "http://foo/bar/")
+            #expect(HTTPURL(string: "http://foo/bar/")?.replacingPathExtension(nil).string == "http://foo/bar/")
+            #expect(HTTPURL(string: "http://foo")?.replacingPathExtension("xml").string == "http://foo")
+        }
+
+        @Test("query returns parsed query parameters")
+        func query() {
+            #expect(HTTPURL(string: "http://foo/bar")?.query == nil)
+            #expect(
+                HTTPURL(string: "http://foo/bar?param=quz%20baz")?.query
+                    == URLQuery(parameters: [.init(name: "param", value: "quz baz")])
+            )
+        }
+
+        @Test("removingQuery removes the query component")
+        func removingQuery() {
+            #expect(HTTPURL(string: "http://foo/bar")?.removingQuery() == HTTPURL(string: "http://foo/bar"))
+            #expect(HTTPURL(string: "http://foo/bar?param=quz%20baz")?.removingQuery() == HTTPURL(string: "http://foo/bar"))
+        }
+
+        @Test("fragment is percent-decoded")
+        func fragment() {
+            #expect(HTTPURL(string: "http://foo/bar")?.fragment == nil)
+            #expect(HTTPURL(string: "http://foo/bar#quz%20baz")?.fragment == "quz baz")
+        }
+
+        @Test("removingFragment removes the fragment component")
+        func removingFragment() {
+            #expect(HTTPURL(string: "http://foo/bar")?.removingFragment() == HTTPURL(string: "http://foo/bar"))
+            #expect(HTTPURL(string: "http://foo/bar#quz%20baz")?.removingFragment() == HTTPURL(string: "http://foo/bar"))
+        }
+
+        @Test("replacingFragment sets or removes the fragment")
+        func replacingFragment() {
+            // Sets fragment on URL without one.
+            #expect(HTTPURL(string: "http://foo/bar")?.replacingFragment("baz").string == "http://foo/bar#baz")
+            // Replaces existing fragment.
+            #expect(HTTPURL(string: "http://foo/bar#old")?.replacingFragment("new").string == "http://foo/bar#new")
+            // Removing via nil matches removingFragment().
+            #expect(HTTPURL(string: "http://foo/bar#quz%20baz")?.replacingFragment(nil) == HTTPURL(string: "http://foo/bar"))
+            // Fragment is percent-encoded.
+            #expect(HTTPURL(string: "http://foo/bar")?.replacingFragment("quz baz").string == "http://foo/bar#quz%20baz")
+        }
     }
 
-    func testCreateFromString() {
-        XCTAssertEqual(HTTPURL(string: "http://domain.com")?.string, "http://domain.com")
+    @Suite struct AbsoluteURLImplementation {
+        @Test("scheme is normalized to lowercase")
+        func scheme() {
+            #expect(HTTPURL(string: "http://foo/bar")?.scheme == .http)
+            #expect(HTTPURL(string: "HTTP://foo/bar")?.scheme == .http)
+            #expect(HTTPURL(string: "https://foo/bar")?.scheme == .https)
+        }
 
-        // Empty
-        XCTAssertNil(HTTPURL(string: "")?.string)
-        // Not absolute
-        XCTAssertNil(HTTPURL(string: "path"))
-        // Only valid for schemes `http` or `https`.
-        XCTAssertNil(HTTPURL(string: "file://domain.com"))
-        XCTAssertNil(HTTPURL(string: "opds://domain.com"))
-    }
+        @Test("host returns the hostname component")
+        func host() {
+            #expect(HTTPURL(string: "http://")?.host == nil)
+            #expect(HTTPURL(string: "http:///")?.host == nil)
+            #expect(HTTPURL(string: "http://domain")?.host == "domain")
+            #expect(HTTPURL(string: "http://domain/path")?.host == "domain")
+        }
 
-    func testURL() {
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar?query#fragment")?.url, URL(string: "http://foo/bar?query#fragment"))
-    }
+        @Test("origin returns scheme and host")
+        func origin() {
+            #expect(HTTPURL(string: "HTTP://foo/bar")?.origin == "http://foo")
+            #expect(HTTPURL(string: "https://foo:443/bar")?.origin == "https://foo:443")
+        }
 
-    func testString() {
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar?query#fragment")?.string, "http://foo/bar?query#fragment")
-    }
+        @Test("resolves absolute URL as-is")
+        func resolveAbsoluteURL() throws {
+            let base = try #require(HTTPURL(string: "http://host/foo/bar"))
+            #expect(try base.resolve(#require(HTTPURL(string: "http://domain.com")))?.string == "http://domain.com")
+            #expect(try base.resolve(#require(UnknownAbsoluteURL(string: "opds://other")))?.string == "opds://other")
+            #expect(try base.resolve(#require(FileURL(string: "file:///foo")))?.string == "file:///foo")
+        }
 
-    func testPath() {
-        // Path is percent-decoded.
-        XCTAssertEqual(HTTPURL(string: "http://host/foo/bar%20baz")?.path, "/foo/bar baz")
-        XCTAssertEqual(HTTPURL(string: "http://host/foo/bar%20baz/")?.path, "/foo/bar baz/")
-        XCTAssertEqual(HTTPURL(string: "http://host/foo/bar?query#fragment")?.path, "/foo/bar")
-        XCTAssertEqual(HTTPURL(string: "http://host#fragment")?.path, "")
-        XCTAssertEqual(HTTPURL(string: "http://host?query")?.path, "")
-    }
+        @Test("resolves relative URL against this base")
+        func resolveRelativeURL() throws {
+            var base = try #require(HTTPURL(string: "http://host/foo/bar"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == HTTPURL(string: "http://host/foo/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "../quz/baz"))) == HTTPURL(string: "http://host/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "/quz/baz"))) == HTTPURL(string: "http://host/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "#fragment"))) == HTTPURL(string: "http://host/foo/bar#fragment"))
 
-    func testAppendingPath() throws {
-        var base = try XCTUnwrap(HTTPURL(string: "http://foo/bar"))
-        XCTAssertEqual(base.appendingPath("", isDirectory: false).string, "http://foo/bar")
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "http://foo/bar/baz/quz")
-        XCTAssertEqual(base.appendingPath("/baz/quz", isDirectory: false).string, "http://foo/bar/baz/quz")
-        // The path is supposed to be decoded
-        XCTAssertEqual(base.appendingPath("baz quz", isDirectory: false).string, "http://foo/bar/baz%20quz")
-        XCTAssertEqual(base.appendingPath("baz%20quz", isDirectory: false).string, "http://foo/bar/baz%2520quz")
-        // Directory
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: true).string, "http://foo/bar/baz/quz/")
-        XCTAssertEqual(base.appendingPath("baz/quz/", isDirectory: true).string, "http://foo/bar/baz/quz/")
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "http://foo/bar/baz/quz")
-        XCTAssertEqual(base.appendingPath("baz/quz/", isDirectory: false).string, "http://foo/bar/baz/quz")
+            // With trailing slash
+            base = try #require(HTTPURL(string: "http://host/foo/bar/"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == HTTPURL(string: "http://host/foo/bar/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "../quz/baz"))) == HTTPURL(string: "http://host/foo/quz/baz"))
+        }
 
-        // With trailing slash.
-        base = try XCTUnwrap(HTTPURL(string: "http://foo/bar/"))
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "http://foo/bar/baz/quz")
-    }
+        @Test("relativizes a URL against this base")
+        func relativize() throws {
+            var base = try #require(HTTPURL(string: "http://host/foo"))
+            #expect(try base.relativize(#require(AnyURL(string: "http://host/foo"))) == nil)
+            #expect(try base.relativize(#require(AnyURL(string: "http://host/foo/quz/baz"))) == RelativeURL(string: "quz/baz"))
+            #expect(try base.relativize(#require(AnyURL(string: "http://host/foo#fragment"))) == RelativeURL(string: "#fragment"))
+            #expect(try base.relativize(#require(AnyURL(string: "http://host/quz/baz"))) == nil)
+            #expect(try base.relativize(#require(AnyURL(string: "http://host//foo/bar"))) == nil)
 
-    func testPathSegments() {
-        XCTAssertEqual(HTTPURL(string: "http://host/foo")?.pathSegments, ["foo"])
-        // Segments are percent-decoded.
-        XCTAssertEqual(HTTPURL(string: "http://host/foo/bar%20baz")?.pathSegments, ["foo", "bar baz"])
-        XCTAssertEqual(HTTPURL(string: "http://host/foo/bar%20baz/")?.pathSegments, ["foo", "bar baz"])
-        XCTAssertEqual(HTTPURL(string: "http://host/foo/bar?query#fragment")?.pathSegments, ["foo", "bar"])
-        XCTAssertEqual(HTTPURL(string: "http://host#fragment")?.pathSegments, [])
-        XCTAssertEqual(HTTPURL(string: "http://host?query")?.pathSegments, [])
-    }
+            // With trailing slash
+            base = try #require(HTTPURL(string: "http://host/foo/"))
+            #expect(try base.relativize(#require(AnyURL(string: "http://host/foo/quz/baz"))) == RelativeURL(string: "quz/baz"))
+        }
 
-    func testLastPathSegment() {
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar%20baz")?.lastPathSegment, "bar baz")
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar%20baz/")?.lastPathSegment, "bar baz")
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar?query#fragment")?.lastPathSegment, "bar")
-        XCTAssertNil(HTTPURL(string: "http://#fragment")?.lastPathSegment)
-        XCTAssertNil(HTTPURL(string: "http://?query")?.lastPathSegment)
-    }
+        @Test("relative URL returns nil when relativized against an HTTP base")
+        func relativizeRelativeURL() throws {
+            let base = try #require(HTTPURL(string: "http://host/foo"))
+            #expect(try base.relativize(#require(RelativeURL(string: "host/foo/bar"))) == nil)
+        }
 
-    func testRemovingLastPathSegment() {
-        XCTAssertEqual(HTTPURL(string: "http://")?.removingLastPathSegment().string, "http://")
-        XCTAssertEqual(HTTPURL(string: "http://foo")?.removingLastPathSegment().string, "http://foo")
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar")?.removingLastPathSegment().string, "http://foo/")
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar/baz")?.removingLastPathSegment().string, "http://foo/bar/")
-    }
+        @Test("URL with different scheme returns nil when relativized")
+        func relativizeAbsoluteURLWithDifferentScheme() throws {
+            let base = try #require(HTTPURL(string: "http://host/foo"))
+            #expect(try base.relativize(#require(HTTPURL(string: "https://host/foo/bar"))) == nil)
+            #expect(try base.relativize(#require(FileURL(string: "file://host/foo/bar"))) == nil)
+        }
 
-    func testPathExtension() {
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar.txt")?.pathExtension, "txt")
-        XCTAssertNil(HTTPURL(string: "http://foo/bar")?.pathExtension)
-        XCTAssertNil(HTTPURL(string: "http://foo/bar/")?.pathExtension)
-        XCTAssertNil(HTTPURL(string: "http://foo/.hidden")?.pathExtension)
-    }
+        @Test("isRelative is true only for same origin")
+        func isRelative() throws {
+            let url = try #require(HTTPURL(string: "http://host/foo/bar"))
+            #expect(try url.isRelative(to: #require(HTTPURL(string: "http://host/foo"))))
+            #expect(try url.isRelative(to: #require(HTTPURL(string: "http://host/foo/bar"))))
+            #expect(try url.isRelative(to: #require(HTTPURL(string: "http://host/foo/bar/baz"))))
+            #expect(try url.isRelative(to: #require(HTTPURL(string: "http://host/bar"))))
 
-    func testReplacingPathExtension() {
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar")?.replacingPathExtension("xml").string, "http://foo/bar.xml")
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar.txt")?.replacingPathExtension("xml").string, "http://foo/bar.xml")
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar.txt")?.replacingPathExtension(nil).string, "http://foo/bar")
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar/")?.replacingPathExtension("xml").string, "http://foo/bar/")
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar/")?.replacingPathExtension(nil).string, "http://foo/bar/")
-        XCTAssertEqual(HTTPURL(string: "http://foo")?.replacingPathExtension("xml").string, "http://foo")
-    }
-
-    func testQuery() {
-        XCTAssertNil(HTTPURL(string: "http://foo/bar")?.query)
-        XCTAssertEqual(
-            HTTPURL(string: "http://foo/bar?param=quz%20baz")?.query,
-            URLQuery(parameters: [.init(name: "param", value: "quz baz")])
-        )
-    }
-
-    func testRemovingQuery() {
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar")?.removingQuery(), HTTPURL(string: "http://foo/bar"))
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar?param=quz%20baz")?.removingQuery(), HTTPURL(string: "http://foo/bar"))
-    }
-
-    func testFragment() {
-        XCTAssertNil(HTTPURL(string: "http://foo/bar")?.fragment)
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar#quz%20baz")?.fragment, "quz baz")
-    }
-
-    func testRemovingFragment() {
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar")?.removingFragment(), HTTPURL(string: "http://foo/bar"))
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar#quz%20baz")?.removingFragment(), HTTPURL(string: "http://foo/bar"))
-    }
-
-    // MARK: - AbsoluteURL
-
-    func testScheme() {
-        XCTAssertEqual(HTTPURL(string: "http://foo/bar")?.scheme, .http)
-        XCTAssertEqual(HTTPURL(string: "HTTP://foo/bar")?.scheme, .http)
-        XCTAssertEqual(HTTPURL(string: "https://foo/bar")?.scheme, .https)
-    }
-
-    func testHost() {
-        XCTAssertNil(HTTPURL(string: "http://")?.host)
-        XCTAssertNil(HTTPURL(string: "http:///")?.host)
-        XCTAssertEqual(HTTPURL(string: "http://domain")?.host, "domain")
-        XCTAssertEqual(HTTPURL(string: "http://domain/path")?.host, "domain")
-    }
-
-    func testOrigin() {
-        XCTAssertEqual(HTTPURL(string: "HTTP://foo/bar")?.origin, "http://foo")
-        XCTAssertEqual(HTTPURL(string: "https://foo:443/bar")?.origin, "https://foo:443")
-    }
-
-    func testResolveAbsoluteURL() throws {
-        let base = try XCTUnwrap(HTTPURL(string: "http://host/foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(HTTPURL(string: "http://domain.com")))?.string, "http://domain.com")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(UnknownAbsoluteURL(string: "opds://other")))?.string, "opds://other")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(FileURL(string: "file:///foo")))?.string, "file:///foo")
-    }
-
-    func testResolveRelativeURL() throws {
-        var base = try XCTUnwrap(HTTPURL(string: "http://host/foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), HTTPURL(string: "http://host/foo/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "../quz/baz"))), HTTPURL(string: "http://host/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "/quz/baz"))), HTTPURL(string: "http://host/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "#fragment"))), HTTPURL(string: "http://host/foo/bar#fragment"))
-
-        // With trailing slash
-        base = try XCTUnwrap(HTTPURL(string: "http://host/foo/bar/"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), HTTPURL(string: "http://host/foo/bar/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "../quz/baz"))), HTTPURL(string: "http://host/foo/quz/baz"))
-    }
-
-    func testRelativize() throws {
-        var base = try XCTUnwrap(HTTPURL(string: "http://host/foo"))
-
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "http://host/foo"))))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "http://host/foo/quz/baz"))), RelativeURL(string: "quz/baz"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "http://host/foo#fragment"))), RelativeURL(string: "#fragment"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "http://host/quz/baz"))))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "http://host//foo/bar"))))
-
-        // With trailing slash
-        base = try XCTUnwrap(HTTPURL(string: "http://host/foo/"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "http://host/foo/quz/baz"))), RelativeURL(string: "quz/baz"))
-    }
-
-    func testRelativizeRelativeURL() throws {
-        let base = try XCTUnwrap(HTTPURL(string: "http://host/foo"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(RelativeURL(string: "host/foo/bar"))))
-    }
-
-    func testRelativizeAbsoluteURLWithDifferentScheme() throws {
-        let base = try XCTUnwrap(HTTPURL(string: "http://host/foo"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(HTTPURL(string: "https://host/foo/bar"))))
-        XCTAssertNil(try base.relativize(XCTUnwrap(FileURL(string: "file://host/foo/bar"))))
-    }
-
-    func testIsRelative() throws {
-        // Only relative with the same origin.
-        let url = try XCTUnwrap(HTTPURL(string: "http://host/foo/bar"))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(HTTPURL(string: "http://host/foo"))))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(HTTPURL(string: "http://host/foo/bar"))))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(HTTPURL(string: "http://host/foo/bar/baz"))))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(HTTPURL(string: "http://host/bar"))))
-
-        // Different scheme
-        XCTAssertFalse(try url.isRelative(to: XCTUnwrap(UnknownAbsoluteURL(string: "other://host/foo"))))
-        XCTAssertFalse(try url.isRelative(to: XCTUnwrap(HTTPURL(string: "https://host/foo"))))
-        // Different host
-        XCTAssertFalse(try url.isRelative(to: XCTUnwrap(HTTPURL(string: "http://foo"))))
-        // Relative path
-        XCTAssertFalse(try url.isRelative(to: XCTUnwrap(RelativeURL(path: "foo/bar"))))
+            // Different scheme
+            #expect(try !url.isRelative(to: #require(UnknownAbsoluteURL(string: "other://host/foo"))))
+            #expect(try !url.isRelative(to: #require(HTTPURL(string: "https://host/foo"))))
+            // Different host
+            #expect(try !url.isRelative(to: #require(HTTPURL(string: "http://foo"))))
+            // Relative path
+            #expect(try !url.isRelative(to: #require(RelativeURL(path: "foo/bar"))))
+        }
     }
 }

--- a/Tests/SharedTests/Toolkit/URL/Absolute URL/HTTPURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/Absolute URL/HTTPURLTests.swift
@@ -8,8 +8,8 @@ import Foundation
 @testable import ReadiumShared
 import Testing
 
-@Suite enum HTTPURLTests {
-    @Suite struct Equality {
+enum HTTPURLTests {
+    struct Equality {
         @Test("equal URLs compare as equal, fragments are significant")
         func equality() throws {
             #expect(HTTPURL(string: "http://domain.com") == HTTPURL(string: "http://domain.com"))
@@ -20,7 +20,7 @@ import Testing
         }
     }
 
-    @Suite struct URLProtocolImplementation {
+    struct URLProtocolImplementation {
         @Test("creates from Foundation URL")
         func createFromURL() throws {
             #expect(try HTTPURL(url: #require(URL(string: "http://domain.com")))?.string == "http://domain.com")
@@ -169,7 +169,7 @@ import Testing
         }
     }
 
-    @Suite struct AbsoluteURLImplementation {
+    struct AbsoluteURLImplementation {
         @Test("scheme is normalized to lowercase")
         func scheme() {
             #expect(HTTPURL(string: "http://foo/bar")?.scheme == .http)

--- a/Tests/SharedTests/Toolkit/URL/Absolute URL/UnknownAbsoluteURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/Absolute URL/UnknownAbsoluteURLTests.swift
@@ -6,211 +6,245 @@
 
 import Foundation
 @testable import ReadiumShared
-import XCTest
+import Testing
 
-class UnknownAbsoluteURLTests: XCTestCase {
-    func testEquality() throws {
-        XCTAssertEqual(
-            UnknownAbsoluteURL(string: "opds://domain.com"),
-            UnknownAbsoluteURL(string: "opds://domain.com")
-        )
-        XCTAssertNotEqual(
-            try XCTUnwrap(UnknownAbsoluteURL(string: "opds://domain.com")),
-            try XCTUnwrap(UnknownAbsoluteURL(string: "opds://domain.com#fragment"))
-        )
+@Suite enum UnknownAbsoluteURLTests {
+    @Suite struct Equality {
+        @Test("equal URLs compare as equal, fragments are significant")
+        func equality() throws {
+            #expect(UnknownAbsoluteURL(string: "opds://domain.com") == UnknownAbsoluteURL(string: "opds://domain.com"))
+            #expect(
+                try #require(UnknownAbsoluteURL(string: "opds://domain.com"))
+                    != #require(UnknownAbsoluteURL(string: "opds://domain.com#fragment"))
+            )
+        }
     }
 
-    // MARK: - URLProtocol
+    @Suite struct URLProtocolImplementation {
+        @Test("creates from Foundation URL")
+        func createFromURL() throws {
+            #expect(try UnknownAbsoluteURL(url: #require(URL(string: "opds://callback")))?.string == "opds://callback")
+        }
 
-    func testCreateFromURL() throws {
-        XCTAssertEqual(try UnknownAbsoluteURL(url: XCTUnwrap(URL(string: "opds://callback")))?.string, "opds://callback")
+        @Test("creates from percent-encoded string")
+        func createFromString() {
+            #expect(UnknownAbsoluteURL(string: "opds://callback")?.string == "opds://callback")
+
+            // Empty
+            #expect(UnknownAbsoluteURL(string: "")?.string == nil)
+            // Not absolute
+            #expect(UnknownAbsoluteURL(string: "path") == nil)
+        }
+
+        @Test("url property returns Foundation URL")
+        func url() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar?query#fragment")?.url == URL(string: "opds://foo/bar?query#fragment"))
+        }
+
+        @Test("string property returns percent-encoded string")
+        func string() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar?query#fragment")?.string == "opds://foo/bar?query#fragment")
+        }
+
+        @Test("path is percent-decoded")
+        func path() {
+            #expect(UnknownAbsoluteURL(string: "opds://host/foo/bar%20baz")?.path == "/foo/bar baz")
+            #expect(UnknownAbsoluteURL(string: "opds://host/foo/bar%20baz/")?.path == "/foo/bar baz/")
+            #expect(UnknownAbsoluteURL(string: "opds://host/foo/bar?query#fragment")?.path == "/foo/bar")
+            #expect(UnknownAbsoluteURL(string: "opds://host#fragment")?.path == "")
+            #expect(UnknownAbsoluteURL(string: "opds://host?query")?.path == "")
+        }
+
+        @Test("appendingPath appends a decoded path segment")
+        func appendingPath() throws {
+            var base = try #require(UnknownAbsoluteURL(string: "opds://foo/bar"))
+            #expect(base.appendingPath("", isDirectory: false).string == "opds://foo/bar")
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "opds://foo/bar/baz/quz")
+            #expect(base.appendingPath("/baz/quz", isDirectory: false).string == "opds://foo/bar/baz/quz")
+            // The path is supposed to be decoded
+            #expect(base.appendingPath("baz quz", isDirectory: false).string == "opds://foo/bar/baz%20quz")
+            #expect(base.appendingPath("baz%20quz", isDirectory: false).string == "opds://foo/bar/baz%2520quz")
+            // Directory
+            #expect(base.appendingPath("baz/quz", isDirectory: true).string == "opds://foo/bar/baz/quz/")
+            #expect(base.appendingPath("baz/quz/", isDirectory: true).string == "opds://foo/bar/baz/quz/")
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "opds://foo/bar/baz/quz")
+            #expect(base.appendingPath("baz/quz/", isDirectory: false).string == "opds://foo/bar/baz/quz")
+
+            // With trailing slash.
+            base = try #require(UnknownAbsoluteURL(string: "opds://foo/bar/"))
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "opds://foo/bar/baz/quz")
+        }
+
+        @Test("pathSegments returns percent-decoded segments")
+        func pathSegments() {
+            #expect(UnknownAbsoluteURL(string: "opds://host/foo")?.pathSegments == ["foo"])
+            // Segments are percent-decoded.
+            #expect(UnknownAbsoluteURL(string: "opds://host/foo/bar%20baz")?.pathSegments == ["foo", "bar baz"])
+            #expect(UnknownAbsoluteURL(string: "opds://host/foo/bar%20baz/")?.pathSegments == ["foo", "bar baz"])
+            #expect(UnknownAbsoluteURL(string: "opds://host/foo/bar?query#fragment")?.pathSegments == ["foo", "bar"])
+            #expect(UnknownAbsoluteURL(string: "opds://host#fragment")?.pathSegments == [])
+            #expect(UnknownAbsoluteURL(string: "opds://host?query")?.pathSegments == [])
+        }
+
+        @Test("lastPathSegment returns the last decoded segment")
+        func lastPathSegment() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar%20baz")?.lastPathSegment == "bar baz")
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar%20baz/")?.lastPathSegment == "bar baz")
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar?query#fragment")?.lastPathSegment == "bar")
+            #expect(UnknownAbsoluteURL(string: "opds://#fragment")?.lastPathSegment == nil)
+            #expect(UnknownAbsoluteURL(string: "opds://?query")?.lastPathSegment == nil)
+        }
+
+        @Test("removingLastPathSegment removes the last path segment")
+        func removingLastPathSegment() {
+            #expect(UnknownAbsoluteURL(string: "opds://")?.removingLastPathSegment().string == "opds://")
+            #expect(UnknownAbsoluteURL(string: "opds://foo")?.removingLastPathSegment().string == "opds://foo")
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.removingLastPathSegment().string == "opds://foo/")
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar/baz")?.removingLastPathSegment().string == "opds://foo/bar/")
+        }
+
+        @Test("pathExtension returns the file extension")
+        func pathExtension() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar.txt")?.pathExtension == "txt")
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.pathExtension == nil)
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar/")?.pathExtension == nil)
+            #expect(UnknownAbsoluteURL(string: "opds://foo/.hidden")?.pathExtension == nil)
+        }
+
+        @Test("replacingPathExtension replaces or removes the file extension")
+        func replacingPathExtension() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.replacingPathExtension("xml").string == "opds://foo/bar.xml")
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar.txt")?.replacingPathExtension("xml").string == "opds://foo/bar.xml")
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar.txt")?.replacingPathExtension(nil).string == "opds://foo/bar")
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar/")?.replacingPathExtension("xml").string == "opds://foo/bar/")
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar/")?.replacingPathExtension(nil).string == "opds://foo/bar/")
+            #expect(UnknownAbsoluteURL(string: "opds://foo")?.replacingPathExtension("xml").string == "opds://foo")
+        }
+
+        @Test("query returns parsed query parameters")
+        func query() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.query == nil)
+            #expect(
+                UnknownAbsoluteURL(string: "opds://foo/bar?param=quz%20baz")?.query
+                    == URLQuery(parameters: [.init(name: "param", value: "quz baz")])
+            )
+        }
+
+        @Test("removingQuery removes the query component")
+        func removingQuery() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.removingQuery() == UnknownAbsoluteURL(string: "opds://foo/bar"))
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar?param=quz%20baz")?.removingQuery() == UnknownAbsoluteURL(string: "opds://foo/bar"))
+        }
+
+        @Test("fragment is percent-decoded")
+        func fragment() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.fragment == nil)
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar#quz%20baz")?.fragment == "quz baz")
+        }
+
+        @Test("removingFragment removes the fragment component")
+        func removingFragment() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.removingFragment() == UnknownAbsoluteURL(string: "opds://foo/bar"))
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar#quz%20baz")?.removingFragment() == UnknownAbsoluteURL(string: "opds://foo/bar"))
+        }
+
+        @Test("replacingFragment sets or removes the fragment")
+        func replacingFragment() {
+            // Sets fragment on URL without one.
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.replacingFragment("baz").string == "opds://foo/bar#baz")
+            // Replaces existing fragment.
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar#old")?.replacingFragment("new").string == "opds://foo/bar#new")
+            // Removing via nil matches removingFragment().
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar#quz%20baz")?.replacingFragment(nil) == UnknownAbsoluteURL(string: "opds://foo/bar"))
+            // Fragment is percent-encoded.
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.replacingFragment("quz baz").string == "opds://foo/bar#quz%20baz")
+        }
     }
 
-    func testCreateFromString() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://callback")?.string, "opds://callback")
+    @Suite struct AbsoluteURLImplementation {
+        @Test("scheme is normalized to lowercase")
+        func scheme() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.scheme == URLScheme(rawValue: "opds"))
+            #expect(UnknownAbsoluteURL(string: "OPDS://foo/bar")?.scheme == URLScheme(rawValue: "opds"))
+        }
 
-        // Empty
-        XCTAssertNil(UnknownAbsoluteURL(string: "")?.string)
-        // Not absolute
-        XCTAssertNil(UnknownAbsoluteURL(string: "path"))
-    }
+        @Test("host returns the hostname component")
+        func host() {
+            #expect(UnknownAbsoluteURL(string: "opds://")?.host == nil)
+            #expect(UnknownAbsoluteURL(string: "opds:///")?.host == nil)
+            #expect(UnknownAbsoluteURL(string: "opds://domain")?.host == "domain")
+            #expect(UnknownAbsoluteURL(string: "opds://domain/path")?.host == "domain")
+        }
 
-    func testURL() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar?query#fragment")?.url, URL(string: "opds://foo/bar?query#fragment"))
-    }
+        @Test("origin is always nil for unknown schemes")
+        func origin() {
+            #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.origin == nil)
+        }
 
-    func testString() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar?query#fragment")?.string, "opds://foo/bar?query#fragment")
-    }
+        @Test("resolves absolute URL as-is")
+        func resolveAbsoluteURL() throws {
+            let base = try #require(UnknownAbsoluteURL(string: "opds://host/foo/bar"))
+            #expect(try base.resolve(#require(UnknownAbsoluteURL(string: "opds://other")))?.string == "opds://other")
+            #expect(try base.resolve(#require(HTTPURL(string: "http://domain.com")))?.string == "http://domain.com")
+            #expect(try base.resolve(#require(FileURL(string: "file:///foo")))?.string == "file:///foo")
+        }
 
-    func testPath() {
-        // Path is percent-decoded.
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host/foo/bar%20baz")?.path, "/foo/bar baz")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host/foo/bar%20baz/")?.path, "/foo/bar baz/")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host/foo/bar?query#fragment")?.path, "/foo/bar")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host#fragment")?.path, "")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host?query")?.path, "")
-    }
+        @Test("resolves relative URL against this base")
+        func resolveRelativeURL() throws {
+            var base = try #require(UnknownAbsoluteURL(string: "opds://host/foo/bar"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == UnknownAbsoluteURL(string: "opds://host/foo/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "../quz/baz"))) == UnknownAbsoluteURL(string: "opds://host/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "/quz/baz"))) == UnknownAbsoluteURL(string: "opds://host/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "#fragment"))) == UnknownAbsoluteURL(string: "opds://host/foo/bar#fragment"))
 
-    func testAppendingPath() throws {
-        var base = try XCTUnwrap(UnknownAbsoluteURL(string: "opds://foo/bar"))
-        XCTAssertEqual(base.appendingPath("", isDirectory: false).string, "opds://foo/bar")
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "opds://foo/bar/baz/quz")
-        XCTAssertEqual(base.appendingPath("/baz/quz", isDirectory: false).string, "opds://foo/bar/baz/quz")
-        // The path is supposed to be decoded
-        XCTAssertEqual(base.appendingPath("baz quz", isDirectory: false).string, "opds://foo/bar/baz%20quz")
-        XCTAssertEqual(base.appendingPath("baz%20quz", isDirectory: false).string, "opds://foo/bar/baz%2520quz")
-        // Directory
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: true).string, "opds://foo/bar/baz/quz/")
-        XCTAssertEqual(base.appendingPath("baz/quz/", isDirectory: true).string, "opds://foo/bar/baz/quz/")
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "opds://foo/bar/baz/quz")
-        XCTAssertEqual(base.appendingPath("baz/quz/", isDirectory: false).string, "opds://foo/bar/baz/quz")
+            // With trailing slash
+            base = try #require(UnknownAbsoluteURL(string: "opds://host/foo/bar/"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == UnknownAbsoluteURL(string: "opds://host/foo/bar/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "../quz/baz"))) == UnknownAbsoluteURL(string: "opds://host/foo/quz/baz"))
+        }
 
-        // With trailing slash.
-        base = try XCTUnwrap(UnknownAbsoluteURL(string: "opds://foo/bar/"))
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "opds://foo/bar/baz/quz")
-    }
+        @Test("relativizes a URL against this base")
+        func relativize() throws {
+            var base = try #require(UnknownAbsoluteURL(string: "opds://host/foo"))
+            #expect(try base.relativize(#require(AnyURL(string: "opds://host/foo"))) == nil)
+            #expect(try base.relativize(#require(AnyURL(string: "opds://host/foo/quz/baz"))) == RelativeURL(string: "quz/baz"))
+            #expect(try base.relativize(#require(AnyURL(string: "opds://host/foo#fragment"))) == RelativeURL(string: "#fragment"))
+            #expect(try base.relativize(#require(AnyURL(string: "opds://host/quz/baz"))) == nil)
+            #expect(try base.relativize(#require(AnyURL(string: "opds://host//foo/bar"))) == nil)
 
-    func testPathSegments() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host/foo")?.pathSegments, ["foo"])
-        // Segments are percent-decoded.
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host/foo/bar%20baz")?.pathSegments, ["foo", "bar baz"])
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host/foo/bar%20baz/")?.pathSegments, ["foo", "bar baz"])
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host/foo/bar?query#fragment")?.pathSegments, ["foo", "bar"])
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host#fragment")?.pathSegments, [])
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://host?query")?.pathSegments, [])
-    }
+            // With trailing slash
+            base = try #require(UnknownAbsoluteURL(string: "opds://host/foo/"))
+            #expect(try base.relativize(#require(AnyURL(string: "opds://host/foo/quz/baz"))) == RelativeURL(string: "quz/baz"))
+        }
 
-    func testLastPathSegment() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar%20baz")?.lastPathSegment, "bar baz")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar%20baz/")?.lastPathSegment, "bar baz")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar?query#fragment")?.lastPathSegment, "bar")
-        XCTAssertNil(UnknownAbsoluteURL(string: "opds://#fragment")?.lastPathSegment)
-        XCTAssertNil(UnknownAbsoluteURL(string: "opds://?query")?.lastPathSegment)
-    }
+        @Test("relative URL returns nil when relativized against an opds base")
+        func relativizeRelativeURL() throws {
+            let base = try #require(UnknownAbsoluteURL(string: "opds://host/foo"))
+            #expect(try base.relativize(#require(RelativeURL(string: "host/foo/bar"))) == nil)
+        }
 
-    func testRemovingLastPathSegment() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://")?.removingLastPathSegment().string, "opds://")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo")?.removingLastPathSegment().string, "opds://foo")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar")?.removingLastPathSegment().string, "opds://foo/")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar/baz")?.removingLastPathSegment().string, "opds://foo/bar/")
-    }
+        @Test("URL with different scheme returns nil when relativized")
+        func relativizeAbsoluteURLWithDifferentScheme() throws {
+            let base = try #require(UnknownAbsoluteURL(string: "opds://host/foo"))
+            #expect(try base.relativize(#require(HTTPURL(string: "http://host/foo/bar"))) == nil)
+            #expect(try base.relativize(#require(FileURL(string: "file://host/foo/bar"))) == nil)
+        }
 
-    func testPathExtension() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar.txt")?.pathExtension, "txt")
-        XCTAssertNil(UnknownAbsoluteURL(string: "opds://foo/bar")?.pathExtension)
-        XCTAssertNil(UnknownAbsoluteURL(string: "opds://foo/bar/")?.pathExtension)
-        XCTAssertNil(UnknownAbsoluteURL(string: "opds://foo/.hidden")?.pathExtension)
-    }
+        @Test("isRelative is true for same scheme regardless of host")
+        func isRelative() throws {
+            // Always relative if same scheme.
+            let url = try #require(UnknownAbsoluteURL(string: "opds://host/foo/bar"))
+            #expect(try url.isRelative(to: #require(UnknownAbsoluteURL(string: "opds://host/foo"))))
+            #expect(try url.isRelative(to: #require(UnknownAbsoluteURL(string: "opds://host/foo/bar"))))
+            #expect(try url.isRelative(to: #require(UnknownAbsoluteURL(string: "opds://host/foo/bar/baz"))))
+            #expect(try url.isRelative(to: #require(UnknownAbsoluteURL(string: "opds://host/bar"))))
+            #expect(try url.isRelative(to: #require(UnknownAbsoluteURL(string: "opds://other-host"))))
 
-    func testReplacingPathExtension() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar")?.replacingPathExtension("xml").string, "opds://foo/bar.xml")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar.txt")?.replacingPathExtension("xml").string, "opds://foo/bar.xml")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar.txt")?.replacingPathExtension(nil).string, "opds://foo/bar")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar/")?.replacingPathExtension("xml").string, "opds://foo/bar/")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar/")?.replacingPathExtension(nil).string, "opds://foo/bar/")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo")?.replacingPathExtension("xml").string, "opds://foo")
-    }
-
-    func testQuery() {
-        XCTAssertNil(UnknownAbsoluteURL(string: "opds://foo/bar")?.query)
-        XCTAssertEqual(
-            UnknownAbsoluteURL(string: "opds://foo/bar?param=quz%20baz")?.query,
-            URLQuery(parameters: [.init(name: "param", value: "quz baz")])
-        )
-    }
-
-    func testRemovingQuery() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar")?.removingQuery(), UnknownAbsoluteURL(string: "opds://foo/bar"))
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar?param=quz%20baz")?.removingQuery(), UnknownAbsoluteURL(string: "opds://foo/bar"))
-    }
-
-    func testFragment() {
-        XCTAssertNil(UnknownAbsoluteURL(string: "opds://foo/bar")?.fragment)
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar#quz%20baz")?.fragment, "quz baz")
-    }
-
-    func testRemovingFragment() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar")?.removingFragment(), UnknownAbsoluteURL(string: "opds://foo/bar"))
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar#quz%20baz")?.removingFragment(), UnknownAbsoluteURL(string: "opds://foo/bar"))
-    }
-
-    // MARK: - AbsoluteURL
-
-    func testScheme() {
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://foo/bar")?.scheme, URLScheme(rawValue: "opds"))
-        XCTAssertEqual(UnknownAbsoluteURL(string: "OPDS://foo/bar")?.scheme, URLScheme(rawValue: "opds"))
-    }
-
-    func testHost() {
-        XCTAssertNil(UnknownAbsoluteURL(string: "opds://")?.host)
-        XCTAssertNil(UnknownAbsoluteURL(string: "opds:///")?.host)
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://domain")?.host, "domain")
-        XCTAssertEqual(UnknownAbsoluteURL(string: "opds://domain/path")?.host, "domain")
-    }
-
-    func testOrigin() {
-        XCTAssertNil(UnknownAbsoluteURL(string: "opds://foo/bar")?.origin)
-    }
-
-    func testResolveAbsoluteURL() throws {
-        let base = try XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(UnknownAbsoluteURL(string: "opds://other")))?.string, "opds://other")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(HTTPURL(string: "http://domain.com")))?.string, "http://domain.com")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(FileURL(string: "file:///foo")))?.string, "file:///foo")
-    }
-
-    func testResolveRelativeURL() throws {
-        var base = try XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), UnknownAbsoluteURL(string: "opds://host/foo/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "../quz/baz"))), UnknownAbsoluteURL(string: "opds://host/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "/quz/baz"))), UnknownAbsoluteURL(string: "opds://host/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "#fragment"))), UnknownAbsoluteURL(string: "opds://host/foo/bar#fragment"))
-
-        // With trailing slash
-        base = try XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo/bar/"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), UnknownAbsoluteURL(string: "opds://host/foo/bar/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "../quz/baz"))), UnknownAbsoluteURL(string: "opds://host/foo/quz/baz"))
-    }
-
-    func testRelativize() throws {
-        var base = try XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo"))
-
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "opds://host/foo"))))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "opds://host/foo/quz/baz"))), RelativeURL(string: "quz/baz"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "opds://host/foo#fragment"))), RelativeURL(string: "#fragment"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "opds://host/quz/baz"))))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "opds://host//foo/bar"))))
-
-        // With trailing slash
-        base = try XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo/"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "opds://host/foo/quz/baz"))), RelativeURL(string: "quz/baz"))
-    }
-
-    func testRelativizeRelativeURL() throws {
-        let base = try XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(RelativeURL(string: "host/foo/bar"))))
-    }
-
-    func testRelativizeAbsoluteURLWithDifferentScheme() throws {
-        let base = try XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(HTTPURL(string: "http://host/foo/bar"))))
-        XCTAssertNil(try base.relativize(XCTUnwrap(FileURL(string: "file://host/foo/bar"))))
-    }
-
-    func testIsRelative() throws {
-        // Always relative if same scheme.
-        let url = try XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo/bar"))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo"))))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo/bar"))))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo/bar/baz"))))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/bar"))))
-        XCTAssertTrue(try url.isRelative(to: XCTUnwrap(UnknownAbsoluteURL(string: "opds://other-host"))))
-
-        // Different scheme
-        XCTAssertFalse(try url.isRelative(to: XCTUnwrap(UnknownAbsoluteURL(string: "other://host/foo"))))
-        XCTAssertFalse(try url.isRelative(to: XCTUnwrap(HTTPURL(string: "http://foo"))))
-        // Relative path
-        XCTAssertFalse(try url.isRelative(to: XCTUnwrap(RelativeURL(path: "foo/bar"))))
+            // Different scheme
+            #expect(try !url.isRelative(to: #require(UnknownAbsoluteURL(string: "other://host/foo"))))
+            #expect(try !url.isRelative(to: #require(HTTPURL(string: "http://foo"))))
+            // Relative path
+            #expect(try !url.isRelative(to: #require(RelativeURL(path: "foo/bar"))))
+        }
     }
 }

--- a/Tests/SharedTests/Toolkit/URL/Absolute URL/UnknownAbsoluteURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/Absolute URL/UnknownAbsoluteURLTests.swift
@@ -8,8 +8,8 @@ import Foundation
 @testable import ReadiumShared
 import Testing
 
-@Suite enum UnknownAbsoluteURLTests {
-    @Suite struct Equality {
+enum UnknownAbsoluteURLTests {
+    struct Equality {
         @Test("equal URLs compare as equal, fragments are significant")
         func equality() throws {
             #expect(UnknownAbsoluteURL(string: "opds://domain.com") == UnknownAbsoluteURL(string: "opds://domain.com"))
@@ -20,7 +20,7 @@ import Testing
         }
     }
 
-    @Suite struct URLProtocolImplementation {
+    struct URLProtocolImplementation {
         @Test("creates from Foundation URL")
         func createFromURL() throws {
             #expect(try UnknownAbsoluteURL(url: #require(URL(string: "opds://callback")))?.string == "opds://callback")
@@ -161,7 +161,7 @@ import Testing
         }
     }
 
-    @Suite struct AbsoluteURLImplementation {
+    struct AbsoluteURLImplementation {
         @Test("scheme is normalized to lowercase")
         func scheme() {
             #expect(UnknownAbsoluteURL(string: "opds://foo/bar")?.scheme == URLScheme(rawValue: "opds"))

--- a/Tests/SharedTests/Toolkit/URL/AnyURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/AnyURLTests.swift
@@ -6,193 +6,198 @@
 
 import Foundation
 @testable import ReadiumShared
-import XCTest
+import Testing
 
-class AnyURLTests: XCTestCase {
-    func testEquality() throws {
-        XCTAssertEqual(
-            AnyURL(string: "opds://domain.com"),
-            AnyURL(string: "opds://domain.com")
-        )
-        XCTAssertNotEqual(
-            try XCTUnwrap(AnyURL(string: "opds://domain.com")),
-            try XCTUnwrap(AnyURL(string: "https://domain.com"))
-        )
-
-        XCTAssertEqual(
-            AnyURL(string: "dir/file"),
-            AnyURL(string: "dir/file")
-        )
-        XCTAssertNotEqual(
-            try XCTUnwrap(AnyURL(string: "dir/file")),
-            try XCTUnwrap(AnyURL(string: "dir/file#fragment"))
-        )
+@Suite enum AnyURLTests {
+    @Suite struct Equality {
+        @Test("equal URLs compare as equal")
+        func equality() throws {
+            #expect(AnyURL(string: "opds://domain.com") == AnyURL(string: "opds://domain.com"))
+            #expect(
+                try #require(AnyURL(string: "opds://domain.com"))
+                    != #require(AnyURL(string: "https://domain.com"))
+            )
+            #expect(AnyURL(string: "dir/file") == AnyURL(string: "dir/file"))
+            #expect(
+                try #require(AnyURL(string: "dir/file"))
+                    != #require(AnyURL(string: "dir/file#fragment"))
+            )
+        }
     }
 
-    func testCreateFromInvalidUrl() {
-        XCTAssertNil(AnyURL(string: ""))
-        XCTAssertNil(AnyURL(string: "     "))
-        XCTAssertNil(AnyURL(string: "invalid character"))
+    @Suite struct Creation {
+        @Test("invalid URLs return nil")
+        func createFromInvalidUrl() {
+            #expect(AnyURL(string: "") == nil)
+            #expect(AnyURL(string: "     ") == nil)
+            #expect(AnyURL(string: "invalid character") == nil)
+        }
+
+        @Test("relative paths create relative AnyURL")
+        func createFromRelativePath() throws {
+            #expect(try AnyURL(string: "/foo/bar") == .relative(#require(RelativeURL(string: "/foo/bar"))))
+            #expect(try AnyURL(string: "foo/bar") == .relative(#require(RelativeURL(string: "foo/bar"))))
+            #expect(try AnyURL(string: "../bar") == .relative(#require(RelativeURL(string: "../bar"))))
+        }
+
+        @Test("absolute URLs create absolute AnyURL")
+        func createFromAbsoluteURLs() throws {
+            #expect(try AnyURL(string: "file:///foo/bar") == .absolute(#require(FileURL(string: "file:///foo/bar"))))
+            #expect(try AnyURL(string: "http://host/foo/bar") == .absolute(#require(HTTPURL(string: "http://host/foo/bar"))))
+            #expect(try AnyURL(string: "opds://host/foo/bar") == .absolute(#require(UnknownAbsoluteURL(string: "opds://host/foo/bar"))))
+        }
+
+        @Test("legacy HREFs are normalized and percent-encoded")
+        func createFromLegacyHREF() throws {
+            #expect(try AnyURL(legacyHREF: "dir/chapter.xhtml") == .relative(#require(RelativeURL(string: "dir/chapter.xhtml"))))
+            // Starting slash is removed.
+            #expect(try AnyURL(legacyHREF: "/dir/chapter.xhtml") == .relative(#require(RelativeURL(string: "dir/chapter.xhtml"))))
+            // Special characters are percent-encoded.
+            #expect(try AnyURL(legacyHREF: "/dir/per%cent.xhtml") == .relative(#require(RelativeURL(string: "dir/per%25cent.xhtml"))))
+            #expect(try AnyURL(legacyHREF: "/barré.xhtml") == .relative(#require(RelativeURL(string: "barr%C3%A9.xhtml"))))
+            #expect(try AnyURL(legacyHREF: "/spa ce.xhtml") == .relative(#require(RelativeURL(string: "spa%20ce.xhtml"))))
+            // We assume that a relative path is percent-decoded.
+            #expect(try AnyURL(legacyHREF: "/spa%20ce.xhtml") == .relative(#require(RelativeURL(string: "spa%2520ce.xhtml"))))
+            // Some special characters are authorized in a path.
+            #expect(try AnyURL(legacyHREF: "/$&+,/=@") == .relative(#require(RelativeURL(string: "$&+,/=@"))))
+            // Valid absolute URL are left untouched.
+            #expect(
+                try AnyURL(legacyHREF: "http://domain.com/a%20book?page=3")
+                    == .absolute(#require(HTTPURL(string: "http://domain.com/a%20book?page=3")))
+            )
+        }
     }
 
-    func testCreateFromRelativePath() throws {
-        XCTAssertEqual(AnyURL(string: "/foo/bar"), try .relative(XCTUnwrap(RelativeURL(string: "/foo/bar"))))
-        XCTAssertEqual(AnyURL(string: "foo/bar"), try .relative(XCTUnwrap(RelativeURL(string: "foo/bar"))))
-        XCTAssertEqual(AnyURL(string: "../bar"), try .relative(XCTUnwrap(RelativeURL(string: "../bar"))))
+    @Suite struct Resolution {
+        @Test("resolves relative URLs against an HTTP base")
+        func resolveHTTPURL() throws {
+            var base = try #require(AnyURL(string: "http://example.com/foo/bar"))
+            #expect(try base.resolve(#require(AnyURL(string: "quz/baz")))?.string == "http://example.com/foo/quz/baz")
+            #expect(try base.resolve(#require(AnyURL(string: "../quz/baz")))?.string == "http://example.com/quz/baz")
+            #expect(try base.resolve(#require(AnyURL(string: "/quz/baz")))?.string == "http://example.com/quz/baz")
+            #expect(try base.resolve(#require(AnyURL(string: "#fragment")))?.string == "http://example.com/foo/bar#fragment")
+            #expect(try base.resolve(#require(AnyURL(string: "file:///foo/bar")))?.string == "file:///foo/bar")
+
+            // With trailing slash
+            base = try #require(AnyURL(string: "http://example.com/foo/bar/"))
+            #expect(try base.resolve(#require(AnyURL(string: "quz/baz")))?.string == "http://example.com/foo/bar/quz/baz")
+            #expect(try base.resolve(#require(AnyURL(string: "../quz/baz")))?.string == "http://example.com/foo/quz/baz")
+        }
+
+        @Test("resolves relative URLs against a file base")
+        func resolveFileURL() throws {
+            var base = try #require(AnyURL(string: "file:///root/foo/bar"))
+            #expect(try base.resolve(#require(AnyURL(string: "quz")))?.string == "file:///root/foo/quz")
+            #expect(try base.resolve(#require(AnyURL(string: "quz/baz")))?.string == "file:///root/foo/quz/baz")
+            #expect(try base.resolve(#require(AnyURL(string: "../quz")))?.string == "file:///root/quz")
+
+            // With trailing slash
+            base = try #require(AnyURL(string: "file:///root/foo/bar/"))
+            #expect(try base.resolve(#require(AnyURL(string: "quz/baz")))?.string == "file:///root/foo/bar/quz/baz")
+            #expect(try base.resolve(#require(AnyURL(string: "../quz")))?.string == "file:///root/foo/quz")
+        }
+
+        @Test("resolves two relative URLs")
+        func resolveTwoRelativeURLs() throws {
+            var base = try #require(RelativeURL(string: "foo/bar"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == RelativeURL(string: "foo/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "../quz/baz"))) == RelativeURL(string: "quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "/quz/baz"))) == RelativeURL(string: "/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "#fragment"))) == RelativeURL(string: "foo/bar#fragment"))
+
+            // With trailing slash
+            base = try #require(RelativeURL(string: "foo/bar/"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == RelativeURL(string: "foo/bar/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "../quz/baz"))) == RelativeURL(string: "foo/quz/baz"))
+
+            // With starting slash
+            base = try #require(RelativeURL(string: "/foo/bar"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == RelativeURL(string: "/foo/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "/quz/baz"))) == RelativeURL(string: "/quz/baz"))
+        }
     }
 
-    func testCreateFromAbsoluteURLs() throws {
-        XCTAssertEqual(AnyURL(string: "file:///foo/bar"), try .absolute(XCTUnwrap(FileURL(string: "file:///foo/bar"))))
-        XCTAssertEqual(AnyURL(string: "http://host/foo/bar"), try .absolute(XCTUnwrap(HTTPURL(string: "http://host/foo/bar"))))
-        XCTAssertEqual(AnyURL(string: "opds://host/foo/bar"), try .absolute(XCTUnwrap(UnknownAbsoluteURL(string: "opds://host/foo/bar"))))
+    @Suite struct Relativization {
+        @Test("relativizes URLs against an HTTP base")
+        func relativizeHTTPURL() throws {
+            var base = try #require(AnyURL(string: "http://example.com/foo"))
+            #expect(try base.relativize(#require(AnyURL(string: "http://example.com/foo/quz/baz")))?.string == "quz/baz")
+            #expect(try base.relativize(#require(AnyURL(string: "http://example.com/foo#fragment")))?.string == "#fragment")
+
+            // With trailing slash
+            base = try #require(AnyURL(string: "http://example.com/foo/"))
+            #expect(try base.relativize(#require(AnyURL(string: "http://example.com/foo/quz/baz")))?.string == "quz/baz")
+        }
+
+        @Test("relativizes URLs against a file base")
+        func relativizeFileURL() throws {
+            var base = try #require(AnyURL(string: "file:///root/foo"))
+            #expect(try base.relativize(#require(AnyURL(string: "file:///root/foo/quz/baz")))?.string == "quz/baz")
+            #expect(try base.relativize(#require(AnyURL(string: "http://example.com/foo/bar"))) == nil)
+
+            // With trailing slash
+            base = try #require(AnyURL(string: "file:///root/foo/"))
+            #expect(try base.relativize(#require(AnyURL(string: "file:///root/foo/quz/baz")))?.string == "quz/baz")
+        }
+
+        @Test("relativizes two relative URLs")
+        func relativizeTwoRelativeURLs() throws {
+            var base = try #require(AnyURL(string: "foo"))
+            #expect(try base.relativize(#require(AnyURL(string: "foo/quz/baz")))?.string == "quz/baz")
+            #expect(try base.relativize(#require(AnyURL(string: "foo#fragment")))?.string == "#fragment")
+            #expect(try base.relativize(#require(AnyURL(string: "quz/baz"))) == nil)
+            #expect(try base.relativize(#require(AnyURL(string: "/quz/baz"))) == nil)
+            #expect(try base.relativize(#require(AnyURL(string: "http://example.com/foo/bar"))) == nil)
+
+            // With trailing slash
+            base = try #require(AnyURL(string: "foo/"))
+            #expect(try base.relativize(#require(AnyURL(string: "foo/quz/baz")))?.string == "quz/baz")
+
+            // With starting slash
+            base = try #require(AnyURL(string: "/foo"))
+            #expect(try base.relativize(#require(AnyURL(string: "/foo/quz/baz")))?.string == "quz/baz")
+            #expect(try base.relativize(#require(AnyURL(string: "/quz/baz"))) == nil)
+        }
     }
 
-    func testCreateFromLegacyHREF() throws {
-        XCTAssertEqual(AnyURL(legacyHREF: "dir/chapter.xhtml"), try .relative(XCTUnwrap(RelativeURL(string: "dir/chapter.xhtml"))))
-        // Starting slash is removed.
-        XCTAssertEqual(AnyURL(legacyHREF: "/dir/chapter.xhtml"), try .relative(XCTUnwrap(RelativeURL(string: "dir/chapter.xhtml"))))
-        // Special characters are percent-encoded.
-        XCTAssertEqual(AnyURL(legacyHREF: "/dir/per%cent.xhtml"), try .relative(XCTUnwrap(RelativeURL(string: "dir/per%25cent.xhtml"))))
-        XCTAssertEqual(AnyURL(legacyHREF: "/barré.xhtml"), try .relative(XCTUnwrap(RelativeURL(string: "barr%C3%A9.xhtml"))))
-        XCTAssertEqual(AnyURL(legacyHREF: "/spa ce.xhtml"), try .relative(XCTUnwrap(RelativeURL(string: "spa%20ce.xhtml"))))
-        // We assume that a relative path is percent-decoded.
-        XCTAssertEqual(AnyURL(legacyHREF: "/spa%20ce.xhtml"), try .relative(XCTUnwrap(RelativeURL(string: "spa%2520ce.xhtml"))))
-        // Some special characters are authorized in a path.
-        XCTAssertEqual(AnyURL(legacyHREF: "/$&+,/=@"), try .relative(XCTUnwrap(RelativeURL(string: "$&+,/=@"))))
-        // Valid absolute URL are left untouched.
-        XCTAssertEqual(
-            AnyURL(legacyHREF: "http://domain.com/a%20book?page=3"),
-            try .absolute(XCTUnwrap(HTTPURL(string: "http://domain.com/a%20book?page=3")))
-        )
+    @Suite struct Normalization {
+        @Test("scheme is lowercased, path is decoded, relative segments are resolved")
+        func normalized() {
+            // Scheme is lower case.
+            #expect(AnyURL(string: "HTTP://example.com")?.normalized.string == "http://example.com")
+
+            // Path is percent-decoded.
+            #expect(AnyURL(string: "HTTP://example.com/c%27est%20valide")?.normalized.string == "http://example.com/c'est%20valide")
+            #expect(AnyURL(string: "c%27est%20valide")?.normalized.string == "c'est%20valide")
+
+            // Relative paths are resolved.
+            #expect(AnyURL(string: "http://example.com/foo/./bar/../baz")?.normalized.string == "http://example.com/foo/baz")
+            #expect(AnyURL(string: "foo/./bar/../baz")?.normalized.string == "foo/baz")
+            #expect(AnyURL(string: "foo/./bar/../../../baz")?.normalized.string == "../baz")
+
+            // Trailing slash is kept.
+            #expect(AnyURL(string: "http://example.com/foo/")?.normalized.string == "http://example.com/foo/")
+            #expect(AnyURL(string: "foo/")?.normalized.string == "foo/")
+
+            // The other components are left as-is.
+            #expect(
+                AnyURL(string: "http://user:password@example.com:443/foo?b=b&a=a#fragment")?.normalized.string
+                    == "http://user:password@example.com:443/foo?b=b&a=a#fragment"
+            )
+        }
     }
 
-    func testResolveHTTPURL() throws {
-        var base = try XCTUnwrap(AnyURL(string: "http://example.com/foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "quz/baz")))?.string, "http://example.com/foo/quz/baz")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "../quz/baz")))?.string, "http://example.com/quz/baz")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "/quz/baz")))?.string, "http://example.com/quz/baz")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "#fragment")))?.string, "http://example.com/foo/bar#fragment")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "file:///foo/bar")))?.string, "file:///foo/bar")
-
-        // With trailing slash
-        base = try XCTUnwrap(AnyURL(string: "http://example.com/foo/bar/"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "quz/baz")))?.string, "http://example.com/foo/bar/quz/baz")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "../quz/baz")))?.string, "http://example.com/foo/quz/baz")
-    }
-
-    func testResolveFileURL() throws {
-        var base = try XCTUnwrap(AnyURL(string: "file:///root/foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "quz")))?.string, "file:///root/foo/quz")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "quz/baz")))?.string, "file:///root/foo/quz/baz")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "../quz")))?.string, "file:///root/quz")
-
-        // With trailing slash
-        base = try XCTUnwrap(AnyURL(string: "file:///root/foo/bar/"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "quz/baz")))?.string, "file:///root/foo/bar/quz/baz")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "../quz")))?.string, "file:///root/foo/quz")
-    }
-
-    func testResolveTwoRelativeURLs() throws {
-        var base = try XCTUnwrap(RelativeURL(string: "foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), RelativeURL(string: "foo/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "../quz/baz"))), RelativeURL(string: "quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "/quz/baz"))), RelativeURL(string: "/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "#fragment"))), RelativeURL(string: "foo/bar#fragment"))
-
-        // With trailing slash
-        base = try XCTUnwrap(RelativeURL(string: "foo/bar/"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), RelativeURL(string: "foo/bar/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "../quz/baz"))), RelativeURL(string: "foo/quz/baz"))
-
-        // With starting slash
-        base = try XCTUnwrap(RelativeURL(string: "/foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), RelativeURL(string: "/foo/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "/quz/baz"))), RelativeURL(string: "/quz/baz"))
-    }
-
-    func testRelativizeHTTPURL() throws {
-        var base = try XCTUnwrap(AnyURL(string: "http://example.com/foo"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "http://example.com/foo/quz/baz")))?.string, "quz/baz")
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "http://example.com/foo#fragment")))?.string, "#fragment")
-
-        // With trailing slash
-        base = try XCTUnwrap(AnyURL(string: "http://example.com/foo/"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "http://example.com/foo/quz/baz")))?.string, "quz/baz")
-    }
-
-    func testRelativizeFileURL() throws {
-        var base = try XCTUnwrap(AnyURL(string: "file:///root/foo"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "file:///root/foo/quz/baz")))?.string, "quz/baz")
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "http://example.com/foo/bar"))))
-
-        // With trailing slash
-        base = try XCTUnwrap(AnyURL(string: "file:///root/foo/"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "file:///root/foo/quz/baz")))?.string, "quz/baz")
-    }
-
-    func testRelativizeTwoRelativeURLs() throws {
-        var base = try XCTUnwrap(AnyURL(string: "foo"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "foo/quz/baz")))?.string, "quz/baz")
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "foo#fragment")))?.string, "#fragment")
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "quz/baz"))))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "/quz/baz"))))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "http://example.com/foo/bar"))))
-
-        // With trailing slash
-        base = try XCTUnwrap(AnyURL(string: "foo/"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "foo/quz/baz")))?.string, "quz/baz")
-
-        // With starting slash
-        base = try XCTUnwrap(AnyURL(string: "/foo"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "/foo/quz/baz")))?.string, "quz/baz")
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "/quz/baz"))))
-    }
-
-    func testNormalized() {
-        // Scheme is lower case.
-        XCTAssertEqual(
-            AnyURL(string: "HTTP://example.com")?.normalized.string,
-            "http://example.com"
-        )
-
-        // Path is percent-decoded.
-        XCTAssertEqual(
-            AnyURL(string: "HTTP://example.com/c%27est%20valide")?.normalized.string,
-            "http://example.com/c'est%20valide"
-        )
-        XCTAssertEqual(
-            AnyURL(string: "c%27est%20valide")?.normalized.string,
-            "c'est%20valide"
-        )
-
-        // Relative paths are resolved.
-        XCTAssertEqual(
-            AnyURL(string: "http://example.com/foo/./bar/../baz")?.normalized.string,
-            "http://example.com/foo/baz"
-        )
-        XCTAssertEqual(
-            AnyURL(string: "foo/./bar/../baz")?.normalized.string,
-            "foo/baz"
-        )
-        XCTAssertEqual(
-            AnyURL(string: "foo/./bar/../../../baz")?.normalized.string,
-            "../baz"
-        )
-
-        // Trailing slash is kept.
-        XCTAssertEqual(
-            AnyURL(string: "http://example.com/foo/")?.normalized.string,
-            "http://example.com/foo/"
-        )
-        XCTAssertEqual(
-            AnyURL(string: "foo/")?.normalized.string,
-            "foo/"
-        )
-
-        // The other components are left as-is.
-        XCTAssertEqual(
-            AnyURL(string: "http://user:password@example.com:443/foo?b=b&a=a#fragment")?.normalized.string,
-            "http://user:password@example.com:443/foo?b=b&a=a#fragment"
-        )
+    @Suite struct Fragment {
+        @Test("replacingFragment sets or removes the fragment")
+        func replacingFragment() {
+            // Sets fragment on URL without one.
+            #expect(AnyURL(string: "foo/bar")?.replacingFragment("baz").string == "foo/bar#baz")
+            // Replaces existing fragment.
+            #expect(AnyURL(string: "foo/bar#old")?.replacingFragment("new").string == "foo/bar#new")
+            // Removing via nil matches removingFragment().
+            #expect(AnyURL(string: "foo/bar#quz%20baz")?.replacingFragment(nil) == AnyURL(string: "foo/bar"))
+            // Fragment is percent-encoded.
+            #expect(AnyURL(string: "foo/bar")?.replacingFragment("quz baz").string == "foo/bar#quz%20baz")
+        }
     }
 }

--- a/Tests/SharedTests/Toolkit/URL/AnyURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/AnyURLTests.swift
@@ -8,8 +8,8 @@ import Foundation
 @testable import ReadiumShared
 import Testing
 
-@Suite enum AnyURLTests {
-    @Suite struct Equality {
+enum AnyURLTests {
+    struct Equality {
         @Test("equal URLs compare as equal")
         func equality() throws {
             #expect(AnyURL(string: "opds://domain.com") == AnyURL(string: "opds://domain.com"))
@@ -25,7 +25,7 @@ import Testing
         }
     }
 
-    @Suite struct Creation {
+    struct Creation {
         @Test("invalid URLs return nil")
         func createFromInvalidUrl() {
             #expect(AnyURL(string: "") == nil)
@@ -68,7 +68,7 @@ import Testing
         }
     }
 
-    @Suite struct Resolution {
+    struct Resolution {
         @Test("resolves relative URLs against an HTTP base")
         func resolveHTTPURL() throws {
             var base = try #require(AnyURL(string: "http://example.com/foo/bar"))
@@ -117,7 +117,7 @@ import Testing
         }
     }
 
-    @Suite struct Relativization {
+    struct Relativization {
         @Test("relativizes URLs against an HTTP base")
         func relativizeHTTPURL() throws {
             var base = try #require(AnyURL(string: "http://example.com/foo"))
@@ -160,7 +160,7 @@ import Testing
         }
     }
 
-    @Suite struct Normalization {
+    struct Normalization {
         @Test("scheme is lowercased, path is decoded, relative segments are resolved")
         func normalized() {
             // Scheme is lower case.
@@ -187,7 +187,7 @@ import Testing
         }
     }
 
-    @Suite struct Fragment {
+    struct Fragment {
         @Test("replacingFragment sets or removes the fragment")
         func replacingFragment() {
             // Sets fragment on URL without one.

--- a/Tests/SharedTests/Toolkit/URL/RelativeURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/RelativeURLTests.swift
@@ -6,219 +6,243 @@
 
 import Foundation
 @testable import ReadiumShared
-import XCTest
+import Testing
 
-class RelativeURLTests: XCTestCase {
-    func testEquality() throws {
-        XCTAssertEqual(
-            RelativeURL(string: "dir/file"),
-            RelativeURL(string: "dir/file")
-        )
-        XCTAssertNotEqual(
-            try XCTUnwrap(RelativeURL(string: "dir/file/")),
-            try XCTUnwrap(RelativeURL(string: "dir/file"))
-        )
-        XCTAssertNotEqual(
-            try XCTUnwrap(RelativeURL(string: "dir")),
-            try XCTUnwrap(RelativeURL(string: "dir/file"))
-        )
+@Suite enum RelativeURLTests {
+    @Suite struct Equality {
+        @Test("equal URLs compare as equal")
+        func equality() throws {
+            #expect(RelativeURL(string: "dir/file") == RelativeURL(string: "dir/file"))
+            #expect(try #require(RelativeURL(string: "dir/file/")) != #require(RelativeURL(string: "dir/file")))
+            #expect(try #require(RelativeURL(string: "dir")) != #require(RelativeURL(string: "dir/file")))
+        }
     }
 
-    // MARK: - URLProtocol
+    @Suite struct URLProtocolImplementation {
+        @Test("creates from Foundation URL")
+        func createFromURL() throws {
+            #expect(try RelativeURL(url: #require(URL(string: "https://domain.com"))) == nil)
+            #expect(RelativeURL(url: URL(fileURLWithPath: "/dir/file")) == nil)
+            #expect(try RelativeURL(url: #require(URL(string: "/dir/file")))?.string == "/dir/file")
+        }
 
-    func testCreateFromURL() throws {
-        XCTAssertNil(try RelativeURL(url: XCTUnwrap(URL(string: "https://domain.com"))))
-        XCTAssertNil(RelativeURL(url: URL(fileURLWithPath: "/dir/file")))
-        XCTAssertEqual(try RelativeURL(url: XCTUnwrap(URL(string: "/dir/file")))?.string, "/dir/file")
+        @Test("creates from decoded path string")
+        func createFromPath() {
+            // Empty
+            #expect(RelativeURL(path: "")?.string == nil)
+            // Whitespace
+            #expect(RelativeURL(path: "  ")?.string == "%20%20")
+            // Relative path
+            #expect(RelativeURL(path: "foo/bar")?.string == "foo/bar")
+            // Absolute to root
+            #expect(RelativeURL(path: "/foo/bar")?.string == "/foo/bar")
+            // Containing special characters valid in a path
+            #expect(RelativeURL(path: "$&+,/=@")?.string == "$&+,/=@")
+            // Containing special characters and ..
+            #expect(RelativeURL(path: "foo/../bar baz")?.string == "foo/../bar%20baz")
+            #expect(RelativeURL(path: "../foo")?.string == "../foo")
+        }
+
+        @Test("creates from percent-encoded string")
+        func createFromString() {
+            // Empty
+            #expect(RelativeURL(string: "")?.string == nil)
+            // Whitespace
+            #expect(RelativeURL(string: "%20%20")?.string == "%20%20")
+            // Percent-encoded special characters
+            #expect(RelativeURL(string: "foo/../bar%20baz?query#fragment")?.string == "foo/../bar%20baz?query#fragment")
+            // Invalid characters
+            #expect(RelativeURL(string: "foo/../bar baz") == nil)
+            // Absolute URL
+            #expect(RelativeURL(string: "https://domain.com") == nil)
+            #expect(RelativeURL(string: "file:///dir/file") == nil)
+            // Fragment only
+            #expect(RelativeURL(string: "#")?.string == "#")
+            #expect(RelativeURL(string: "#fragment")?.string == "#fragment")
+            // Query only
+            #expect(RelativeURL(string: "?query=foo%bar")?.string == "?query=foo%bar")
+        }
+
+        @Test("url property returns Foundation URL")
+        func url() {
+            #expect(RelativeURL(string: "foo/bar?query#fragment")?.url == URL(string: "foo/bar?query#fragment"))
+        }
+
+        @Test("string property returns percent-encoded string")
+        func string() {
+            #expect(RelativeURL(string: "foo/bar?query#fragment")?.string == "foo/bar?query#fragment")
+        }
+
+        @Test("path is percent-decoded")
+        func path() {
+            #expect(RelativeURL(string: "foo/bar%20baz")?.path == "foo/bar baz")
+            #expect(RelativeURL(string: "foo/bar%20baz/")?.path == "foo/bar baz/")
+            #expect(RelativeURL(string: "/foo/bar%20baz")?.path == "/foo/bar baz")
+            #expect(RelativeURL(string: "foo/bar?query#fragment")?.path == "foo/bar")
+            #expect(RelativeURL(string: "#fragment")?.path == "")
+            #expect(RelativeURL(string: "?query")?.path == "")
+        }
+
+        @Test("appendingPath appends a decoded path segment")
+        func appendingPath() throws {
+            var base = try #require(RelativeURL(string: "foo/bar"))
+            #expect(base.appendingPath("", isDirectory: false).string == "foo/bar")
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "foo/bar/baz/quz")
+            #expect(base.appendingPath("/baz/quz", isDirectory: false).string == "foo/bar/baz/quz")
+            // The path is supposed to be decoded
+            #expect(base.appendingPath("baz quz", isDirectory: false).string == "foo/bar/baz%20quz")
+            #expect(base.appendingPath("baz%20quz", isDirectory: false).string == "foo/bar/baz%2520quz")
+            // Directory
+            #expect(base.appendingPath("baz/quz", isDirectory: true).string == "foo/bar/baz/quz/")
+            #expect(base.appendingPath("baz/quz/", isDirectory: true).string == "foo/bar/baz/quz/")
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "foo/bar/baz/quz")
+            #expect(base.appendingPath("baz/quz/", isDirectory: false).string == "foo/bar/baz/quz")
+
+            // With trailing slash.
+            base = try #require(RelativeURL(string: "foo/bar/"))
+            #expect(base.appendingPath("baz/quz", isDirectory: false).string == "foo/bar/baz/quz")
+        }
+
+        @Test("pathSegments returns percent-decoded segments")
+        func pathSegments() {
+            #expect(RelativeURL(string: "foo")?.pathSegments == ["foo"])
+            // Segments are percent-decoded.
+            #expect(RelativeURL(string: "foo/bar%20baz")?.pathSegments == ["foo", "bar baz"])
+            #expect(RelativeURL(string: "foo/bar%20baz/")?.pathSegments == ["foo", "bar baz"])
+            #expect(RelativeURL(string: "/foo/bar%20baz")?.pathSegments == ["foo", "bar baz"])
+            #expect(RelativeURL(string: "foo/bar?query#fragment")?.pathSegments == ["foo", "bar"])
+            #expect(RelativeURL(string: "#fragment")?.pathSegments == [])
+            #expect(RelativeURL(string: "?query")?.pathSegments == [])
+        }
+
+        @Test("lastPathSegment returns the last decoded segment")
+        func lastPathSegment() {
+            #expect(RelativeURL(string: "foo/bar%20baz")?.lastPathSegment == "bar baz")
+            #expect(RelativeURL(string: "foo/bar%20baz/")?.lastPathSegment == "bar baz")
+            #expect(RelativeURL(string: "foo/bar?query#fragment")?.lastPathSegment == "bar")
+            #expect(RelativeURL(string: "#fragment")?.lastPathSegment == nil)
+            #expect(RelativeURL(string: "?query")?.lastPathSegment == nil)
+        }
+
+        @Test("removingLastPathSegment removes the last path segment")
+        func removingLastPathSegment() {
+            #expect(RelativeURL(string: "foo")?.removingLastPathSegment().string == "./")
+            #expect(RelativeURL(string: "foo/bar")?.removingLastPathSegment().string == "foo/")
+            #expect(RelativeURL(string: "foo/bar/")?.removingLastPathSegment().string == "foo/")
+            #expect(RelativeURL(string: "/foo")?.removingLastPathSegment().string == "/")
+            #expect(RelativeURL(string: "/foo/bar")?.removingLastPathSegment().string == "/foo/")
+            #expect(RelativeURL(string: "/foo/bar/")?.removingLastPathSegment().string == "/foo/")
+        }
+
+        @Test("pathExtension returns the file extension")
+        func pathExtension() {
+            #expect(RelativeURL(string: "foo/bar.txt")?.pathExtension == "txt")
+            #expect(RelativeURL(string: "foo/bar")?.pathExtension == nil)
+            #expect(RelativeURL(string: "foo/bar/")?.pathExtension == nil)
+            #expect(RelativeURL(string: "foo/.hidden")?.pathExtension == nil)
+        }
+
+        @Test("replacingPathExtension replaces or removes the file extension")
+        func replacingPathExtension() {
+            #expect(RelativeURL(string: "/foo/bar")?.replacingPathExtension("xml").string == "/foo/bar.xml")
+            #expect(RelativeURL(string: "/foo/bar.txt")?.replacingPathExtension("xml").string == "/foo/bar.xml")
+            #expect(RelativeURL(string: "/foo/bar.txt")?.replacingPathExtension(nil).string == "/foo/bar")
+            #expect(RelativeURL(string: "/foo/bar/")?.replacingPathExtension("xml").string == "/foo/bar/")
+            #expect(RelativeURL(string: "/foo/bar/")?.replacingPathExtension(nil).string == "/foo/bar/")
+        }
+
+        @Test("query returns parsed query parameters")
+        func query() {
+            #expect(RelativeURL(string: "foo/bar")?.query == nil)
+            #expect(
+                RelativeURL(string: "foo/bar?param=quz%20baz")?.query
+                    == URLQuery(parameters: [.init(name: "param", value: "quz baz")])
+            )
+        }
+
+        @Test("removingQuery removes the query component")
+        func removingQuery() {
+            #expect(RelativeURL(string: "foo/bar")?.removingQuery() == RelativeURL(string: "foo/bar"))
+            #expect(RelativeURL(string: "foo/bar?param=quz%20baz")?.removingQuery() == RelativeURL(string: "foo/bar"))
+        }
+
+        @Test("fragment is percent-decoded")
+        func fragment() {
+            #expect(RelativeURL(string: "foo/bar")?.fragment == nil)
+            #expect(RelativeURL(string: "foo/bar#quz%20baz")?.fragment == "quz baz")
+        }
+
+        @Test("removingFragment removes the fragment component")
+        func removingFragment() {
+            #expect(RelativeURL(string: "foo/bar")?.removingFragment() == RelativeURL(string: "foo/bar"))
+            #expect(RelativeURL(string: "foo/bar#quz%20baz")?.removingFragment() == RelativeURL(string: "foo/bar"))
+        }
+
+        @Test("replacingFragment sets or removes the fragment")
+        func replacingFragment() {
+            // Sets fragment on URL without one.
+            #expect(RelativeURL(string: "foo/bar")?.replacingFragment("baz").string == "foo/bar#baz")
+            // Replaces existing fragment.
+            #expect(RelativeURL(string: "foo/bar#old")?.replacingFragment("new").string == "foo/bar#new")
+            // Removing via nil matches removingFragment().
+            #expect(RelativeURL(string: "foo/bar#quz%20baz")?.replacingFragment(nil) == RelativeURL(string: "foo/bar"))
+            // Fragment is percent-encoded.
+            #expect(RelativeURL(string: "foo/bar")?.replacingFragment("quz baz").string == "foo/bar#quz%20baz")
+        }
     }
 
-    func testCreateFromPath() {
-        // Empty
-        XCTAssertNil(RelativeURL(path: "")?.string, "")
-        // Whitespace
-        XCTAssertEqual(RelativeURL(path: "  ")?.string, "%20%20")
-        // Relative path
-        XCTAssertEqual(RelativeURL(path: "foo/bar")?.string, "foo/bar")
-        // Absolute to root
-        XCTAssertEqual(RelativeURL(path: "/foo/bar")?.string, "/foo/bar")
-        // Containing special characters valid in a path
-        XCTAssertEqual(RelativeURL(path: "$&+,/=@")?.string, "$&+,/=@")
-        // Containing special characters and ..
-        XCTAssertEqual(RelativeURL(path: "foo/../bar baz")?.string, "foo/../bar%20baz")
-        XCTAssertEqual(RelativeURL(path: "../foo")?.string, "../foo")
-    }
+    @Suite struct RelativeURLImplementation {
+        @Test("resolves against any URLConvertible")
+        func resolveURLConvertible() throws {
+            let base = try #require(RelativeURL(string: "foo/bar"))
+            #expect(try base.resolve(#require(AnyURL(string: "quz")))?.string == "foo/quz")
+            #expect(try base.resolve(#require(HTTPURL(string: "http://domain.com")))?.string == "http://domain.com")
+            #expect(try base.resolve(#require(FileURL(string: "file:///foo")))?.string == "file:///foo")
+        }
 
-    func testCreateFromString() {
-        // Empty
-        XCTAssertNil(RelativeURL(string: "")?.string)
-        // Whitespace
-        XCTAssertEqual(RelativeURL(string: "%20%20")?.string, "%20%20")
-        // Percent-encoded special characters
-        XCTAssertEqual(RelativeURL(string: "foo/../bar%20baz?query#fragment")?.string, "foo/../bar%20baz?query#fragment")
-        // Invalid characters
-        XCTAssertNil(RelativeURL(string: "foo/../bar baz"))
-        // Absolute URL
-        XCTAssertNil(RelativeURL(string: "https://domain.com"))
-        XCTAssertNil(RelativeURL(string: "file:///dir/file"))
-        // Fragment only
-        XCTAssertEqual(RelativeURL(string: "#")?.string, "#")
-        XCTAssertEqual(RelativeURL(string: "#fragment")?.string, "#fragment")
-        // Query only
-        XCTAssertEqual(RelativeURL(string: "?query=foo%bar")?.string, "?query=foo%bar")
-    }
+        @Test("resolves relative URL against another relative URL")
+        func resolveRelativeURL() throws {
+            var base = try #require(RelativeURL(string: "foo/bar"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == RelativeURL(string: "foo/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "../quz/baz"))) == RelativeURL(string: "quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "/quz/baz"))) == RelativeURL(string: "/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "#fragment"))) == RelativeURL(string: "foo/bar#fragment"))
 
-    func testURL() {
-        XCTAssertEqual(RelativeURL(string: "foo/bar?query#fragment")?.url, URL(string: "foo/bar?query#fragment"))
-    }
+            // With trailing slash
+            base = try #require(RelativeURL(string: "foo/bar/"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == RelativeURL(string: "foo/bar/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "../quz/baz"))) == RelativeURL(string: "foo/quz/baz"))
 
-    func testString() {
-        XCTAssertEqual(RelativeURL(string: "foo/bar?query#fragment")?.string, "foo/bar?query#fragment")
-    }
+            // With starting slash
+            base = try #require(RelativeURL(string: "/foo/bar"))
+            #expect(try base.resolve(#require(RelativeURL(string: "quz/baz"))) == RelativeURL(string: "/foo/quz/baz"))
+            #expect(try base.resolve(#require(RelativeURL(string: "/quz/baz"))) == RelativeURL(string: "/quz/baz"))
+        }
 
-    func testPath() {
-        // Path is percent-decoded.
-        XCTAssertEqual(RelativeURL(string: "foo/bar%20baz")?.path, "foo/bar baz")
-        XCTAssertEqual(RelativeURL(string: "foo/bar%20baz/")?.path, "foo/bar baz/")
-        XCTAssertEqual(RelativeURL(string: "/foo/bar%20baz")?.path, "/foo/bar baz")
-        XCTAssertEqual(RelativeURL(string: "foo/bar?query#fragment")?.path, "foo/bar")
-        XCTAssertEqual(RelativeURL(string: "#fragment")?.path, "")
-        XCTAssertEqual(RelativeURL(string: "?query")?.path, "")
-    }
+        @Test("relativizes a URL against this base")
+        func relativize() throws {
+            var base = try #require(RelativeURL(string: "foo"))
+            #expect(try base.relativize(#require(AnyURL(string: "foo/quz/baz"))) == RelativeURL(string: "quz/baz"))
+            #expect(try base.relativize(#require(AnyURL(string: "foo#fragment"))) == RelativeURL(string: "#fragment"))
+            #expect(try base.relativize(#require(AnyURL(string: "quz/baz"))) == nil)
+            #expect(try base.relativize(#require(AnyURL(string: "/foo/bar"))) == nil)
 
-    func testAppendingPath() throws {
-        var base = try XCTUnwrap(RelativeURL(string: "foo/bar"))
-        XCTAssertEqual(base.appendingPath("", isDirectory: false).string, "foo/bar")
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "foo/bar/baz/quz")
-        XCTAssertEqual(base.appendingPath("/baz/quz", isDirectory: false).string, "foo/bar/baz/quz")
-        // The path is supposed to be decoded
-        XCTAssertEqual(base.appendingPath("baz quz", isDirectory: false).string, "foo/bar/baz%20quz")
-        XCTAssertEqual(base.appendingPath("baz%20quz", isDirectory: false).string, "foo/bar/baz%2520quz")
-        // Directory
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: true).string, "foo/bar/baz/quz/")
-        XCTAssertEqual(base.appendingPath("baz/quz/", isDirectory: true).string, "foo/bar/baz/quz/")
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "foo/bar/baz/quz")
-        XCTAssertEqual(base.appendingPath("baz/quz/", isDirectory: false).string, "foo/bar/baz/quz")
+            // With trailing slash
+            base = try #require(RelativeURL(string: "foo/"))
+            #expect(try base.relativize(#require(AnyURL(string: "foo/quz/baz"))) == RelativeURL(string: "quz/baz"))
 
-        // With trailing slash.
-        base = try XCTUnwrap(RelativeURL(string: "foo/bar/"))
-        XCTAssertEqual(base.appendingPath("baz/quz", isDirectory: false).string, "foo/bar/baz/quz")
-    }
+            // With starting slash
+            base = try #require(RelativeURL(string: "/foo"))
+            #expect(try base.relativize(#require(AnyURL(string: "/foo/quz/baz"))) == RelativeURL(string: "quz/baz"))
+            #expect(try base.relativize(#require(AnyURL(string: "foo/quz"))) == nil)
+            #expect(try base.relativize(#require(AnyURL(string: "/quz/baz"))) == nil)
+        }
 
-    func testPathSegments() {
-        XCTAssertEqual(RelativeURL(string: "foo")?.pathSegments, ["foo"])
-        // Segments are percent-decoded.
-        XCTAssertEqual(RelativeURL(string: "foo/bar%20baz")?.pathSegments, ["foo", "bar baz"])
-        XCTAssertEqual(RelativeURL(string: "foo/bar%20baz/")?.pathSegments, ["foo", "bar baz"])
-        XCTAssertEqual(RelativeURL(string: "/foo/bar%20baz")?.pathSegments, ["foo", "bar baz"])
-        XCTAssertEqual(RelativeURL(string: "foo/bar?query#fragment")?.pathSegments, ["foo", "bar"])
-        XCTAssertEqual(RelativeURL(string: "#fragment")?.pathSegments, [])
-        XCTAssertEqual(RelativeURL(string: "?query")?.pathSegments, [])
-    }
-
-    func testLastPathSegment() {
-        XCTAssertEqual(RelativeURL(string: "foo/bar%20baz")?.lastPathSegment, "bar baz")
-        XCTAssertEqual(RelativeURL(string: "foo/bar%20baz/")?.lastPathSegment, "bar baz")
-        XCTAssertEqual(RelativeURL(string: "foo/bar?query#fragment")?.lastPathSegment, "bar")
-        XCTAssertNil(RelativeURL(string: "#fragment")?.lastPathSegment)
-        XCTAssertNil(RelativeURL(string: "?query")?.lastPathSegment)
-    }
-
-    func testRemovingLastPathSegment() {
-        XCTAssertEqual(RelativeURL(string: "foo")?.removingLastPathSegment().string, "./")
-        XCTAssertEqual(RelativeURL(string: "foo/bar")?.removingLastPathSegment().string, "foo/")
-        XCTAssertEqual(RelativeURL(string: "foo/bar/")?.removingLastPathSegment().string, "foo/")
-        XCTAssertEqual(RelativeURL(string: "/foo")?.removingLastPathSegment().string, "/")
-        XCTAssertEqual(RelativeURL(string: "/foo/bar")?.removingLastPathSegment().string, "/foo/")
-        XCTAssertEqual(RelativeURL(string: "/foo/bar/")?.removingLastPathSegment().string, "/foo/")
-    }
-
-    func testPathExtension() {
-        XCTAssertEqual(RelativeURL(string: "foo/bar.txt")?.pathExtension, "txt")
-        XCTAssertNil(RelativeURL(string: "foo/bar")?.pathExtension)
-        XCTAssertNil(RelativeURL(string: "foo/bar/")?.pathExtension)
-        XCTAssertNil(RelativeURL(string: "foo/.hidden")?.pathExtension)
-    }
-
-    func testReplacingPathExtension() {
-        XCTAssertEqual(RelativeURL(string: "/foo/bar")?.replacingPathExtension("xml").string, "/foo/bar.xml")
-        XCTAssertEqual(RelativeURL(string: "/foo/bar.txt")?.replacingPathExtension("xml").string, "/foo/bar.xml")
-        XCTAssertEqual(RelativeURL(string: "/foo/bar.txt")?.replacingPathExtension(nil).string, "/foo/bar")
-        XCTAssertEqual(RelativeURL(string: "/foo/bar/")?.replacingPathExtension("xml").string, "/foo/bar/")
-        XCTAssertEqual(RelativeURL(string: "/foo/bar/")?.replacingPathExtension(nil).string, "/foo/bar/")
-    }
-
-    func testQuery() {
-        XCTAssertNil(RelativeURL(string: "foo/bar")?.query)
-        XCTAssertEqual(
-            RelativeURL(string: "foo/bar?param=quz%20baz")?.query,
-            URLQuery(parameters: [.init(name: "param", value: "quz baz")])
-        )
-    }
-
-    func testRemovingQuery() {
-        XCTAssertEqual(RelativeURL(string: "foo/bar")?.removingQuery(), RelativeURL(string: "foo/bar"))
-        XCTAssertEqual(RelativeURL(string: "foo/bar?param=quz%20baz")?.removingQuery(), RelativeURL(string: "foo/bar"))
-    }
-
-    func testFragment() {
-        XCTAssertNil(RelativeURL(string: "foo/bar")?.fragment)
-        XCTAssertEqual(RelativeURL(string: "foo/bar#quz%20baz")?.fragment, "quz baz")
-    }
-
-    func testRemovingFragment() {
-        XCTAssertEqual(RelativeURL(string: "foo/bar")?.removingFragment(), RelativeURL(string: "foo/bar"))
-        XCTAssertEqual(RelativeURL(string: "foo/bar#quz%20baz")?.removingFragment(), RelativeURL(string: "foo/bar"))
-    }
-
-    // MARK: - RelativeURL
-
-    func testResolveURLConvertible() throws {
-        let base = try XCTUnwrap(RelativeURL(string: "foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(AnyURL(string: "quz")))?.string, "foo/quz")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(HTTPURL(string: "http://domain.com")))?.string, "http://domain.com")
-        XCTAssertEqual(try base.resolve(XCTUnwrap(FileURL(string: "file:///foo")))?.string, "file:///foo")
-    }
-
-    func testResolveRelativeURL() throws {
-        var base = try XCTUnwrap(RelativeURL(string: "foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), RelativeURL(string: "foo/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "../quz/baz"))), RelativeURL(string: "quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "/quz/baz"))), RelativeURL(string: "/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "#fragment"))), RelativeURL(string: "foo/bar#fragment"))
-
-        // With trailing slash
-        base = try XCTUnwrap(RelativeURL(string: "foo/bar/"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), RelativeURL(string: "foo/bar/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "../quz/baz"))), RelativeURL(string: "foo/quz/baz"))
-
-        // With starting slash
-        base = try XCTUnwrap(RelativeURL(string: "/foo/bar"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "quz/baz"))), RelativeURL(string: "/foo/quz/baz"))
-        XCTAssertEqual(try base.resolve(XCTUnwrap(RelativeURL(string: "/quz/baz"))), RelativeURL(string: "/quz/baz"))
-    }
-
-    func testRelativize() throws {
-        var base = try XCTUnwrap(RelativeURL(string: "foo"))
-
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "foo/quz/baz"))), RelativeURL(string: "quz/baz"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "foo#fragment"))), RelativeURL(string: "#fragment"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "quz/baz"))))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "/foo/bar"))))
-
-        // With trailing slash
-        base = try XCTUnwrap(RelativeURL(string: "foo/"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "foo/quz/baz"))), RelativeURL(string: "quz/baz"))
-
-        // With starting slash
-        base = try XCTUnwrap(RelativeURL(string: "/foo"))
-        XCTAssertEqual(try base.relativize(XCTUnwrap(AnyURL(string: "/foo/quz/baz"))), RelativeURL(string: "quz/baz"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "foo/quz"))))
-        XCTAssertNil(try base.relativize(XCTUnwrap(AnyURL(string: "/quz/baz"))))
-    }
-
-    func testRelativizeAbsoluteURL() throws {
-        let base = try XCTUnwrap(RelativeURL(string: "foo"))
-        XCTAssertNil(try base.relativize(XCTUnwrap(HTTPURL(string: "http://example.com/foo/bar"))))
-        XCTAssertNil(try base.relativize(XCTUnwrap(FileURL(string: "file:///foo"))))
+        @Test("absolute URL returns nil when relativized against a relative base")
+        func relativizeAbsoluteURL() throws {
+            let base = try #require(RelativeURL(string: "foo"))
+            #expect(try base.relativize(#require(HTTPURL(string: "http://example.com/foo/bar"))) == nil)
+            #expect(try base.relativize(#require(FileURL(string: "file:///foo"))) == nil)
+        }
     }
 }

--- a/Tests/SharedTests/Toolkit/URL/RelativeURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/RelativeURLTests.swift
@@ -8,8 +8,8 @@ import Foundation
 @testable import ReadiumShared
 import Testing
 
-@Suite enum RelativeURLTests {
-    @Suite struct Equality {
+enum RelativeURLTests {
+    struct Equality {
         @Test("equal URLs compare as equal")
         func equality() throws {
             #expect(RelativeURL(string: "dir/file") == RelativeURL(string: "dir/file"))
@@ -18,7 +18,7 @@ import Testing
         }
     }
 
-    @Suite struct URLProtocolImplementation {
+    struct URLProtocolImplementation {
         @Test("creates from Foundation URL")
         func createFromURL() throws {
             #expect(try RelativeURL(url: #require(URL(string: "https://domain.com"))) == nil)
@@ -191,7 +191,7 @@ import Testing
         }
     }
 
-    @Suite struct RelativeURLImplementation {
+    struct RelativeURLImplementation {
         @Test("resolves against any URLConvertible")
         func resolveURLConvertible() throws {
             let base = try #require(RelativeURL(string: "foo/bar"))

--- a/Tests/SharedTests/Toolkit/URL/URLQueryTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/URLQueryTests.swift
@@ -8,8 +8,8 @@ import Foundation
 @testable import ReadiumShared
 import Testing
 
-@Suite enum URLQueryTests {
-    @Suite struct Parsing {
+enum URLQueryTests {
+    struct Parsing {
         @Test("URL without query returns nil")
         func parseEmptyQuery() throws {
             let query = try URLQuery(url: #require(URL(string: "foo")))
@@ -18,8 +18,8 @@ import Testing
 
         @Test("first(named:) returns the first matching parameter value")
         func getFirstQueryParameterNamedX() throws {
-            let query = try #require(try URLQuery(
-                url: #require(URL(string: "foo?query=param&fruit=banana&query=other&empty"))
+            let query = try #require(URLQuery(
+                url: URL(string: "foo?query=param&fruit=banana&query=other&empty")!
             ))
             #expect(query.first(named: "query") == "param")
             #expect(query.first(named: "fruit") == "banana")
@@ -29,8 +29,8 @@ import Testing
 
         @Test("all(named:) returns all matching parameter values")
         func getAllQueryParametersNamedX() throws {
-            let query = try #require(try URLQuery(
-                url: #require(URL(string: "foo?query=param&fruit=banana&query=other&empty"))
+            let query = try #require(URLQuery(
+                url: URL(string: "foo?query=param&fruit=banana&query=other&empty")!
             ))
             #expect(query.all(named: "query") == ["param", "other"])
             #expect(query.all(named: "fruit") == ["banana"])
@@ -40,8 +40,8 @@ import Testing
 
         @Test("parameter values are percent-decoded")
         func queryParameterArePercentDecoded() throws {
-            let query = try #require(try URLQuery(
-                url: #require(URL(string: "foo?query=hello%20world"))
+            let query = try #require(URLQuery(
+                url: URL(string: "foo?query=hello%20world")!
             ))
             #expect(query.first(named: "query") == "hello world")
         }

--- a/Tests/SharedTests/Toolkit/URL/URLQueryTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/URLQueryTests.swift
@@ -6,40 +6,44 @@
 
 import Foundation
 @testable import ReadiumShared
-import XCTest
+import Testing
 
-class URLQueryTests: XCTestCase {
-    func testParseEmptyQuery() throws {
-        let query = try URLQuery(url: XCTUnwrap(URL(string: "foo")))
-        XCTAssertNil(query)
-    }
+@Suite enum URLQueryTests {
+    @Suite struct Parsing {
+        @Test("URL without query returns nil")
+        func parseEmptyQuery() throws {
+            let query = try URLQuery(url: #require(URL(string: "foo")))
+            #expect(query == nil)
+        }
 
-    func testGetFirstQueryParameterNamedX() throws {
-        let query = try XCTUnwrap(try URLQuery(
-            url: XCTUnwrap(URL(string: "foo?query=param&fruit=banana&query=other&empty"))
-        ))
+        @Test("first(named:) returns the first matching parameter value")
+        func getFirstQueryParameterNamedX() throws {
+            let query = try #require(try URLQuery(
+                url: #require(URL(string: "foo?query=param&fruit=banana&query=other&empty"))
+            ))
+            #expect(query.first(named: "query") == "param")
+            #expect(query.first(named: "fruit") == "banana")
+            #expect(query.first(named: "empty") == nil)
+            #expect(query.first(named: "not-found") == nil)
+        }
 
-        XCTAssertEqual(query.first(named: "query"), "param")
-        XCTAssertEqual(query.first(named: "fruit"), "banana")
-        XCTAssertNil(query.first(named: "empty"))
-        XCTAssertNil(query.first(named: "not-found"))
-    }
+        @Test("all(named:) returns all matching parameter values")
+        func getAllQueryParametersNamedX() throws {
+            let query = try #require(try URLQuery(
+                url: #require(URL(string: "foo?query=param&fruit=banana&query=other&empty"))
+            ))
+            #expect(query.all(named: "query") == ["param", "other"])
+            #expect(query.all(named: "fruit") == ["banana"])
+            #expect(query.all(named: "empty") == [])
+            #expect(query.all(named: "not-found") == [])
+        }
 
-    func testGetAllQueryParametersNamedX() throws {
-        let query = try XCTUnwrap(try URLQuery(
-            url: XCTUnwrap(URL(string: "foo?query=param&fruit=banana&query=other&empty"))
-        ))
-
-        XCTAssertEqual(query.all(named: "query"), ["param", "other"])
-        XCTAssertEqual(query.all(named: "fruit"), ["banana"])
-        XCTAssertEqual(query.all(named: "empty"), [])
-        XCTAssertEqual(query.all(named: "not-found"), [])
-    }
-
-    func testQueryParameterArePercentDecoded() throws {
-        let query = try XCTUnwrap(try URLQuery(
-            url: XCTUnwrap(URL(string: "foo?query=hello%20world"))
-        ))
-        XCTAssertEqual(query.first(named: "query"), "hello world")
+        @Test("parameter values are percent-decoded")
+        func queryParameterArePercentDecoded() throws {
+            let query = try #require(try URLQuery(
+                url: #require(URL(string: "foo?query=hello%20world"))
+            ))
+            #expect(query.first(named: "query") == "hello world")
+        }
     }
 }

--- a/Tests/StreamerTests/Parser/EPUB/SMIL/SMILGuidedNavigationServiceTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/SMIL/SMILGuidedNavigationServiceTests.swift
@@ -9,7 +9,7 @@ import ReadiumShared
 @testable import ReadiumStreamer
 import Testing
 
-@Suite class SMILGuidedNavigationServiceTests {
+class SMILGuidedNavigationServiceTests {
     let smilData = """
     <?xml version="1.0" encoding="utf-8"?>
     <smil xmlns="http://www.w3.org/ns/SMIL" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0">

--- a/Tests/StreamerTests/Parser/EPUB/SMIL/SMILParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/SMIL/SMILParserTests.swift
@@ -9,7 +9,7 @@ import ReadiumShared
 @testable import ReadiumStreamer
 import Testing
 
-@Suite enum SMILParserTests {
+enum SMILParserTests {
     static let fixtures = Fixtures(path: "SMIL")
 
     /// Returns the parsed document for the given SMIL fixture filename.

--- a/Tests/StreamerTests/Parser/Readium/ReadiumGuidedNavigationServiceTests.swift
+++ b/Tests/StreamerTests/Parser/Readium/ReadiumGuidedNavigationServiceTests.swift
@@ -9,7 +9,7 @@ import ReadiumShared
 @testable import ReadiumStreamer
 import Testing
 
-@Suite class ReadiumGuidedNavigationServiceTests {
+class ReadiumGuidedNavigationServiceTests {
     /// Per-resource GN alternate link.
     lazy var gnLink = Link(
         href: "guided.json",


### PR DESCRIPTION
The PDF navigator now fires the same `VisualNavigatorDelegate` callbacks for internal link taps that the EPUB navigator already supports:

- `navigator(_:shouldNavigateToLink:)` – called before navigation; return `false` to intercept it.
- `navigator(_:didJumpTo:)` – called after PDFKit navigates to the destination.

This is implemented by overriding `go(to: PDFDestination)` in `PDFDocumentView`, which is the method PDFKit calls when the user taps an internal link annotation. Programmatic navigation (via `go(to: PDFPage)`) is unaffected and does not trigger these callbacks.

## Changelog

### Added

#### Navigator

* The PDF navigator now calls `VisualNavigatorDelegate.navigator(_:shouldNavigateToLink:)` and `NavigatorDelegate.navigator(_:didJumpTo:)` when the user taps an internal link, matching the behavior of the EPUB navigator.