### PR TITLE
Update SwiftFormat version

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,4 +1,4 @@
---swiftversion 5.6
+--swiftversion 5.10
 --header "//\n//  Copyright {year} Readium Foundation. All rights reserved.\n//  Use of this source code is governed by the BSD-style license\n//  available in the top-level LICENSE file of the project.\n//"
 --stripunusedargs closure-only
---disable redundantSendable,noForceUnwrapInTests
+--disable redundantSendable,redundantSelf,noForceUnwrapInTests,conditionalAssignment,opaqueGenericParameters,typeSugar,genericExtensions,redundantOptionalBinding


### PR DESCRIPTION
## Summary


- Update the SwiftFormat target in `.swiftformat` to Swift version 5.10.
- Disable rules that would modify the codebase:
  - `conditionalAssignment`
  - `opaqueGenericParameters`
  - `typeSugar`
  - `genericExtensions`
  - `redundantSelf` — retain explicit `self.` for improved readability.
  - `redundantOptionalBinding` — maintain `if let a = a` instead of shorthand `if let a`.