### PR TITLE
Fixed EPUB reverting to previous preferences after a screen rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,12 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * [#737](https://github.com/readium/swift-toolkit/issues/737) Improved page turn animations in the EPUB navigator.
-    * Fixed screen glitches when turning with animations disabled.
+    * Fixed screen glitches when animations are disabled.
     * A slide animation is now used when navigating between adjacent resources.
 * The EPUB navigator now reports a continuous `locator.locations.totalProgression` value, interpolated from the actual scroll position within the resource's global progression range. Previously, the value was quantized to the nearest position in the position list.
 * Fixed a race condition in `EPUBNavigatorViewController` where rapidly calling `apply(decorations:in:)` for the same group could cause multiple decorations to appear simultaneously.
 * [#721](https://github.com/readium/swift-toolkit/issues/721) Fixed position of EPUB decorations when using the paragraph indent preference.
+* Fixed the EPUB navigator reverting to the previous EPUB preferences after a screen rotation for previously loaded resources.
 
 #### Streamer
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -349,6 +349,13 @@ enum EPUBScriptScope {
         let previous = css
         css.update(with: settings)
 
+        // HTML resources in the cache have the CSS already injected at the time
+        // they were first served. Evict them so that any future resource load
+        // (e.g. after a screen rotation) reflects the updated CSS instead of
+        // the stale cached version. Non-HTML resources (images, audio, etc.)
+        // are not affected by CSS changes and can remain cached.
+        server.clearResourceCache { _, mediaType in mediaType.isHTML }
+
         if commitNow {
             commitCSSChange(from: previous, to: css)
         }

--- a/Sources/Navigator/EPUB/WebViewServer.swift
+++ b/Sources/Navigator/EPUB/WebViewServer.swift
@@ -115,6 +115,12 @@ import WebKit
     /// Oldest entries are evicted when the cache exceeds its capacity.
     private var resourceCache = BoundedResourceCache()
 
+    /// Removes cached resources matching the given predicate, forcing them to
+    /// be re-served on the next request.
+    func clearResourceCache(where predicate: (RelativeURL, MediaType) -> Bool) {
+        resourceCache.remove(where: predicate)
+    }
+
     // MARK: - WKURLSchemeHandler
 
     func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
@@ -354,5 +360,15 @@ private struct BoundedResourceCache {
             let evicted = order.removeFirst()
             entries.removeValue(forKey: evicted)
         }
+    }
+
+    mutating func remove(where predicate: (RelativeURL, MediaType) -> Bool) {
+        let toRemove = order.filter { url in
+            entries[url].map { predicate(url, $0.1) } ?? false
+        }
+        for url in toRemove {
+            entries.removeValue(forKey: url)
+        }
+        order = order.filter { entries[$0] != nil }
     }
 }


### PR DESCRIPTION

## Changelog

### Fixed

#### Navigator

* Fixed the EPUB navigator reverting to the previous EPUB preferences after a screen rotation for previously loaded resources.

---

## Problem

When the user changes the EPUB theme (e.g. to sepia) and then rotates the screen, the background color momentarily reverts to the previous theme for resources that reload.

## Root cause

`WebViewServer` caches `Resource` objects in a `BoundedResourceCache`. For reflowable HTML files, the cached resource injects Readium CSS into the HTML at serve time.

After the user changes the theme, already-loaded web views are correctly updated but the cached `Resource` still holds the pre-change CSS-injected HTML.

When screen rotation triggers, the new spread views request their HTML from the server. The server finds the cached (stale) resource and serves the old CSS, causing the background color to revert.

## Fix

When `updateCSS()` is called (i.e. whenever EPUB preferences change), evict all HTML entries from the server's resource cache. Non-HTML resources (images, audio, fonts, ZIP-compressed binaries) are unaffected by CSS changes and remain cached.
