### PR TITLE
Fix LCP dialog UI

### DIFF
--- a/Sources/LCP/Authentications/LCPDialog.swift
+++ b/Sources/LCP/Authentications/LCPDialog.swift
@@ -213,9 +213,10 @@ public struct LCPDialog: View {
 
         if let onForgotPassphrase = onForgotPassphrase {
             Section {
-                Button(ReadiumLCPLocalizedStringKey("dialog.actions.recoverPassphrase"), role: .destructive) {
+                Button(ReadiumLCPLocalizedStringKey("dialog.actions.recoverPassphrase")) {
                     onForgotPassphrase()
                 }
+                .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, alignment: .center)
             }
         }

--- a/Sources/Shared/Toolkit/HTTP/DefaultHTTPClient.swift
+++ b/Sources/Shared/Toolkit/HTTP/DefaultHTTPClient.swift
@@ -406,13 +406,14 @@ public final class DefaultHTTPClient: HTTPClient, Loggable {
                 continuation.resume(returning: .success(response))
 
             case let .failure(continuation, error):
-                var errorDescription = ""
-                dump(error, to: &errorDescription)
-                
-                if case .cancelled = error {} else {
+                if case .cancelled = error {
+                    // no-op
+                } else {
+                    var errorDescription = ""
+                    dump(error, to: &errorDescription)
                     log(.error, "\(request.method) \(request.url) failed with:\n\(errorDescription)")
                 }
-                
+
                 continuation.resume(returning: .failure(error))
 
             case .initializing, .finished:

--- a/Sources/Shared/Toolkit/HTTP/DefaultHTTPClient.swift
+++ b/Sources/Shared/Toolkit/HTTP/DefaultHTTPClient.swift
@@ -408,7 +408,11 @@ public final class DefaultHTTPClient: HTTPClient, Loggable {
             case let .failure(continuation, error):
                 var errorDescription = ""
                 dump(error, to: &errorDescription)
-                log(.error, "\(request.method) \(request.url) failed with:\n\(errorDescription)")
+                
+                if case .cancelled = error {} else {
+                    log(.error, "\(request.method) \(request.url) failed with:\n\(errorDescription)")
+                }
+                
                 continuation.resume(returning: .failure(error))
 
             case .initializing, .finished:


### PR DESCRIPTION
The "Recover passphrase" button in the LCP dialog was displayed as `destructive` (in red), which did not fit its role.

Here's the new version:

<img width="474" height="532" alt="Screenshot 2026-04-21 at 17 45 43" src="https://github.com/user-attachments/assets/c891cd1e-5eb1-407f-8695-e3808a1102d0" />


+ And don't log `cancelled` HTTP errors.