### PR TITLE
Update Logger to be Swift 6 compliant

### DIFF
--- a/Sources/Shared/Logger/Loggable.swift
+++ b/Sources/Shared/Logger/Loggable.swift
@@ -63,11 +63,13 @@ public protocol Loggable {
 /// Default implementation
 public extension Loggable {
     func log(_ level: SeverityLevel, _ value: Any?, file: String, line: Int) {
-        Logger.sharedInstance.log(value, at: level, file: file, line: line)
+        let message = value.map { String(describing: $0) }
+        Logger.sharedInstance.log(message, at: level, file: file, line: line)
     }
 
     func log(_ level: SeverityLevel, _ value: Any?, defaultFile: String = #file, defaultLine: Int = #line) {
-        Logger.sharedInstance.log(value, at: level, file: defaultFile, line: defaultLine)
+        let message = value.map { String(describing: $0) }
+        Logger.sharedInstance.log(message, at: level, file: defaultFile, line: defaultLine)
     }
 
     @discardableResult func logAndRethrow<T>(_ block: () throws -> T) rethrows -> T {
@@ -80,11 +82,13 @@ public extension Loggable {
     }
 
     static func log(_ level: SeverityLevel, _ value: Any?, file: String, line: Int) {
-        Logger.sharedInstance.log(value, at: level, file: file, line: line)
+        let message = value.map { String(describing: $0) }
+        Logger.sharedInstance.log(message, at: level, file: file, line: line)
     }
 
     static func log(_ level: SeverityLevel, _ value: Any?, defaultFile: String = #file, defaultLine: Int = #line) {
-        Logger.sharedInstance.log(value, at: level, file: defaultFile, line: defaultLine)
+        let message = value.map { String(describing: $0) }
+        Logger.sharedInstance.log(message, at: level, file: defaultFile, line: defaultLine)
     }
 
     func warnIfMainThread(_ path: String = #file, _ function: String = #function, _ className: String = String(describing: Self.self), _ line: Int = #line) {

--- a/Sources/Shared/Logger/Logger.swift
+++ b/Sources/Shared/Logger/Logger.swift
@@ -21,22 +21,28 @@ public func ReadiumEnableLog(withMinimumSeverityLevel level: SeverityLevel, cust
 }
 
 /// The Logger protocol.
-public protocol LoggerType {
-    func log(level: SeverityLevel, value: Any?, file: String, line: Int)
+public protocol LoggerType: Sendable {
+    func log(level: SeverityLevel, value: String?, file: String, line: Int)
 }
 
 /// Logger singleton.
-public final class Logger {
-    /// The active logger is responssible for displaying the log message
-    /// throughout the framework. There is a default implementation `StubLogger`
-    /// available. You can define your own implementation by applying the
-    /// `Loggable` protocol to your xLogger class.
-    var activeLogger: LoggerType?
+public final class Logger: Sendable {
+    struct State {
+        /// The active logger responsible for displaying the log messages
+        /// throughout the framework. There is a default implementation `LoggerStub`
+        /// available. You can define your own implementation by conforming your
+        /// custom logger class to the `LoggerType` protocol.
+        var activeLogger: LoggerType?
 
-    /// The minimum severity level for logs to be displayed.
-    var minimumSeverityLevel: SeverityLevel?
+        /// The minimum severity level for logs to be displayed.
+        var minimumSeverityLevel: SeverityLevel?
+    }
 
-    private(set) static var sharedInstance = Logger()
+    private let state = Mutex(State())
+
+    static let sharedInstance = Logger()
+
+    private init() {}
 
     // MARK: - Public methods.
 
@@ -49,8 +55,10 @@ public final class Logger {
     public func setupLogger(logger: LoggerType,
                             withMinimumSeverityLevel severityLevel: SeverityLevel? = .warning)
     {
-        activeLogger = logger
-        minimumSeverityLevel = severityLevel
+        state.withLock { currentState in
+            currentState.activeLogger = logger
+            currentState.minimumSeverityLevel = severityLevel
+        }
     }
 
     /// Allow the framework user to set the minimum severity level for the logs
@@ -58,20 +66,20 @@ public final class Logger {
     ///
     /// - Parameter severityLevel: The value from the `SeverityLevel` enum.
     public func setMinimumSeverityLevel(at severityLevel: SeverityLevel?) {
-        guard let severityLevel = severityLevel else {
-            return
+        guard let severityLevel else { return }
+        state.withLock { currentState in
+            currentState.minimumSeverityLevel = severityLevel
         }
-        minimumSeverityLevel = severityLevel
     }
 
     // MARK: - Internal methods.
 
-    func log(_ value: Any?, at level: SeverityLevel, file: String, line: Int) {
-        if let minimumSeverityLevel = minimumSeverityLevel {
-            guard level.numericValue >= minimumSeverityLevel.numericValue else {
-                return
+    func log(_ value: String?, at level: SeverityLevel, file: String, line: Int) {
+        state.withLock { currentState in
+            if let minimumSeverityLevel = currentState.minimumSeverityLevel {
+                guard level.numericValue >= minimumSeverityLevel.numericValue else { return }
             }
+            currentState.activeLogger?.log(level: level, value: value, file: file, line: line)
         }
-        activeLogger?.log(level: level, value: value, file: file, line: line)
     }
 }

--- a/Sources/Shared/Logger/Logger.swift
+++ b/Sources/Shared/Logger/Logger.swift
@@ -14,8 +14,7 @@ import Foundation
 ///   - customLogger: The Logger that will be used for printing logs.
 ///     Defaults to a `LoggerStub` which may perform no-op logging.
 public func ReadiumEnableLog(withMinimumSeverityLevel level: SeverityLevel, customLogger: LoggerType = LoggerStub()) {
-    Logger.sharedInstance.setupLogger(logger: customLogger)
-    Logger.sharedInstance.setMinimumSeverityLevel(at: level)
+    Logger.sharedInstance.setupLogger(logger: customLogger, withMinimumSeverityLevel: level)
 
     print("\(SeverityLevel.info.symbol) Readium 2 Log enabled with minimum severity level of [\(level)].")
 }
@@ -75,11 +74,12 @@ public final class Logger: Sendable {
     // MARK: - Internal methods.
 
     func log(_ value: String?, at level: SeverityLevel, file: String, line: Int) {
-        state.withLock { currentState in
+        let logger: LoggerType? = state.withLock { currentState in
             if let minimumSeverityLevel = currentState.minimumSeverityLevel {
-                guard level.numericValue >= minimumSeverityLevel.numericValue else { return }
+                guard level.numericValue >= minimumSeverityLevel.numericValue else { return nil }
             }
-            currentState.activeLogger?.log(level: level, value: value, file: file, line: line)
+            return currentState.activeLogger
         }
+        logger?.log(level: level, value: value, file: file, line: line)
     }
 }

--- a/Sources/Shared/Logger/LoggerStub.swift
+++ b/Sources/Shared/Logger/LoggerStub.swift
@@ -12,7 +12,7 @@ public final class LoggerStub: LoggerType, Sendable {
     public init() {}
 
     /// Log `message` with a severity of `level`.
-    public func log(level: SeverityLevel, value: Any?, file: String, line: Int) {
+    public func log(level: SeverityLevel, value: String?, file: String, line: Int) {
         guard let value = value else {
             return
         }

--- a/Sources/Shared/Logger/LoggerStub.swift
+++ b/Sources/Shared/Logger/LoggerStub.swift
@@ -17,6 +17,6 @@ public final class LoggerStub: LoggerType, Sendable {
             return
         }
         let fileName = URL(fileURLWithPath: file).lastPathComponent
-        print("\(level.symbol) \(fileName):\(line): \(String(describing: value))")
+        print("\(level.symbol) \(fileName):\(line): \(value)")
     }
 }


### PR DESCRIPTION
The Logger class Now explicitly conforms to Sendable. The internal mutable state (activeLogger and minimumSeverityLevel) was moved into a nested State struct and wrapped in a Mutex. A private init() was added to prevent manual instantiation of the singleton.

### Public API Breaking Changes

LoggerType:

1. Now requires conformance to Sendable.
2. For the log function, the value parameter is now a `String?` instead of `Any?`.

```diff
-func log(level: SeverityLevel, value: Any?, file: String, line: Int)
+func log(level: SeverityLevel, value: String?, file: String, line: Int)
```

LoggerStub:

1. Log function was also updated to accept `value: String?` instead of `value: Any?`.

Related to https://github.com/readium/swift-toolkit/issues/758.