### PR TITLE
Make Streamable and Resource protocols Sendable   

### DIFF
--- a/Sources/LCP/Content Protection/LCPDecryptor.swift
+++ b/Sources/LCP/Content Protection/LCPDecryptor.swift
@@ -72,7 +72,7 @@ final class LCPDecryptor {
         private let resource: Resource
         private let license: LCPLicense
         private let encryption: ReadiumShared.Encryption
-        private let plainTextSizeMemoizer: AsyncMemoizer<ReadResult<UInt64?>>
+        private let plainTextSize: AsyncMemoizer<ReadResult<UInt64?>>
 
         init(_ resource: Resource, license: LCPLicense, encryption: ReadiumShared.Encryption) {
             assert(!encryption.isDeflated)
@@ -81,34 +81,8 @@ final class LCPDecryptor {
             self.license = license
             self.encryption = encryption
 
-            plainTextSizeMemoizer = AsyncMemoizer { [resource, license] in
-                await resource.estimatedLength().asyncFlatMap { length in
-                    guard let length = length else {
-                        return .failure(.decoding(LCPDecryptor.Error.requiredEstimatedLength))
-                    }
-                    guard length.isValidAESChunk else {
-                        return .failure(.decoding(LCPDecryptor.Error.invalidCBCData))
-                    }
-
-                    let readPosition = length - 2 * AESBlockSize
-                    return await resource.read(range: readPosition ..< length)
-                        .flatMap { encryptedData in
-                            do {
-                                guard let data = try license.decipher(encryptedData) else {
-                                    return .failure(.decoding(LCPDecryptor.Error.emptyDecryptedData))
-                                }
-
-                                let paddingSize = UInt64(data.last ?? 0)
-
-                                let result = length
-                                    - AESBlockSize // Minus IV or previous block
-                                    - paddingSize // Minus padding part
-                                return .success(result)
-                            } catch {
-                                return .failure(.decoding(error))
-                            }
-                        }
-                }
+            plainTextSize = AsyncMemoizer { [resource, license] in
+                await license.plainTextSizeOfCBCResource(resource)
             }
         }
 
@@ -119,11 +93,7 @@ final class LCPDecryptor {
         }
 
         func estimatedLength() async -> ReadResult<UInt64?> {
-            await plainTextSize
-        }
-
-        private var plainTextSize: ReadResult<UInt64?> {
-            get async { await plainTextSizeMemoizer() }
+            await plainTextSize()
         }
 
         func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
@@ -152,7 +122,7 @@ final class LCPDecryptor {
                 )
 
                 return await resource.read(range: encryptedStart ..< encryptedEndExclusive)
-                    .combine(plainTextSize)
+                    .combine(plainTextSize())
                     .flatMap { encryptedData, plainTextSize in
                         do {
                             guard let plainTextSize = plainTextSize else {
@@ -188,6 +158,58 @@ final class LCPDecryptor {
 }
 
 private extension LCPLicense {
+    /// Computes the plain text size of a CBC-encrypted, non-deflated LCP
+    /// resource.
+    ///
+    /// The size of an LCP-encrypted resource doesn't match the size of its
+    /// decrypted content, because of:
+    ///   - the 16-byte IV prepended to the ciphertext, and
+    ///   - the PKCS#7 padding (1...16 bytes) appended to align the plaintext
+    ///     on a multiple of `AESBlockSize`.
+    ///
+    /// To recover the exact plain text size without decrypting the whole
+    /// resource, we read and decrypt only the last two AES blocks: the second-
+    /// to-last block serves as the IV for the last one, whose final byte
+    /// encodes the padding length per PKCS#7.
+    ///
+    /// - Important: This must only be called on a CBC-encrypted resource that
+    ///   is **not** deflated. On a deflated resource, the returned value would
+    ///   be the *compressed* size, not the actual plain text size.
+    ///
+    /// - Returns: The decrypted content length in bytes, or a failure if
+    ///   the resource is not a valid CBC chunk or cannot be deciphered.
+    func plainTextSizeOfCBCResource(_ resource: Resource) async -> ReadResult<UInt64?> {
+        await resource.estimatedLength().asyncFlatMap { length in
+            guard let length = length else {
+                return .failure(.decoding(LCPDecryptor.Error.requiredEstimatedLength))
+            }
+            guard length.isValidAESChunk else {
+                return .failure(.decoding(LCPDecryptor.Error.invalidCBCData))
+            }
+
+            // Read the last two AES blocks: the penultimate one is needed as
+            // the IV to decrypt the last one, which carries the PKCS#7 padding.
+            let readPosition = length - 2 * AESBlockSize
+            return await resource.read(range: readPosition ..< length)
+                .flatMap { encryptedData in
+                    do {
+                        guard let data = try self.decipher(encryptedData) else {
+                            return .failure(.decoding(LCPDecryptor.Error.emptyDecryptedData))
+                        }
+
+                        let paddingSize = UInt64(data.last ?? 0)
+                        return .success(
+                            length
+                                - AESBlockSize // IV
+                                - paddingSize // PKCS#7 padding
+                        )
+                    } catch {
+                        return .failure(.decoding(error))
+                    }
+                }
+        }
+    }
+
     func decryptFully(data: ReadResult<Data>, isDeflated: Bool) async -> ReadResult<Data> {
         data.flatMap {
             guard UInt64($0.count).isValidAESChunk else {

--- a/Sources/LCP/Content Protection/LCPDecryptor.swift
+++ b/Sources/LCP/Content Protection/LCPDecryptor.swift
@@ -44,7 +44,14 @@ final class LCPDecryptor {
         }
 
         if encryption.isDeflated || !encryption.isCbcEncrypted {
-            return FullLCPResource(resource, license: license, encryption: encryption).cached()
+            let fullLCP = TransformingResource(
+                resource,
+                estimatedLength: { .success(encryption.originalLength.map { UInt64($0) }) },
+                transform: { data in
+                    await license.decryptFully(data: data, isDeflated: encryption.isDeflated)
+                }
+            )
+            return fullLCP.cached()
 
         } else {
             // We use a buffered resource because when requesting a range from
@@ -58,36 +65,14 @@ final class LCPDecryptor {
         }
     }
 
-    /// A  LCP resource that is read, decrypted and cached fully before reading requested ranges.
-    ///
-    /// Can be used when it's impossible to map a read range (byte range request) to the encrypted
-    /// resource, for example when the resource is deflated before encryption.
-    private class FullLCPResource: TransformingResource {
-        private let license: LCPLicense
-        private let encryption: ReadiumShared.Encryption
-
-        init(_ resource: Resource, license: LCPLicense, encryption: ReadiumShared.Encryption) {
-            self.license = license
-            self.encryption = encryption
-            super.init(resource)
-        }
-
-        override func transform(data: ReadResult<Data>) async -> ReadResult<Data> {
-            await license.decryptFully(data: data, isDeflated: encryption.isDeflated)
-        }
-
-        override func estimatedLength() async -> ReadResult<UInt64?> {
-            .success(encryption.originalLength.map { UInt64($0) })
-        }
-    }
-
     /// A LCP resource used to read content encrypted with the CBC algorithm.
     ///
     /// Supports random access for byte range requests, but the resource MUST NOT be deflated.
-    private class CBCLCPResource: Resource {
+    private final class CBCLCPResource: Resource, Sendable {
         private let resource: Resource
         private let license: LCPLicense
         private let encryption: ReadiumShared.Encryption
+        private let plainTextSizeTask: Task<ReadResult<UInt64?>, Never>
 
         init(_ resource: Resource, license: LCPLicense, encryption: ReadiumShared.Encryption) {
             assert(!encryption.isDeflated)
@@ -95,6 +80,36 @@ final class LCPDecryptor {
             self.resource = resource
             self.license = license
             self.encryption = encryption
+
+            self.plainTextSizeTask = Task {
+                await resource.estimatedLength().asyncFlatMap { length in
+                    guard let length = length else {
+                        return .failure(.decoding(LCPDecryptor.Error.requiredEstimatedLength))
+                    }
+                    guard length.isValidAESChunk else {
+                        return .failure(.decoding(LCPDecryptor.Error.invalidCBCData))
+                    }
+
+                    let readPosition = length - 2 * AESBlockSize
+                    return await resource.read(range: readPosition ..< length)
+                        .flatMap { encryptedData in
+                            do {
+                                guard let data = try license.decipher(encryptedData) else {
+                                    return .failure(.decoding(LCPDecryptor.Error.emptyDecryptedData))
+                                }
+
+                                let paddingSize = UInt64(data.last ?? 0)
+
+                                let result = length
+                                    - AESBlockSize // Minus IV or previous block
+                                    - paddingSize // Minus padding part
+                                return .success(result)
+                            } catch {
+                                return .failure(.decoding(error))
+                            }
+                        }
+                }
+            }
         }
 
         let sourceURL: AbsoluteURL? = nil
@@ -111,37 +126,7 @@ final class LCPDecryptor {
             get async { await plainTextSizeTask.value }
         }
 
-        private lazy var plainTextSizeTask = Task<ReadResult<UInt64?>, Never> {
-            await resource.estimatedLength().asyncFlatMap { length in
-                guard let length = length else {
-                    return failure(.requiredEstimatedLength)
-                }
-                guard length.isValidAESChunk else {
-                    return failure(.invalidCBCData)
-                }
-
-                let readPosition = length - 2 * AESBlockSize
-                return await resource.read(range: readPosition ..< length)
-                    .flatMap { encryptedData in
-                        do {
-                            guard let data = try license.decipher(encryptedData) else {
-                                return failure(.emptyDecryptedData)
-                            }
-
-                            let paddingSize = UInt64(data.last ?? 0)
-
-                            let result = length
-                                - AESBlockSize // Minus IV or previous block
-                                - paddingSize // Minus padding part
-                            return .success(result)
-                        } catch {
-                            return .failure(.decoding(error))
-                        }
-                    }
-            }
-        }
-
-        func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+        func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
             guard let range = range else {
                 return await license.decryptFully(data: resource.read(), isDeflated: encryption.isDeflated)
                     .map {
@@ -152,10 +137,10 @@ final class LCPDecryptor {
 
             return await resource.estimatedLength().asyncFlatMap { encryptedLength in
                 guard let encryptedLength = encryptedLength else {
-                    return failure(.requiredEstimatedLength)
+                    return .failure(.decoding(LCPDecryptor.Error.requiredEstimatedLength))
                 }
                 guard let rangeFirst = range.first, let rangeLast = range.last else {
-                    return failure(.invalidRange(range))
+                    return .failure(.decoding(LCPDecryptor.Error.invalidRange(range)))
                 }
 
                 // Encrypted data is shifted by AESBlockSize, because of IV and because the
@@ -171,10 +156,10 @@ final class LCPDecryptor {
                     .flatMap { encryptedData, plainTextSize in
                         do {
                             guard let plainTextSize = plainTextSize else {
-                                return failure(.noPlainTextSize)
+                                return .failure(.decoding(LCPDecryptor.Error.noPlainTextSize))
                             }
                             guard let bytes = try license.decipher(encryptedData) else {
-                                return failure(.emptyDecryptedData)
+                                return .failure(.decoding(LCPDecryptor.Error.emptyDecryptedData))
                             }
 
                             // Exclude the bytes added to match a multiple of AESBlockSize.
@@ -198,10 +183,6 @@ final class LCPDecryptor {
                         }
                     }
             }
-        }
-
-        private func failure<T>(_ error: LCPDecryptor.Error) -> ReadResult<T> {
-            .failure(.decoding(error))
         }
     }
 }

--- a/Sources/LCP/Content Protection/LCPDecryptor.swift
+++ b/Sources/LCP/Content Protection/LCPDecryptor.swift
@@ -44,14 +44,7 @@ final class LCPDecryptor {
         }
 
         if encryption.isDeflated || !encryption.isCbcEncrypted {
-            let fullLCP = TransformingResource(
-                resource,
-                estimatedLength: { .success(encryption.originalLength.map { UInt64($0) }) },
-                transform: { data in
-                    await license.decryptFully(data: data, isDeflated: encryption.isDeflated)
-                }
-            )
-            return fullLCP.cached()
+            return FullLCPResource(resource, license: license, encryption: encryption).cached()
 
         } else {
             // We use a buffered resource because when requesting a range from
@@ -62,6 +55,34 @@ final class LCPDecryptor {
             // See https://github.com/readium/r2-shared-swift/issues/98
             // and https://github.com/readium/r2-shared-swift/pull/119
             return CBCLCPResource(resource.buffered(), license: license, encryption: encryption)
+        }
+    }
+
+    /// A LCP resource used to read content fully, which is the most common case:
+    /// resource, for example when the resource is deflated before encryption.
+    private final class FullLCPResource: Resource, Sendable {
+        private let resource: TransformingResource
+        private let originalLength: UInt64?
+
+        init(_ resource: Resource, license: LCPLicense, encryption: ReadiumShared.Encryption) {
+            originalLength = encryption.originalLength.map { UInt64($0) }
+            self.resource = TransformingResource(resource, transform: { data in
+                await license.decryptFully(data: data, isDeflated: encryption.isDeflated)
+            })
+        }
+
+        let sourceURL: AbsoluteURL? = nil
+
+        func properties() async -> ReadResult<ResourceProperties> {
+            await resource.properties()
+        }
+
+        func estimatedLength() async -> ReadResult<UInt64?> {
+            .success(originalLength)
+        }
+
+        func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
+            await resource.stream(range: range, consume: consume)
         }
     }
 

--- a/Sources/LCP/Content Protection/LCPDecryptor.swift
+++ b/Sources/LCP/Content Protection/LCPDecryptor.swift
@@ -81,7 +81,7 @@ final class LCPDecryptor {
             self.license = license
             self.encryption = encryption
 
-            self.plainTextSizeTask = Task {
+            plainTextSizeTask = Task {
                 await resource.estimatedLength().asyncFlatMap { length in
                     guard let length = length else {
                         return .failure(.decoding(LCPDecryptor.Error.requiredEstimatedLength))

--- a/Sources/LCP/Content Protection/LCPDecryptor.swift
+++ b/Sources/LCP/Content Protection/LCPDecryptor.swift
@@ -58,8 +58,12 @@ final class LCPDecryptor {
         }
     }
 
-    /// A LCP resource used to read content fully, which is the most common case:
-    /// resource, for example when the resource is deflated before encryption.
+    /// An LCP resource that is read, decrypted and cached fully before reading
+    /// requested ranges.
+    ///
+    /// Can be used when it's impossible to map a read range (byte range
+    /// request) to the encrypted resource, for example when the resource is
+    /// deflated before encryption.
     private final class FullLCPResource: Resource, Sendable {
         private let resource: TransformingResource
         private let originalLength: UInt64?

--- a/Sources/LCP/Content Protection/LCPDecryptor.swift
+++ b/Sources/LCP/Content Protection/LCPDecryptor.swift
@@ -72,7 +72,7 @@ final class LCPDecryptor {
         private let resource: Resource
         private let license: LCPLicense
         private let encryption: ReadiumShared.Encryption
-        private let plainTextSizeTask: Task<ReadResult<UInt64?>, Never>
+        private let plainTextSizeMemoizer: AsyncMemoizer<ReadResult<UInt64?>>
 
         init(_ resource: Resource, license: LCPLicense, encryption: ReadiumShared.Encryption) {
             assert(!encryption.isDeflated)
@@ -81,7 +81,7 @@ final class LCPDecryptor {
             self.license = license
             self.encryption = encryption
 
-            plainTextSizeTask = Task {
+            plainTextSizeMemoizer = AsyncMemoizer { [resource, license] in
                 await resource.estimatedLength().asyncFlatMap { length in
                     guard let length = length else {
                         return .failure(.decoding(LCPDecryptor.Error.requiredEstimatedLength))
@@ -123,7 +123,7 @@ final class LCPDecryptor {
         }
 
         private var plainTextSize: ReadResult<UInt64?> {
-            get async { await plainTextSizeTask.value }
+            get async { await plainTextSizeMemoizer() }
         }
 
         func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {

--- a/Sources/Navigator/EPUB/CSS/HTMLFontFamilyDeclaration.swift
+++ b/Sources/Navigator/EPUB/CSS/HTMLFontFamilyDeclaration.swift
@@ -7,6 +7,10 @@
 import Foundation
 import ReadiumShared
 
+public enum HTMLFontFamilyError: Error {
+    case fontNotServed(FileURL)
+}
+
 public protocol HTMLFontFamilyDeclaration: Sendable {
     /// Name of the font family.
     ///
@@ -22,9 +26,9 @@ public protocol HTMLFontFamilyDeclaration: Sendable {
 
     /// Injects this font family declaration in the given `html` document.
     ///
-    /// Use `servingFile` to convert a file URL into a URL accessible from the
+    /// Use `servedFiles` to convert a file URL into a URL accessible from the
     /// web views.
-    func inject(in html: String, servingFile: (FileURL) throws -> any AbsoluteURL) throws -> String
+    func inject(in html: String, servedFiles: [FileURL: any AbsoluteURL]) throws -> String
 }
 
 /// A type-erasing `HTMLFontFamilyDeclaration` object
@@ -32,7 +36,7 @@ public struct AnyHTMLFontFamilyDeclaration: HTMLFontFamilyDeclaration, Sendable 
     private let _fontFamily: @Sendable () -> FontFamily
     private let _alternates: @Sendable () -> [FontFamily]
     private let _fontFiles: @Sendable () -> [FileURL]
-    private let _inject: @Sendable (String, (FileURL) throws -> any AbsoluteURL) throws -> String
+    private let _inject: @Sendable (String, [FileURL: any AbsoluteURL]) throws -> String
 
     public var fontFamily: FontFamily {
         _fontFamily()
@@ -50,11 +54,11 @@ public struct AnyHTMLFontFamilyDeclaration: HTMLFontFamilyDeclaration, Sendable 
         _fontFamily = { declaration.fontFamily }
         _alternates = { declaration.alternates }
         _fontFiles = { declaration.fontFiles }
-        _inject = { try declaration.inject(in: $0, servingFile: $1) }
+        _inject = { try declaration.inject(in: $0, servedFiles: $1) }
     }
 
-    public func inject(in html: String, servingFile: (FileURL) throws -> any AbsoluteURL) throws -> String {
-        try _inject(html, servingFile)
+    public func inject(in html: String, servedFiles: [FileURL: any AbsoluteURL]) throws -> String {
+        try _inject(html, servedFiles)
     }
 }
 
@@ -83,13 +87,13 @@ public struct CSSFontFamilyDeclaration: HTMLFontFamilyDeclaration, Sendable {
         self.fontFaces = fontFaces
     }
 
-    public func inject(in html: String, servingFile: (FileURL) throws -> any AbsoluteURL) throws -> String {
+    public func inject(in html: String, servedFiles: [FileURL: any AbsoluteURL]) throws -> String {
         var injections = try fontFaces.flatMap {
-            try $0.injections(for: html, servingFile: servingFile)
+            try $0.injections(for: html, servedFiles: servedFiles)
         }
 
         let css = try fontFaces
-            .map { try $0.css(for: fontFamily.rawValue, servingFile: servingFile) }
+            .map { try $0.css(for: fontFamily.rawValue, servedFiles: servedFiles) }
             .joined(separator: "\n")
         injections.append(.style(css))
 
@@ -141,17 +145,24 @@ public struct CSSFontFace: Sendable {
         return copy
     }
 
-    func injections(for html: String, servingFile: (FileURL) throws -> any AbsoluteURL) throws -> [HTMLInjection] {
+    func injections(for html: String, servedFiles: [FileURL: any AbsoluteURL]) throws -> [HTMLInjection] {
         try sources
             .filter(\.preload)
             .map { source in
-                let file = try servingFile(source.file)
+                guard let file = servedFiles[source.file] else {
+                    throw HTMLFontFamilyError.fontNotServed(source.file)
+                }
                 return .link(href: file.string, rel: "preload", as: "font", crossOrigin: "")
             }
     }
 
-    func css(for fontFamily: String, servingFile: (FileURL) throws -> any AbsoluteURL) throws -> String {
-        let urls = try sources.map { try servingFile($0.file) }
+    func css(for fontFamily: String, servedFiles: [FileURL: any AbsoluteURL]) throws -> String {
+        let urls = try sources.map { source in
+            guard let url = servedFiles[source.file] else {
+                throw HTMLFontFamilyError.fontNotServed(source.file)
+            }
+            return url
+        }
         var descriptors: [String: String] = [
             "font-family": "\"\(fontFamily)\"",
             "src": urls.map { "url(\"\($0.string)\")" }.joined(separator: ", "),

--- a/Sources/Navigator/EPUB/CSS/HTMLFontFamilyDeclaration.swift
+++ b/Sources/Navigator/EPUB/CSS/HTMLFontFamilyDeclaration.swift
@@ -21,14 +21,24 @@ public protocol HTMLFontFamilyDeclaration: Sendable {
     /// symbols are missing from `fontFamily`.
     var alternates: [FontFamily] { get }
 
-    /// List of font files associated with this declaration.
+    /// List of local font files that must be served and made accessible to web
+    /// content before calling `inject(in:servedFiles:)`.
+    ///
+    /// This is optional and only needed when the implementation injects local
+    /// font files. Return an empty array if no local files need to be served.
     var fontFiles: [FileURL] { get }
 
     /// Injects this font family declaration in the given `html` document.
     ///
-    /// Use `servedFiles` to convert a file URL into a URL accessible from the
-    /// web views.
+    /// Use `servedFiles` to look up the web-accessible URL for a given
+    /// `fontFiles` URL.
     func inject(in html: String, servedFiles: [FileURL: any AbsoluteURL]) throws -> String
+}
+
+public extension HTMLFontFamilyDeclaration {
+    var fontFiles: [FileURL] {
+        []
+    }
 }
 
 /// A type-erasing `HTMLFontFamilyDeclaration` object
@@ -213,4 +223,24 @@ public enum CSSStandardFontWeight: Int, Codable, Sendable {
     case bold = 700
     case extraBold = 800
     case black = 900
+}
+
+extension WebViewServer {
+    /// Serves the font files for the given font family declarations and returns
+    /// a mapping from each font file URL to its web-accessible URL.
+    func serve(
+        _ fontFamilyDeclarations: [AnyHTMLFontFamilyDeclaration]
+    ) -> [FileURL: any AbsoluteURL] {
+        var servedFonts: [FileURL: AbsoluteURL] = [:]
+        for ff in fontFamilyDeclarations {
+            for file in ff.fontFiles {
+                if servedFonts[file] == nil {
+                    let name = file.lastPathSegment ?? UUID().uuidString
+                    servedFonts[file] = serve(file: file, at: "assets/fonts/\(name)")
+                }
+            }
+        }
+
+        return servedFonts
+    }
 }

--- a/Sources/Navigator/EPUB/CSS/HTMLFontFamilyDeclaration.swift
+++ b/Sources/Navigator/EPUB/CSS/HTMLFontFamilyDeclaration.swift
@@ -74,7 +74,7 @@ public struct CSSFontFamilyDeclaration: HTMLFontFamilyDeclaration, Sendable {
     public var fontFaces: [CSSFontFace]
 
     public var fontFiles: [FileURL] {
-        fontFaces.flatMap { $0.fontFiles }
+        fontFaces.flatMap(\.fontFiles)
     }
 
     public init(fontFamily: FontFamily, alternates: [FontFamily] = [], fontFaces: [CSSFontFace] = []) {
@@ -114,7 +114,7 @@ public struct CSSFontFace: Sendable {
     private var sources: [Source]
 
     public var fontFiles: [FileURL] {
-        sources.map { $0.file }
+        sources.map(\.file)
     }
 
     public init(

--- a/Sources/Navigator/EPUB/CSS/HTMLFontFamilyDeclaration.swift
+++ b/Sources/Navigator/EPUB/CSS/HTMLFontFamilyDeclaration.swift
@@ -7,7 +7,7 @@
 import Foundation
 import ReadiumShared
 
-public protocol HTMLFontFamilyDeclaration {
+public protocol HTMLFontFamilyDeclaration: Sendable {
     /// Name of the font family.
     ///
     /// This will be the value of the `fontFamily` EPUB preference.
@@ -17,6 +17,9 @@ public protocol HTMLFontFamilyDeclaration {
     /// symbols are missing from `fontFamily`.
     var alternates: [FontFamily] { get }
 
+    /// List of font files associated with this declaration.
+    var fontFiles: [FileURL] { get }
+
     /// Injects this font family declaration in the given `html` document.
     ///
     /// Use `servingFile` to convert a file URL into a URL accessible from the
@@ -25,10 +28,11 @@ public protocol HTMLFontFamilyDeclaration {
 }
 
 /// A type-erasing `HTMLFontFamilyDeclaration` object
-public struct AnyHTMLFontFamilyDeclaration: HTMLFontFamilyDeclaration {
-    private let _fontFamily: () -> FontFamily
-    private let _alternates: () -> [FontFamily]
-    private let _inject: (String, (FileURL) throws -> any AbsoluteURL) throws -> String
+public struct AnyHTMLFontFamilyDeclaration: HTMLFontFamilyDeclaration, Sendable {
+    private let _fontFamily: @Sendable () -> FontFamily
+    private let _alternates: @Sendable () -> [FontFamily]
+    private let _fontFiles: @Sendable () -> [FileURL]
+    private let _inject: @Sendable (String, (FileURL) throws -> any AbsoluteURL) throws -> String
 
     public var fontFamily: FontFamily {
         _fontFamily()
@@ -38,9 +42,14 @@ public struct AnyHTMLFontFamilyDeclaration: HTMLFontFamilyDeclaration {
         _alternates()
     }
 
+    public var fontFiles: [FileURL] {
+        _fontFiles()
+    }
+
     public init<T: HTMLFontFamilyDeclaration>(_ declaration: T) {
         _fontFamily = { declaration.fontFamily }
         _alternates = { declaration.alternates }
+        _fontFiles = { declaration.fontFiles }
         _inject = { try declaration.inject(in: $0, servingFile: $1) }
     }
 
@@ -63,6 +72,10 @@ public struct CSSFontFamilyDeclaration: HTMLFontFamilyDeclaration, Sendable {
 
     /// Declarations for the individual font files for this font family.
     public var fontFaces: [CSSFontFace]
+
+    public var fontFiles: [FileURL] {
+        fontFaces.flatMap { $0.fontFiles }
+    }
 
     public init(fontFamily: FontFamily, alternates: [FontFamily] = [], fontFaces: [CSSFontFace] = []) {
         self.fontFamily = fontFamily
@@ -99,6 +112,10 @@ public struct CSSFontFace: Sendable {
     public var style: CSSFontStyle?
     public var weight: CSSFontWeight?
     private var sources: [Source]
+
+    public var fontFiles: [FileURL] {
+        sources.map { $0.file }
+    }
 
     public init(
         file: FileURL,

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -339,6 +339,7 @@ enum EPUBScriptScope {
                         in: content,
                         servingFile: { file in
                             guard let url = servedFonts[file] else {
+                                self.log(.warning, "Font file was not pre-served: \(file)")
                                 return file
                             }
                             return url
@@ -347,6 +348,7 @@ enum EPUBScriptScope {
                 }
                 return content
             } catch {
+                self.log(.error, error)
                 return content
             }
         }

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -331,7 +331,7 @@ enum EPUBScriptScope {
         let fontFamilyDeclarations = config.fontFamilyDeclarations
         let servedFonts = servedFonts.withLock { $0 }
 
-        return resource.mapAsString { [weak self] content in
+        return resource.mapAsString { content in
             do {
                 var content = try css.inject(in: content)
                 for ff in fontFamilyDeclarations {
@@ -339,7 +339,7 @@ enum EPUBScriptScope {
                         in: content,
                         servingFile: { file in
                             guard let url = servedFonts[file] else {
-                                self?.log(.warning, "Font file was not pre-served: \(file)")
+                                EPUBNavigatorViewModel.log(.warning, "Font file was not pre-served: \(file)")
                                 return file
                             }
                             return url
@@ -348,7 +348,7 @@ enum EPUBScriptScope {
                 }
                 return content
             } catch {
-                self?.log(.error, error)
+                EPUBNavigatorViewModel.log(.error, error)
                 return content
             }
         }

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -305,7 +305,7 @@ enum EPUBScriptScope {
     // MARK: - Readium CSS
 
     private var css: ReadiumCSS
-    private var servedFonts: [FileURL: AbsoluteURL] = [:]
+    private let servedFonts = Mutex<[FileURL: AbsoluteURL]>([:])
 
     func injectReadiumCSS<HREF: URLConvertible>(in resource: Resource, at href: HREF) -> Resource {
         guard
@@ -316,30 +316,37 @@ enum EPUBScriptScope {
             return resource
         }
 
-        return resource.mapAsString { [weak self] content in
-            guard let self = self else {
-                return content
+        // Pre-serve all fonts on the MainActor
+        for ff in config.fontFamilyDeclarations {
+            for file in ff.fontFiles {
+                if self.servedFonts.withLock({ $0[file] }) == nil {
+                    let name = file.lastPathSegment ?? UUID().uuidString
+                    let url = self.server.serve(file: file, at: "assets/fonts/\(name)")
+                    self.servedFonts.withLock { $0[file] = url }
+                }
             }
+        }
 
+        let css = self.css
+        let fontFamilyDeclarations = config.fontFamilyDeclarations
+        let servedFonts = self.servedFonts.withLock { $0 }
+
+        return resource.mapAsString { content in
             do {
                 var content = try css.inject(in: content)
-                for ff in config.fontFamilyDeclarations {
+                for ff in fontFamilyDeclarations {
                     content = try ff.inject(
                         in: content,
-                        servingFile: { [server] file in
-                            if let url = self.servedFonts[file] {
-                                return url
+                        servingFile: { file in
+                            guard let url = servedFonts[file] else {
+                                return file
                             }
-                            let name = file.lastPathSegment ?? UUID().uuidString
-                            let url = server.serve(file: file, at: "assets/fonts/\(name)")
-                            self.servedFonts[file] = url
                             return url
                         }
                     )
                 }
                 return content
             } catch {
-                log(.error, error)
                 return content
             }
         }

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -126,6 +126,17 @@ enum EPUBScriptScope {
         self.assetsBaseURL = assetsBaseURL
         self.formatSniffer = formatSniffer
 
+        var servedFonts: [FileURL: AbsoluteURL] = [:]
+        for ff in config.fontFamilyDeclarations {
+            for file in ff.fontFiles {
+                if servedFonts[file] == nil {
+                    let name = file.lastPathSegment ?? UUID().uuidString
+                    servedFonts[file] = server.serve(file: file, at: "assets/fonts/\(name)")
+                }
+            }
+        }
+        self.servedFonts = servedFonts
+
         preferences = config.preferences
         settings = EPUBSettings(publication: publication, config: config)
 
@@ -305,7 +316,7 @@ enum EPUBScriptScope {
     // MARK: - Readium CSS
 
     private var css: ReadiumCSS
-    private let servedFonts = Mutex<[FileURL: AbsoluteURL]>([:])
+    private let servedFonts: [FileURL: AbsoluteURL]
 
     func injectReadiumCSS<HREF: URLConvertible>(in resource: Resource, at href: HREF) -> Resource {
         guard
@@ -316,35 +327,15 @@ enum EPUBScriptScope {
             return resource
         }
 
-        // Pre-serve all fonts on the MainActor
-        for ff in config.fontFamilyDeclarations {
-            for file in ff.fontFiles {
-                if self.servedFonts.withLock({ $0[file] }) == nil {
-                    let name = file.lastPathSegment ?? UUID().uuidString
-                    let url = server.serve(file: file, at: "assets/fonts/\(name)")
-                    self.servedFonts.withLock { $0[file] = url }
-                }
-            }
-        }
-
         let css = css
         let fontFamilyDeclarations = config.fontFamilyDeclarations
-        let servedFonts = servedFonts.withLock { $0 }
+        let servedFonts = servedFonts
 
         return resource.mapAsString { content in
             do {
                 var content = try css.inject(in: content)
                 for ff in fontFamilyDeclarations {
-                    content = try ff.inject(
-                        in: content,
-                        servingFile: { file in
-                            guard let url = servedFonts[file] else {
-                                EPUBNavigatorViewModel.log(.warning, "Font file was not pre-served: \(file)")
-                                return file
-                            }
-                            return url
-                        }
-                    )
+                    content = try ff.inject(in: content, servedFiles: servedFonts)
                 }
                 return content
             } catch {

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -331,7 +331,7 @@ enum EPUBScriptScope {
         let fontFamilyDeclarations = config.fontFamilyDeclarations
         let servedFonts = servedFonts.withLock { $0 }
 
-        return resource.mapAsString { content in
+        return resource.mapAsString { [weak self] content in
             do {
                 var content = try css.inject(in: content)
                 for ff in fontFamilyDeclarations {
@@ -339,7 +339,7 @@ enum EPUBScriptScope {
                         in: content,
                         servingFile: { file in
                             guard let url = servedFonts[file] else {
-                                self.log(.warning, "Font file was not pre-served: \(file)")
+                                self?.log(.warning, "Font file was not pre-served: \(file)")
                                 return file
                             }
                             return url
@@ -348,7 +348,7 @@ enum EPUBScriptScope {
                 }
                 return content
             } catch {
-                self.log(.error, error)
+                self?.log(.error, error)
                 return content
             }
         }

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -125,17 +125,7 @@ enum EPUBScriptScope {
         self.server = server
         self.assetsBaseURL = assetsBaseURL
         self.formatSniffer = formatSniffer
-
-        var servedFonts: [FileURL: AbsoluteURL] = [:]
-        for ff in config.fontFamilyDeclarations {
-            for file in ff.fontFiles {
-                if servedFonts[file] == nil {
-                    let name = file.lastPathSegment ?? UUID().uuidString
-                    servedFonts[file] = server.serve(file: file, at: "assets/fonts/\(name)")
-                }
-            }
-        }
-        self.servedFonts = servedFonts
+        servedFonts = server.serve(config.fontFamilyDeclarations)
 
         preferences = config.preferences
         settings = EPUBSettings(publication: publication, config: config)

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -321,15 +321,15 @@ enum EPUBScriptScope {
             for file in ff.fontFiles {
                 if self.servedFonts.withLock({ $0[file] }) == nil {
                     let name = file.lastPathSegment ?? UUID().uuidString
-                    let url = self.server.serve(file: file, at: "assets/fonts/\(name)")
+                    let url = server.serve(file: file, at: "assets/fonts/\(name)")
                     self.servedFonts.withLock { $0[file] = url }
                 }
             }
         }
 
-        let css = self.css
+        let css = css
         let fontFamilyDeclarations = config.fontFamilyDeclarations
-        let servedFonts = self.servedFonts.withLock { $0 }
+        let servedFonts = servedFonts.withLock { $0 }
 
         return resource.mapAsString { content in
             do {

--- a/Sources/Shared/Publication/Services/Cover/GeneratedCoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/GeneratedCoverService.swift
@@ -50,7 +50,9 @@ public final class GeneratedCoverService: CoverService {
             return nil
         }
 
-        return CoverResource(cover: cachedCover)
+        return CoverResource(cover: { [weak self] in
+            await self?.cachedCover() ?? .failure(.decoding("Deallocated"))
+        })
     }
 
     public static func makeFactory(makeCover: @escaping () async -> ReadResult<UIImage>) -> (PublicationServiceContext) -> GeneratedCoverService? {
@@ -61,10 +63,10 @@ public final class GeneratedCoverService: CoverService {
         { _ in GeneratedCoverService(cover: cover) }
     }
 
-    private class CoverResource: Resource {
-        private let cover: () async -> ReadResult<UIImage>
+    private struct CoverResource: Resource {
+        private let cover: @Sendable () async -> ReadResult<UIImage>
 
-        init(cover: @escaping () async -> ReadResult<UIImage>) {
+        init(cover: @escaping @Sendable () async -> ReadResult<UIImage>) {
             self.cover = cover
         }
 
@@ -78,7 +80,7 @@ public final class GeneratedCoverService: CoverService {
             .success(ResourceProperties())
         }
 
-        func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+        func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
             await cover().flatMap {
                 guard let data = $0.pngData() else {
                     return .failure(.decoding("Failed to convert the cover bitmap to PNG data"))

--- a/Sources/Shared/Publication/Services/Cover/GeneratedCoverService.swift
+++ b/Sources/Shared/Publication/Services/Cover/GeneratedCoverService.swift
@@ -8,16 +8,15 @@ import Foundation
 import UIKit
 
 /// A `CoverService` which holds a lazily generated cover bitmap in memory.
-public final class GeneratedCoverService: CoverService {
+public final class GeneratedCoverService: CoverService, Sendable {
     enum Error: Swift.Error {
         case generationFailed
     }
 
-    private var _cover: ReadResult<UIImage>?
-    private let makeCover: () async -> ReadResult<UIImage>
+    private let cache: AsyncMemoizer<ReadResult<UIImage>>
 
-    public init(makeCover: @escaping () async -> ReadResult<UIImage>) {
-        self.makeCover = makeCover
+    public init(makeCover: @escaping @Sendable () async -> ReadResult<UIImage>) {
+        cache = AsyncMemoizer(makeCover)
     }
 
     public convenience init(cover: UIImage) {
@@ -31,10 +30,7 @@ public final class GeneratedCoverService: CoverService {
     )
 
     private func cachedCover() async -> ReadResult<UIImage> {
-        if _cover == nil {
-            _cover = await makeCover()
-        }
-        return _cover!
+        await cache()
     }
 
     public func cover() async -> ReadResult<UIImage?> {
@@ -50,16 +46,17 @@ public final class GeneratedCoverService: CoverService {
             return nil
         }
 
-        return CoverResource(cover: { [weak self] in
-            await self?.cachedCover() ?? .failure(.decoding("Deallocated"))
+        let cache = cache
+        return CoverResource(cover: {
+            await cache()
         })
     }
 
-    public static func makeFactory(makeCover: @escaping () async -> ReadResult<UIImage>) -> (PublicationServiceContext) -> GeneratedCoverService? {
+    public static func makeFactory(makeCover: @escaping @Sendable () async -> ReadResult<UIImage>) -> @Sendable (PublicationServiceContext) -> GeneratedCoverService? {
         { _ in GeneratedCoverService(makeCover: makeCover) }
     }
 
-    public static func makeFactory(cover: UIImage) -> (PublicationServiceContext) -> GeneratedCoverService? {
+    public static func makeFactory(cover: UIImage) -> @Sendable (PublicationServiceContext) -> GeneratedCoverService? {
         { _ in GeneratedCoverService(cover: cover) }
     }
 

--- a/Sources/Shared/Publication/Services/Positions/PerResourcePositionsService.swift
+++ b/Sources/Shared/Publication/Services/Positions/PerResourcePositionsService.swift
@@ -12,24 +12,20 @@ public final class PerResourcePositionsService: PositionsService, Sendable {
     private let positions: [[Locator]]
 
     init(readingOrder: [Link], fallbackMediaType: MediaType) {
-        guard !readingOrder.isEmpty else {
-            positions = []
-            return
-        }
-
-        positions = readingOrder.enumerated().map { index, link in
-            [
-                Locator(
-                    href: link.url(),
-                    mediaType: link.mediaType ?? fallbackMediaType,
-                    title: link.title,
-                    locations: Locator.Locations(
-                        totalProgression: Double(index) / Double(readingOrder.count),
-                        position: index + 1
-                    )
-                ),
-            ]
-        }
+        positions = readingOrder.enumerated()
+            .map { index, link in
+                [
+                    Locator(
+                        href: link.url(),
+                        mediaType: link.mediaType ?? fallbackMediaType,
+                        title: link.title,
+                        locations: Locator.Locations(
+                            totalProgression: Double(index) / Double(readingOrder.count),
+                            position: index + 1
+                        )
+                    ),
+                ]
+            }
     }
 
     public func positionsByReadingOrder() async -> ReadResult<[[Locator]]> {

--- a/Sources/Shared/Publication/Services/Positions/PerResourcePositionsService.swift
+++ b/Sources/Shared/Publication/Services/Positions/PerResourcePositionsService.swift
@@ -14,29 +14,31 @@ public final class PerResourcePositionsService: PositionsService {
     /// Media type that will be used as a fallback if the `Link` doesn't specify any.
     private let fallbackMediaType: MediaType
 
+    private let pageCount: Int
+    private let positions: [[Locator]]
+
     init(readingOrder: [Link], fallbackMediaType: MediaType) {
         self.readingOrder = readingOrder
         self.fallbackMediaType = fallbackMediaType
+        let pageCount = readingOrder.count
+        self.pageCount = pageCount
+        positions = readingOrder.enumerated().map { index, link in
+            [
+                Locator(
+                    href: link.url(),
+                    mediaType: link.mediaType ?? fallbackMediaType,
+                    title: link.title,
+                    locations: Locator.Locations(
+                        totalProgression: Double(index) / Double(pageCount),
+                        position: index + 1
+                    )
+                ),
+            ]
+        }
     }
 
     public func positionsByReadingOrder() async -> ReadResult<[[Locator]]> {
         .success(positions)
-    }
-
-    private lazy var pageCount: Int = readingOrder.count
-
-    private lazy var positions: [[Locator]] = readingOrder.enumerated().map { index, link in
-        [
-            Locator(
-                href: link.url(),
-                mediaType: link.mediaType ?? fallbackMediaType,
-                title: link.title,
-                locations: Locator.Locations(
-                    totalProgression: Double(index) / Double(pageCount),
-                    position: index + 1
-                )
-            ),
-        ]
     }
 
     public static func makeFactory(fallbackMediaType: MediaType) -> (PublicationServiceContext) -> PerResourcePositionsService {

--- a/Sources/Shared/Publication/Services/Positions/PerResourcePositionsService.swift
+++ b/Sources/Shared/Publication/Services/Positions/PerResourcePositionsService.swift
@@ -14,31 +14,29 @@ public final class PerResourcePositionsService: PositionsService {
     /// Media type that will be used as a fallback if the `Link` doesn't specify any.
     private let fallbackMediaType: MediaType
 
-    private let pageCount: Int
-    private let positions: [[Locator]]
-
     init(readingOrder: [Link], fallbackMediaType: MediaType) {
         self.readingOrder = readingOrder
         self.fallbackMediaType = fallbackMediaType
-        let pageCount = readingOrder.count
-        self.pageCount = pageCount
-        positions = readingOrder.enumerated().map { index, link in
-            [
-                Locator(
-                    href: link.url(),
-                    mediaType: link.mediaType ?? fallbackMediaType,
-                    title: link.title,
-                    locations: Locator.Locations(
-                        totalProgression: Double(index) / Double(pageCount),
-                        position: index + 1
-                    )
-                ),
-            ]
-        }
     }
 
     public func positionsByReadingOrder() async -> ReadResult<[[Locator]]> {
         .success(positions)
+    }
+
+    private lazy var pageCount: Int = readingOrder.count
+
+    private lazy var positions: [[Locator]] = readingOrder.enumerated().map { index, link in
+        [
+            Locator(
+                href: link.url(),
+                mediaType: link.mediaType ?? fallbackMediaType,
+                title: link.title,
+                locations: Locator.Locations(
+                    totalProgression: Double(index) / Double(pageCount),
+                    position: index + 1
+                )
+            ),
+        ]
     }
 
     public static func makeFactory(fallbackMediaType: MediaType) -> (PublicationServiceContext) -> PerResourcePositionsService {

--- a/Sources/Shared/Publication/Services/Positions/PositionsService.swift
+++ b/Sources/Shared/Publication/Services/Positions/PositionsService.swift
@@ -30,7 +30,7 @@ private let positionsLink = Link(
     mediaType: MediaType.readiumPositions
 )
 
-public extension PositionsService where Self: AnyObject {
+public extension PositionsService {
     var links: [Link] {
         [positionsLink]
     }
@@ -39,8 +39,9 @@ public extension PositionsService where Self: AnyObject {
         guard href.anyURL.isEquivalentTo(positionsLink.url()) else {
             return nil
         }
-        return PositionsResource(positions: { [weak self] in
-            await self?.positions() ?? .failure(.decoding("Deallocated"))
+        let service = self
+        return PositionsResource(positions: {
+            await service.positions()
         })
     }
 }

--- a/Sources/Shared/Publication/Services/Positions/PositionsService.swift
+++ b/Sources/Shared/Publication/Services/Positions/PositionsService.swift
@@ -9,7 +9,7 @@ import Foundation
 public typealias PositionsServiceFactory = (PublicationServiceContext) -> PositionsService?
 
 /// Provides a list of discrete locations in the publication, no matter what the original format is.
-public protocol PositionsService: PublicationService {
+public protocol PositionsService: PublicationService & Sendable {
     /// List of all the positions in the publication, grouped by the resource reading order index.
     func positionsByReadingOrder() async -> ReadResult<[[Locator]]>
 
@@ -30,7 +30,7 @@ private let positionsLink = Link(
     mediaType: MediaType.readiumPositions
 )
 
-public extension PositionsService {
+public extension PositionsService where Self: AnyObject {
     var links: [Link] {
         [positionsLink]
     }
@@ -39,14 +39,16 @@ public extension PositionsService {
         guard href.anyURL.isEquivalentTo(positionsLink.url()) else {
             return nil
         }
-        return PositionsResource(positions: positions)
+        return PositionsResource(positions: { [weak self] in
+            await self?.positions() ?? .failure(.decoding("Deallocated"))
+        })
     }
 }
 
-private class PositionsResource: Resource {
-    private let positions: () async -> ReadResult<[Locator]>
+private struct PositionsResource: Resource {
+    private let positions: @Sendable () async -> ReadResult<[Locator]>
 
-    init(positions: @escaping () async -> ReadResult<[Locator]>) {
+    init(positions: @escaping @Sendable () async -> ReadResult<[Locator]>) {
         self.positions = positions
     }
 
@@ -60,7 +62,7 @@ private class PositionsResource: Resource {
         .success(ResourceProperties())
     }
 
-    func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
         await positions().flatMap { positions in
             let response: [String: JSONValue] = .init([
                 "total": positions.count,

--- a/Sources/Shared/Publication/Services/Positions/PositionsService.swift
+++ b/Sources/Shared/Publication/Services/Positions/PositionsService.swift
@@ -9,7 +9,7 @@ import Foundation
 public typealias PositionsServiceFactory = (PublicationServiceContext) -> PositionsService?
 
 /// Provides a list of discrete locations in the publication, no matter what the original format is.
-public protocol PositionsService: PublicationService & Sendable {
+public protocol PositionsService: PublicationService {
     /// List of all the positions in the publication, grouped by the resource reading order index.
     func positionsByReadingOrder() async -> ReadResult<[[Locator]]>
 

--- a/Sources/Shared/Toolkit/Data/Resource/BorrowedResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/BorrowedResource.swift
@@ -18,7 +18,7 @@ public extension Resource {
 }
 
 @available(*, deprecated, message: "Resources are closed on deallocation now.")
-private class BorrowedResource: Resource {
+private struct BorrowedResource: Resource {
     private let resource: Resource
 
     init(resource: Resource) {
@@ -37,7 +37,7 @@ private class BorrowedResource: Resource {
         await resource.properties()
     }
 
-    func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
         await resource.stream(range: range, consume: consume)
     }
 }

--- a/Sources/Shared/Toolkit/Data/Resource/BufferingResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/BufferingResource.swift
@@ -63,7 +63,7 @@ public actor BufferingResource: Resource, Loggable {
 
     public func stream(
         range: Range<UInt64>?,
-        consume: @escaping (Data) -> Void
+        consume: @escaping @Sendable (Data) -> Void
     ) async -> ReadResult<Void> {
         // Reading the whole resource bypasses buffering to keep things simple.
         guard let requestedRange = range, !requestedRange.isEmpty else {
@@ -99,20 +99,22 @@ public actor BufferingResource: Resource, Loggable {
 
         // Read from the original resource using stream to avoid materializing
         // more than needed.
-        var data = prefixData
+        let data = Mutex(prefixData)
+
         let result = await resource.stream(range: fetchRange) { chunk in
-            data.append(chunk)
+            data.withLock { $0.append(chunk) }
         }
 
         guard case .success = result else {
             return result
         }
 
-        buffer.set(data, at: readRange.lowerBound)
+        let finalData = data.withLock { $0 }
+        buffer.set(finalData, at: readRange.lowerBound)
 
-        let end = min(Int(requestedRange.count), data.count)
+        let end = min(Int(requestedRange.count), finalData.count)
         if end > 0 {
-            consume(data[0 ..< end])
+            consume(finalData[0 ..< end])
         }
         return .success(())
     }

--- a/Sources/Shared/Toolkit/Data/Resource/CachingResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/CachingResource.swift
@@ -42,7 +42,7 @@ public actor CachingResource: Resource {
 
     public func stream(
         range: Range<UInt64>?,
-        consume: @escaping (Data) -> Void
+        consume: @escaping @Sendable (Data) -> Void
     ) async -> ReadResult<Void> {
         await data().map { data in
             let length = UInt64(data.count)

--- a/Sources/Shared/Toolkit/Data/Resource/DataResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/DataResource.swift
@@ -10,11 +10,11 @@ import Foundation
 public actor DataResource: Resource {
     public let sourceURL: AbsoluteURL?
 
-    private let makeData: () async -> ReadResult<Data>
+    private let makeData: @Sendable () async -> ReadResult<Data>
 
     /// Creates a `Resource` serving an array of bytes.
     public init(
-        data: @autoclosure @escaping () -> Data,
+        data: @autoclosure @escaping @Sendable () -> Data,
         sourceURL: AbsoluteURL? = nil
     ) {
         self.init(sourceURL: sourceURL) {
@@ -34,7 +34,7 @@ public actor DataResource: Resource {
     /// Creates a `Resource` serving an array of bytes.
     public init(
         sourceURL: AbsoluteURL? = nil,
-        makeData: @escaping () async -> ReadResult<Data>
+        makeData: @escaping @Sendable () async -> ReadResult<Data>
     ) {
         self.makeData = makeData
         self.sourceURL = sourceURL
@@ -59,7 +59,7 @@ public actor DataResource: Resource {
 
     public func stream(
         range: Range<UInt64>?,
-        consume: @escaping (Data) -> Void
+        consume: @escaping @Sendable (Data) -> Void
     ) async -> ReadResult<Void> {
         await data().map { data in
             let length = UInt64(data.count)

--- a/Sources/Shared/Toolkit/Data/Resource/FailureResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/FailureResource.swift
@@ -25,7 +25,7 @@ public final class FailureResource: Resource, Sendable {
         .failure(error)
     }
 
-    public func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    public func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
         .failure(error)
     }
 }

--- a/Sources/Shared/Toolkit/Data/Resource/FailureResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/FailureResource.swift
@@ -32,6 +32,6 @@ public final class FailureResource: Resource, Sendable {
 
 public extension Resource where Self == FailureResource {
     static func failure(_ error: ReadError, sourceURL: AbsoluteURL? = nil) -> FailureResource {
-        FailureResource(error: error)
+        FailureResource(error: error, sourceURL: sourceURL)
     }
 }

--- a/Sources/Shared/Toolkit/Data/Resource/TailCachingResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/TailCachingResource.swift
@@ -35,7 +35,7 @@ actor TailCachingResource: Resource, Loggable {
 
     func stream(
         range: Range<UInt64>?,
-        consume: @escaping (Data) -> Void
+        consume: @escaping @Sendable (Data) -> Void
     ) async -> ReadResult<Void> {
         guard cacheFromOffset <= range?.lowerBound ?? 0 else {
             return await resource.stream(range: range, consume: consume)
@@ -78,10 +78,12 @@ actor TailCachingResource: Resource, Loggable {
                     return cache!
                 }
 
-                var data = Data()
-                cache = await resource.stream(range: cacheFromOffset ..< length) { chunk in
-                    data.append(chunk)
-                }.map { data }
+                let data = Mutex(Data())
+                let streamResult = await resource.stream(range: cacheFromOffset ..< length) { chunk in
+                    data.withLock { $0.append(chunk) }
+                }
+
+                cache = streamResult.map { data.withLock { $0 } }
 
                 return cache!
             }

--- a/Sources/Shared/Toolkit/Data/Resource/TransformingResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/TransformingResource.swift
@@ -14,8 +14,7 @@ import Foundation
 /// good idea to cache the result of the transformation in case multiple ranges
 /// will be read.
 ///
-/// You can either provide a `transform` closure during construction, or extend
-/// `TransformingResource` and override `transform()`.
+/// Customize the transformation by providing a `transform` closure during construction.
 public final class TransformingResource: Resource, Sendable {
     private let resource: Resource
     private let data: AsyncMemoizer<ReadResult<Data>>

--- a/Sources/Shared/Toolkit/Data/Resource/TransformingResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/TransformingResource.swift
@@ -18,15 +18,12 @@ import Foundation
 public final class TransformingResource: Resource, Sendable {
     private let resource: Resource
     private let data: AsyncMemoizer<ReadResult<Data>>
-    private let estimatedLengthClosure: @Sendable () async -> ReadResult<UInt64?>
 
     public init(
         _ resource: Resource,
-        estimatedLength: (@Sendable () async -> ReadResult<UInt64?>)? = nil,
         transform: @escaping @Sendable (ReadResult<Data>) async -> ReadResult<Data> = { $0 }
     ) {
         self.resource = resource
-        estimatedLengthClosure = estimatedLength ?? { .success(nil) }
         data = AsyncMemoizer {
             await transform(resource.read())
         }
@@ -37,7 +34,9 @@ public final class TransformingResource: Resource, Sendable {
     public let sourceURL: AbsoluteURL? = nil
 
     public func estimatedLength() async -> ReadResult<UInt64?> {
-        await estimatedLengthClosure()
+        // As the content will be transformed, we can't rely on the estimated
+        // length from the upstream resource.
+        .success(nil)
     }
 
     public func properties() async -> ReadResult<ResourceProperties> {

--- a/Sources/Shared/Toolkit/Data/Resource/TransformingResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/TransformingResource.swift
@@ -16,42 +16,36 @@ import Foundation
 ///
 /// You can either provide a `transform` closure during construction, or extend
 /// `TransformingResource` and override `transform()`.
-open class TransformingResource: Resource {
+public final class TransformingResource: Resource, Sendable {
     private let resource: Resource
-    private let _transform: ((ReadResult<Data>) async -> ReadResult<Data>)?
-    private var data: AsyncMemoizer<ReadResult<Data>>!
+    private let data: AsyncMemoizer<ReadResult<Data>>
+    private let estimatedLengthClosure: @Sendable () async -> ReadResult<UInt64?>
 
-    public init(_ resource: Resource, transform: ((ReadResult<Data>) async -> ReadResult<Data>)? = nil) {
+    public init(
+        _ resource: Resource,
+        estimatedLength: (@Sendable () async -> ReadResult<UInt64?>)? = nil,
+        transform: @escaping @Sendable (ReadResult<Data>) async -> ReadResult<Data> = { $0 }
+    ) {
         self.resource = resource
-        _transform = transform
-
-        data = AsyncMemoizer { [weak self] in
-            guard let self else {
-                return .failure(.decoding(DebugError("TransformingResource is deallocated")))
-            }
-            return await self.transform(data: resource.read())
+        self.estimatedLengthClosure = estimatedLength ?? { .success(nil) }
+        self.data = AsyncMemoizer {
+            await transform(resource.read())
         }
-    }
-
-    open func transform(data: ReadResult<Data>) async -> ReadResult<Data> {
-        await _transform!(data)
     }
 
     /// As the resource is transformed, we can't use the original source URL
     /// as reference.
     public let sourceURL: AbsoluteURL? = nil
 
-    open func estimatedLength() async -> ReadResult<UInt64?> {
-        // As the content will be transformed, we can't rely on the estimated
-        // length from the upstream resource.
-        .success(nil)
+    public func estimatedLength() async -> ReadResult<UInt64?> {
+        await estimatedLengthClosure()
     }
 
-    open func properties() async -> ReadResult<ResourceProperties> {
+    public func properties() async -> ReadResult<ResourceProperties> {
         await resource.properties()
     }
 
-    public func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    public func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
         await data().map { data in
             if let range = range?.clamped(to: 0 ..< UInt64(data.count)) {
                 consume(data[range])
@@ -65,16 +59,16 @@ open class TransformingResource: Resource {
 
 /// Convenient shortcuts to create a `TransformingResource`.
 public extension Resource {
-    func map(transform: @escaping (Data) async -> Data) -> Resource {
+    func map(transform: @escaping @Sendable (Data) async -> Data) -> Resource {
         TransformingResource(self, transform: { await $0.asyncMap(transform) })
     }
 
-    func mapAsString(encoding: String.Encoding = .utf8, transform: @escaping (String) async -> String) -> Resource {
-        TransformingResource(self) {
+    func mapAsString(encoding: String.Encoding = .utf8, transform: @escaping @Sendable (String) async -> String) -> Resource {
+        TransformingResource(self, transform: {
             await $0.asyncMap { data in
                 let string = String(data: data, encoding: encoding) ?? ""
                 return await transform(string).data(using: .utf8) ?? Data()
             }
-        }
+        })
     }
 }

--- a/Sources/Shared/Toolkit/Data/Resource/TransformingResource.swift
+++ b/Sources/Shared/Toolkit/Data/Resource/TransformingResource.swift
@@ -27,8 +27,8 @@ public final class TransformingResource: Resource, Sendable {
         transform: @escaping @Sendable (ReadResult<Data>) async -> ReadResult<Data> = { $0 }
     ) {
         self.resource = resource
-        self.estimatedLengthClosure = estimatedLength ?? { .success(nil) }
-        self.data = AsyncMemoizer {
+        estimatedLengthClosure = estimatedLength ?? { .success(nil) }
+        data = AsyncMemoizer {
             await transform(resource.read())
         }
     }

--- a/Sources/Shared/Toolkit/Data/Streamable.swift
+++ b/Sources/Shared/Toolkit/Data/Streamable.swift
@@ -121,6 +121,7 @@ package extension Streamable {
 
             guard !Task.isCancelled else {
                 error.withLock { $0 = .cancelled }
+                data.withLock { $0 = Data() }
                 return
             }
 
@@ -128,6 +129,7 @@ package extension Streamable {
             let currentCount = data.withLock { $0.count }
             guard availableMemory == 0 || currentCount + chunk.count <= availableMemory else {
                 error.withLock { $0 = .outOfMemory(nil) }
+                data.withLock { $0 = Data() }
                 return
             }
 

--- a/Sources/Shared/Toolkit/Data/Streamable.swift
+++ b/Sources/Shared/Toolkit/Data/Streamable.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Acts as a proxy to an actual data source by handling read access.
-public protocol Streamable: Closeable {
+public protocol Streamable: Closeable, Sendable {
     /// Returns data length from metadata if available.
     ///
     /// This value must be treated as a hint, as it might not reflect the
@@ -24,7 +24,7 @@ public protocol Streamable: Closeable {
     ///     are responsible to accumulate the data if needed.
     func stream(
         range: Range<UInt64>?,
-        consume: @escaping (Data) -> Void
+        consume: @escaping @Sendable (Data) -> Void
     ) async -> ReadResult<Void>
 }
 
@@ -35,7 +35,7 @@ public extension Streamable {
     ///   - consume: Callback called for each chunk of data received. Callers
     ///     are responsible to accumulate the data if needed.
     // FIXME: Task cancellation
-    func stream(consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    func stream(consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
         await stream(range: nil, consume: consume)
     }
 
@@ -49,11 +49,11 @@ public extension Streamable {
     /// When `range` is null, the whole content is returned. Out-of-range
     /// indexes are clamped to the available length automatically.
     func read(range: Range<UInt64>?) async -> ReadResult<Data> {
-        var data = Data()
-        let result = await stream(range: range) {
-            data += $0
+        let data = Mutex(Data())
+        let result = await stream(range: range) { chunk in
+            data.withLock { $0 += chunk }
         }
-        return result.map { data }
+        return result.map { data.withLock { $0 } }
     }
 
     /// Reads the whole content as a `String`.
@@ -105,43 +105,42 @@ package extension Streamable {
             throw .outOfMemory(nil)
         }
 
-        var data = Data()
+        let data = Mutex(Data())
+
         if let estimated, estimated <= UInt64(Int.max) {
-            data.reserveCapacity(Int(estimated))
+            data.withLock { $0.reserveCapacity(Int(estimated)) }
         }
 
-        var error: ReadError? = nil {
-            didSet {
-                data = Data()
-            }
-        }
+        let error = Mutex<ReadError?>(nil)
 
         let streamResult = await stream { chunk in
-            guard error == nil else {
+            let err = error.withLock { $0 }
+            guard err == nil else {
                 return
             }
 
             guard !Task.isCancelled else {
-                error = .cancelled
+                error.withLock { $0 = .cancelled }
                 return
             }
 
             let availableMemory = os_proc_available_memory()
-            guard availableMemory == 0 || data.count + chunk.count <= availableMemory else {
-                error = .outOfMemory(nil)
+            let currentCount = data.withLock { $0.count }
+            guard availableMemory == 0 || currentCount + chunk.count <= availableMemory else {
+                error.withLock { $0 = .outOfMemory(nil) }
                 return
             }
 
-            data.append(chunk)
+            data.withLock { $0.append(chunk) }
         }
 
-        if let error {
+        if let error = error.withLock({ $0 }) {
             throw error
         }
 
         switch streamResult {
         case .success:
-            return data
+            return data.withLock { $0 }
         case let .failure(error):
             throw error
         }

--- a/Sources/Shared/Toolkit/Data/Streamable.swift
+++ b/Sources/Shared/Toolkit/Data/Streamable.swift
@@ -126,14 +126,20 @@ package extension Streamable {
             }
 
             let availableMemory = os_proc_available_memory()
-            let currentCount = data.withLock { $0.count }
-            guard availableMemory == 0 || currentCount + chunk.count <= availableMemory else {
-                error.withLock { $0 = .outOfMemory(nil) }
-                data.withLock { $0 = Data() }
-                return
+            let success = data.withLock { buffer in
+                if availableMemory == 0 || buffer.count + chunk.count <= availableMemory {
+                    buffer.append(chunk)
+                    return true
+                } else {
+                    buffer = Data()
+                    return false
+                }
             }
 
-            data.withLock { $0.append(chunk) }
+            guard success else {
+                error.withLock { $0 = .outOfMemory(nil) }
+                return
+            }
         }
 
         if let error = error.withLock({ $0 }) {

--- a/Sources/Shared/Toolkit/File/FileResource.swift
+++ b/Sources/Shared/Toolkit/File/FileResource.swift
@@ -42,7 +42,7 @@ public actor FileResource: Resource, Loggable {
         })
     }
 
-    public func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    public func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
         await handle().flatMap { handle in
             do {
                 if var range = range {

--- a/Sources/Shared/Toolkit/HTTP/HTTPResource.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPResource.swift
@@ -78,7 +78,7 @@ public actor HTTPResource: Resource {
         return _headResponse!
     }
 
-    public func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    public func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
         let request = {
             var request = HTTPRequest(url: url)
             if let range = range {

--- a/Sources/Shared/Toolkit/ZIP/Minizip/MinizipContainer.swift
+++ b/Sources/Shared/Toolkit/ZIP/Minizip/MinizipContainer.swift
@@ -117,7 +117,7 @@ private actor MinizipResource: Resource, Loggable {
         })
     }
 
-    func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
         let range = range ?? 0 ..< metadata.length
 
         return await zipFile().flatMap { zipFile in

--- a/Sources/Shared/Toolkit/ZIP/ZIPFoundation/ZIPFoundationContainer.swift
+++ b/Sources/Shared/Toolkit/ZIP/ZIPFoundation/ZIPFoundationContainer.swift
@@ -104,7 +104,7 @@ private actor ZIPFoundationResource: Resource, Loggable {
         })
     }
 
-    func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
         if range != nil {}
 
         return await archive().asyncFlatMap { archive in

--- a/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
+++ b/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
@@ -67,7 +67,7 @@ final class EPUBDeobfuscator {
             await resource.properties()
         }
 
-        func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+        func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
             var readPosition = range?.lowerBound ?? 0
             let obfuscatedLength = algorithm.obfuscatedLength
 

--- a/Sources/Streamer/Parser/PDF/Services/LCPDFPositionsService.swift
+++ b/Sources/Streamer/Parser/PDF/Services/LCPDFPositionsService.swift
@@ -18,7 +18,7 @@ final class LCPDFPositionsService: PositionsService, Loggable, Sendable {
     init(publication: Weak<Publication>) {
         cache = AsyncMemoizer { [publication] in
             guard let publication = publication() else {
-                return .failure(.cancelled)
+                return .failure(.unsupportedOperation(DebugError("The publication is deallocated")))
             }
 
             return await Self.makePositionList(of: publication)

--- a/Tests/SharedTests/Publication/Services/Positions/PositionsServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Positions/PositionsServiceTests.swift
@@ -7,7 +7,7 @@
 @testable import ReadiumShared
 import XCTest
 
-struct TestPositionsService: PositionsService {
+final class TestPositionsService: PositionsService {
     let positions: [[Locator]]
 
     init(_ positions: [[Locator]]) {

--- a/Tests/SharedTests/Toolkit/Data/Resource/FakeResource.swift
+++ b/Tests/SharedTests/Toolkit/Data/Resource/FakeResource.swift
@@ -32,7 +32,7 @@ actor FakeResource: Resource {
         _properties
     }
 
-    func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+    func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
         consume(Data())
         return .success(())
     }

--- a/Tests/SharedTests/Toolkit/Data/Resource/TransformingResourceTests.swift
+++ b/Tests/SharedTests/Toolkit/Data/Resource/TransformingResourceTests.swift
@@ -11,13 +11,13 @@ import Testing
 struct TransformingResourceTests {
     @Test func sourceURLIsNil() {
         let resource = DataResource(string: "hello")
-        let sut = TransformingResource(resource) { $0 }
+        let sut = TransformingResource(resource, transform: { $0 })
         #expect(sut.sourceURL == nil)
     }
 
     @Test func estimatedLengthIsNil() async throws {
         let resource = DataResource(string: "hello")
-        let sut = TransformingResource(resource) { $0 }
+        let sut = TransformingResource(resource, transform: { $0 })
         let result = try await sut.estimatedLength().get()
         #expect(result == nil)
     }
@@ -27,27 +27,27 @@ struct TransformingResourceTests {
             $0.filename = "chapter.html"
         }
         let resource = FakeResource(properties: .success(expected))
-        let sut = TransformingResource(resource) { $0 }
+        let sut = TransformingResource(resource, transform: { $0 })
         let actual = try await sut.properties().get()
         #expect(actual == expected)
     }
 
     @Test func transformApplied() async throws {
         let resource = DataResource(string: "hello")
-        let sut = TransformingResource(resource) { data in
+        let sut = TransformingResource(resource, transform: { data in
             data.map {
                 String(data: $0, encoding: .utf8)!
                     .uppercased()
                     .data(using: .utf8)!
             }
-        }
+        })
         let data = try await sut.read().get()
         #expect(data == "HELLO".data(using: .utf8)!)
     }
 
     @Test func rangeRead() async throws {
         let resource = DataResource(data: Data([0, 1, 2, 3, 4, 5, 6, 7]))
-        let sut = TransformingResource(resource) { $0 }
+        let sut = TransformingResource(resource, transform: { $0 })
         let data = try await sut.read(range: 2 ..< 5).get()
         #expect(data == Data([2, 3, 4]))
     }
@@ -83,13 +83,13 @@ struct TransformingResourceTests {
         @Test func transformCalledOnce() async {
             let counter = Counter()
             let resource = DataResource(string: "hello")
-            let sut = TransformingResource(resource) { data in
+            let sut = TransformingResource(resource, transform: { data in
                 // Sleep to widen the race window so concurrent callers all
                 // enter this branch before any of them finishes writing to `_data`.
                 try? await Task.sleep(seconds: 0.5)
                 await counter.increment()
                 return data
-            }
+            })
 
             await withTaskGroup(of: Void.self) { group in
                 for _ in 0 ..< 50 {
@@ -106,10 +106,10 @@ struct TransformingResourceTests {
         @Test func concurrentReadsReturnSameData() async throws {
             let expected = "hello".data(using: .utf8)!
             let resource = DataResource(string: "hello")
-            let sut = TransformingResource(resource) { data in
+            let sut = TransformingResource(resource, transform: { data in
                 try? await Task.sleep(seconds: 0.5)
                 return data
-            }
+            })
 
             var results: [ReadResult<Data>] = []
             await withTaskGroup(of: ReadResult<Data>.self) { group in

--- a/Tests/SharedTests/Toolkit/HTTP/HTTPResourceTests.swift
+++ b/Tests/SharedTests/Toolkit/HTTP/HTTPResourceTests.swift
@@ -96,10 +96,10 @@ struct HTTPResourceTests {
             body: #require("0123456789".data(using: .utf8))
         ))
 
-        var streamedData = Data()
-        let result = await resource.stream(range: 0 ..< 10, consume: { streamedData.append($0) })
+        let streamedData = Mutex(Data())
+        let result = await resource.stream(range: 0 ..< 10, consume: { chunk in streamedData.withLock { $0.append(chunk) } })
 
         try result.get()
-        #expect(streamedData == "0123456789".data(using: .utf8))
+        #expect(streamedData.withLock { $0 } == "0123456789".data(using: .utf8))
     }
 }

--- a/Tests/SharedTests/Toolkit/HTTP/HTTPResourceTests.swift
+++ b/Tests/SharedTests/Toolkit/HTTP/HTTPResourceTests.swift
@@ -96,10 +96,10 @@ struct HTTPResourceTests {
             body: #require("0123456789".data(using: .utf8))
         ))
 
-        let streamedData = Mutex(Data())
-        let result = await resource.stream(range: 0 ..< 10, consume: { chunk in streamedData.withLock { $0.append(chunk) } })
+        let streamedData = Capture(Data())
+        let result = await resource.stream(range: 0 ..< 10, consume: { chunk in streamedData.value.append(chunk) })
 
         try result.get()
-        #expect(streamedData.withLock { $0 } == "0123456789".data(using: .utf8))
+        #expect(streamedData.value == "0123456789".data(using: .utf8))
     }
 }

--- a/Tests/SharedTests/Toolkit/HTTP/HTTPResourceTests.swift
+++ b/Tests/SharedTests/Toolkit/HTTP/HTTPResourceTests.swift
@@ -22,8 +22,8 @@ struct HTTPResourceTests {
 
         func stream(
             _ request: HTTPRequestConvertible,
-            onReceiveResponse: ((HTTPResponse) async -> HTTPResult<Void>)?,
-            consume: (Data, Double?) -> HTTPResult<Void>
+            onReceiveResponse: (@Sendable (HTTPResponse) async -> HTTPResult<Void>)?,
+            consume: @Sendable (Data, Double?) -> HTTPResult<Void>
         ) async -> HTTPResult<HTTPResponse> {
             let req = try! request.httpRequest().get()
             let key = "\(req.method.rawValue) \(req.url.string)"

--- a/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
@@ -389,7 +389,7 @@ private class MockContainer: Container {
             .success(_properties)
         }
 
-        func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
+        func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
             consume(Data())
             return .success(())
         }


### PR DESCRIPTION
1. Conforms `Streamable` and `Resource` protocols to `Sendable` across the codebase.
2. Updates the `stream` callback signatures to require `@escaping @Sendable (Data) -> Void`.
3. Refactors `TransformingResource` from subclass inheritance to closure-based composition.
4. Converts `BufferingResource`, `TailCachingResource`, and `Streamable` local accumulators to use `Mutex` wrappers to prevent data races.
5. Conforms `PositionsService` to `Sendable & AnyObject` to allow safe `[weak self]` closure capture.
6. Resolves strict concurrency warnings in `LCPDecryptor` and `EPUBNavigatorViewModel` by pre-serving fonts on the main actor and using read-only snapshots in background mapping tasks.
7. In `CBCLCPResource`, the size calculation for `plainTextSizeTask` has been shifted from a `lazy var` to a constant `Task` initialized in `init` to conform to `Sendable`.
8. Because `WebViewServer` is main-actor isolated, font URLs are now pre-served on the `@MainActor` before mapping. A warning is logged if an unserved font is encountered during mapping.


### Public API Breaking Changes

1. `Streamable`, `Resource`, `HTMLFontFamilyDeclaration`, and `PositionsService` all conform to Sendable.
2. The `consume` callback added `@Sendable`.
3. `Resource.map` and `Resource.mapAsString` transform closures both added `@Sendable`
4. `TransformingResource` changed from open class to public final.
5. `fontFiles` is a required property in `HTMLFontFamilyDeclaration`.
6. In `PositionsService`, default implementations for `links` and `get` are now restricted to `where Self: AnyObject` to support safe weak capture. Any custom struct-based conformances must implement these properties manually or be changed to classes/actors.

Note: This will have warnings until #769 and/or #772 are merged.

Relates to #758.