### PR TITLE
Adopt `Sendable` across PDF, LCP and `Container` APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ help:
 	  update-locales\tUpdate the localization files\n\
 	"
 
+.PHONY: test
+test:
+	xcodebuild test -project "TestApp/TestApp.xcodeproj" -scheme TestApp -destination "platform=iOS Simulator,name=iPhone Air" 2> /dev/null \
+		| xcbeautify --quieter --disable-logging \
+		| grep -Ev "^Executed |Test Suite 'All tests'|Test run started\.|Test session results:"; true
+
 .SILENT:
 .PHONY: playground
 playground:

--- a/Sources/LCP/LCPClient.swift
+++ b/Sources/LCP/LCPClient.swift
@@ -29,7 +29,7 @@ import Foundation
 ///          }
 ///
 ///      }
-public protocol LCPClient {
+public protocol LCPClient: Sendable {
     /// Create a context for a given license/passphrase tuple.
     func createContext(jsonLicense: String, hashedPassphrase: LCPPassphraseHash, pemCrl: String) throws -> LCPClientContext
 
@@ -40,7 +40,7 @@ public protocol LCPClient {
     func findOneValidPassphrase(jsonLicense: String, hashedPassphrases: [LCPPassphraseHash]) -> LCPPassphraseHash?
 }
 
-public typealias LCPClientContext = Any
+public typealias LCPClientContext = Any & Sendable
 
 /// Copy of the R2LCPClient.LCPClientError enum.
 ///

--- a/Sources/LCP/LCPLicenseRepository.swift
+++ b/Sources/LCP/LCPLicenseRepository.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// The license repository stores registered licenses with their consumed rights (e.g. copy).
-public protocol LCPLicenseRepository {
+public protocol LCPLicenseRepository: Sendable {
     /// Adds a new `licenseDocument` to the repository, using `licenseDocument.id` as the
     /// primary key.
     ///

--- a/Sources/LCP/LCPRenewDelegate.swift
+++ b/Sources/LCP/LCPRenewDelegate.swift
@@ -10,7 +10,7 @@ import SafariServices
 import UIKit
 
 /// UX delegate for the loan renew LSD interaction.
-public protocol LCPRenewDelegate {
+public protocol LCPRenewDelegate: Sendable {
     /// Called when the renew interaction allows to customize the end date programmatically.
     ///
     /// You can prompt the user for the number of days to renew, for example.
@@ -28,6 +28,7 @@ public protocol LCPRenewDelegate {
 ///
 /// No date picker is presented for selecting a preferred end date. If you want to support one, you can subclass or
 /// decorate `LCPRenewDelegate`.
+@MainActor
 public final class LCPDefaultRenewDelegate: NSObject, LCPRenewDelegate {
     private let presentingViewController: UIViewController
     private let modalPresentationStyle: UIModalPresentationStyle
@@ -64,7 +65,7 @@ extension LCPDefaultRenewDelegate: UIAdaptivePresentationControllerDelegate {
     }
 }
 
-extension LCPDefaultRenewDelegate: SFSafariViewControllerDelegate {
+extension LCPDefaultRenewDelegate: @preconcurrency SFSafariViewControllerDelegate {
     public func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         webPageContinuation?.resume(returning: ())
         webPageContinuation = nil

--- a/Sources/LCP/License/License.swift
+++ b/Sources/LCP/License/License.swift
@@ -8,19 +8,19 @@ import Foundation
 import ReadiumShared
 import ReadiumZIPFoundation
 
-final class License: Loggable {
+final class License: Loggable, Sendable {
     /// Last Documents which passed the integrity checks.
-    private var documents: ValidatedDocuments
+    private let documents: Mutex<ValidatedDocuments>
 
     // Dependencies
-    private let client: LCPClient
+    private let client: any LCPClient
     private let validation: LicenseValidation
-    private let licenses: LCPLicenseRepository
+    private let licenses: any LCPLicenseRepository
     private let device: DeviceService
-    private let httpClient: HTTPClient
+    private let httpClient: any HTTPClient
 
-    init(documents: ValidatedDocuments, client: LCPClient, validation: LicenseValidation, licenses: LCPLicenseRepository, device: DeviceService, httpClient: HTTPClient) {
-        self.documents = documents
+    init(documents: ValidatedDocuments, client: any LCPClient, validation: LicenseValidation, licenses: any LCPLicenseRepository, device: DeviceService, httpClient: any HTTPClient) {
+        self.documents = Mutex(documents)
         self.client = client
         self.validation = validation
         self.licenses = licenses
@@ -29,7 +29,7 @@ final class License: Loggable {
 
         validation.observe { [weak self] result in
             if case let .success(documents) = result {
-                self?.documents = documents
+                self?.documents.withLock { $0 = documents }
             }
         }
     }
@@ -38,19 +38,19 @@ final class License: Loggable {
 /// Public API
 extension License: LCPLicense {
     var license: LicenseDocument {
-        documents.license
+        documents.withLock { $0.license }
     }
 
     var status: StatusDocument? {
-        documents.status
+        documents.withLock { $0.status }
     }
 
     var isRestricted: Bool {
-        documents.context.getOrNil() == nil
+        documents.withLock { $0.context.getOrNil() == nil }
     }
 
     var error: LCPError? {
-        switch documents.context {
+        switch documents.withLock({ $0.context }) {
         case .success:
             return nil
         case let .failure(error):
@@ -70,7 +70,7 @@ extension License: LCPLicense {
     }
 
     func decipher(_ data: Data) throws -> Data? {
-        let context = try documents.context.get()
+        let context = try documents.withLock { $0.context }.get()
         return client.decrypt(data: data, using: context)
     }
 
@@ -187,7 +187,7 @@ extension License: LCPLicense {
 
         /// Finds the renew link according to `prefersWebPage`.
         func findRenewLink() -> Link? {
-            guard let status = documents.status else {
+            guard let status = documents.withLock({ $0.status }) else {
                 return nil
             }
 
@@ -284,7 +284,7 @@ extension License: LCPLicense {
 
     func returnPublication() async -> Result<Void, LCPError> {
         guard
-            let status = documents.status,
+            let status = documents.withLock({ $0.status }),
             let url = try? status.url(
                 for: .return,
                 preferredType: .lcpStatusDocument,

--- a/Sources/LCP/Services/DeviceService.swift
+++ b/Sources/LCP/Services/DeviceService.swift
@@ -7,9 +7,9 @@
 import Foundation
 import ReadiumShared
 
-final class DeviceService {
-    private let repository: LCPLicenseRepository
-    private let httpClient: HTTPClient
+final class DeviceService: Sendable {
+    private let repository: any LCPLicenseRepository
+    private let httpClient: any HTTPClient
 
     /// Returns the device's name.
     let name: String
@@ -19,8 +19,8 @@ final class DeviceService {
     init(
         deviceName: String,
         deviceId: String?,
-        repository: LCPLicenseRepository,
-        httpClient: HTTPClient
+        repository: any LCPLicenseRepository,
+        httpClient: any HTTPClient
     ) {
         name = deviceName
 

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -460,14 +460,15 @@ open class PDFNavigatorViewController:
         let factory = PDFKitPDFDocumentFactory()
         guard
             let resource = publication.get(href),
-            let opened = try? await factory.open(resource: resource, at: href, password: nil) as? PDFKit.PDFDocument
+            let document = try? await factory.open(resource: resource, at: href, password: nil),
+            let pdfKitDocument = (document as? PDFKitDocumentProviding)?.pdfKitDocument
         else {
             return nil
         }
 
-        await service?.setCachedDocument(opened, at: href)
+        await service?.setCachedDocument(document, at: href)
 
-        return opened
+        return pdfKitDocument
     }
 
     /// Updates the scale factors to match the currently visible pages.

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -450,7 +450,7 @@ open class PDFNavigatorViewController:
         return true
     }
 
-    private func openDocument<HREF: URLConvertible>(at href: HREF) async -> PDFKit.PDFDocument? {
+    private func openDocument<HREF: URLConvertible & Sendable>(at href: HREF) async -> PDFKit.PDFDocument? {
         let service = publication.pdfDocumentService
 
         if let cached = await service?.cachedDocument(at: href) as? PDFKitDocumentProviding {

--- a/Sources/Shared/Publication/Services/Content Protection/UserRights.swift
+++ b/Sources/Shared/Publication/Services/Content Protection/UserRights.swift
@@ -35,7 +35,7 @@ public protocol UserRights: Sendable {
 }
 
 /// A `UserRights` without any restriction.
-public final class UnrestrictedUserRights: UserRights, Sendable {
+public final class UnrestrictedUserRights: UserRights {
     public init() {}
 
     public func canCopy(text: String) async -> Bool {
@@ -56,7 +56,7 @@ public final class UnrestrictedUserRights: UserRights, Sendable {
 }
 
 /// A `UserRights` which forbids all rights.
-public final class AllRestrictedUserRights: UserRights, Sendable {
+public final class AllRestrictedUserRights: UserRights {
     public init() {}
 
     public func canCopy(text: String) async -> Bool {

--- a/Sources/Shared/Publication/Services/Content Protection/UserRights.swift
+++ b/Sources/Shared/Publication/Services/Content Protection/UserRights.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Manages consumption of user rights and permissions.
-public protocol UserRights {
+public protocol UserRights: Sendable {
     /// Returns whether the user is allowed to copy the given text to the pasteboard.
     ///
     /// It may return `false` if the given text exceeds the allowed amount of characters to copy.

--- a/Sources/Shared/Toolkit/Data/Container/Container.swift
+++ b/Sources/Shared/Toolkit/Data/Container/Container.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// A container provides access to a list of `Resource` entries.
-public protocol Container: Closeable {
+public protocol Container: Closeable, Sendable {
     /// URL locating this container, when available.
     ///
     /// This can be used to optimize access to a container's content for the
@@ -46,14 +46,14 @@ public struct EmptyContainer: Container, Sendable {
 /// sources.
 ///
 /// The `containers` will be tested in the given order.
-public final class CompositeContainer: Container {
-    private let containers: [Container]
+public final class CompositeContainer: Container, Sendable {
+    private let containers: [any Container]
 
-    public convenience init(_ containers: Container...) {
+    public convenience init(_ containers: any Container...) {
         self.init(containers)
     }
 
-    public init(_ containers: [Container]) {
+    public init(_ containers: [any Container]) {
         self.containers = containers
     }
 

--- a/Sources/Shared/Toolkit/Data/Container/Container.swift
+++ b/Sources/Shared/Toolkit/Data/Container/Container.swift
@@ -28,7 +28,7 @@ public protocol Container: Closeable, Sendable {
 }
 
 /// A `Container` providing no entries at all.
-public struct EmptyContainer: Container, Sendable {
+public struct EmptyContainer: Container {
     public init() {}
 
     public let sourceURL: AbsoluteURL? = nil
@@ -46,7 +46,7 @@ public struct EmptyContainer: Container, Sendable {
 /// sources.
 ///
 /// The `containers` will be tested in the given order.
-public final class CompositeContainer: Container, Sendable {
+public final class CompositeContainer: Container {
     private let containers: [any Container]
 
     public convenience init(_ containers: any Container...) {

--- a/Sources/Shared/Toolkit/Data/Container/SingleResourceContainer.swift
+++ b/Sources/Shared/Toolkit/Data/Container/SingleResourceContainer.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Encapsulates a single ``Resource`` into a ``Container``.
-public final class SingleResourceContainer: Container, Sendable {
+public final class SingleResourceContainer: Container {
     public let entry: AnyURL
     private let resource: Resource
 

--- a/Sources/Shared/Toolkit/Data/Container/SingleResourceContainer.swift
+++ b/Sources/Shared/Toolkit/Data/Container/SingleResourceContainer.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Encapsulates a single ``Resource`` into a ``Container``.
-public final class SingleResourceContainer: Container {
+public final class SingleResourceContainer: Container, Sendable {
     public let entry: AnyURL
     private let resource: Resource
 

--- a/Sources/Shared/Toolkit/Data/Container/TransformingContainer.swift
+++ b/Sources/Shared/Toolkit/Data/Container/TransformingContainer.swift
@@ -46,7 +46,7 @@ public final class TransformingContainer: Container, Sendable {
 
 /// Convenient shortcuts to create a `TransformingContainer`.
 public extension Container {
-    func map(transform: @escaping (_ href: AnyURL, _ resource: Resource) -> Resource) -> Container {
-        TransformingContainer(container: self, transformer: { transform($0, $1) })
+    func map(transform: @escaping @Sendable (_ href: AnyURL, _ resource: Resource) -> Resource) -> Container {
+        TransformingContainer(container: self, transformer: transform)
     }
 }

--- a/Sources/Shared/Toolkit/Data/Container/TransformingContainer.swift
+++ b/Sources/Shared/Toolkit/Data/Container/TransformingContainer.swift
@@ -11,11 +11,11 @@ import Foundation
 /// an HTML document, pre-process – e.g. before indexing a publication's content, etc.
 ///
 /// If the transformation doesn't apply, simply return resource unchanged.
-public typealias ResourceTransformer = (_ href: AnyURL, _ resource: Resource) -> Resource
+public typealias ResourceTransformer = @Sendable (_ href: AnyURL, _ resource: Resource) -> Resource
 
 /// Transforms the resources' content of a child fetcher using a list of `ResourceTransformer`
 /// functions.
-public final class TransformingContainer: Container {
+public final class TransformingContainer: Container, Sendable {
     private let container: Container
     private let transformers: [ResourceTransformer]
 

--- a/Sources/Shared/Toolkit/Data/Container/TransformingContainer.swift
+++ b/Sources/Shared/Toolkit/Data/Container/TransformingContainer.swift
@@ -15,7 +15,7 @@ public typealias ResourceTransformer = @Sendable (_ href: AnyURL, _ resource: Re
 
 /// Transforms the resources' content of a child fetcher using a list of `ResourceTransformer`
 /// functions.
-public final class TransformingContainer: Container, Sendable {
+public final class TransformingContainer: Container {
     private let container: Container
     private let transformers: [ResourceTransformer]
 

--- a/Sources/Shared/Toolkit/Data/Streamable.swift
+++ b/Sources/Shared/Toolkit/Data/Streamable.swift
@@ -21,7 +21,11 @@ public protocol Streamable: Closeable, Sendable {
     ///   - range: When null, the whole content is returned. Out-of-range
     ///     indexes are clamped to the available length automatically.
     ///   - consume: Callback called for each chunk of data received. Callers
-    ///     are responsible to accumulate the data if needed.
+    ///     are responsible to accumulate the data if needed. A chunk may be a
+    ///     `Data` slice whose indices do not start at zero (e.g. when streaming
+    ///     a sub-range). Do not assume zero-based indexing: index relative to
+    ///     `chunk.startIndex`, or rebase with `Data(chunk)` before accessing
+    ///     bytes by position.
     func stream(
         range: Range<UInt64>?,
         consume: @escaping @Sendable (Data) -> Void

--- a/Sources/Shared/Toolkit/File/DirectoryContainer.swift
+++ b/Sources/Shared/Toolkit/File/DirectoryContainer.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// A file system directory as a ``Container``.
-public struct DirectoryContainer: Container, Loggable, Sendable {
+public struct DirectoryContainer: Container, Loggable {
     public struct NotADirectoryError: Error, Sendable {}
 
     private let directoryURL: FileURL

--- a/Sources/Shared/Toolkit/File/FileContainer.swift
+++ b/Sources/Shared/Toolkit/File/FileContainer.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Provides access to individual file resources on the local file system.
-public final class FileContainer: Container, Loggable, Sendable {
+public final class FileContainer: Container, Loggable {
     private let files: [RelativeURL: FileURL]
 
     public let sourceURL: AbsoluteURL? = nil

--- a/Sources/Shared/Toolkit/HTTP/DefaultHTTPClient.swift
+++ b/Sources/Shared/Toolkit/HTTP/DefaultHTTPClient.swift
@@ -107,7 +107,7 @@ public extension DefaultHTTPClientDelegate {
 }
 
 /// An implementation of `HTTPClient` using Apple's `URLSession`.
-public final class DefaultHTTPClient: HTTPClient, Loggable, Sendable {
+public final class DefaultHTTPClient: HTTPClient, Loggable {
     /// Returns the default user agent used when issuing requests.
     ///
     /// For example, TestApp/1.3

--- a/Sources/Shared/Toolkit/HTTP/HTTPClient.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPClient.swift
@@ -13,7 +13,7 @@ import Foundation
 ///
 /// You may provide a custom implementation, or use the `DefaultHTTPClient` one
 /// which relies on native APIs.
-public protocol HTTPClient: Loggable {
+public protocol HTTPClient: Loggable, Sendable {
     /// Streams a resource from the given `request`.
     ///
     /// - Parameters:

--- a/Sources/Shared/Toolkit/HTTP/HTTPContainer.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPContainer.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Fetches remote resources with HTTP.
-public final class HTTPContainer: Container, Sendable {
+public final class HTTPContainer: Container {
     /// HTTP client used to perform HTTP requests.
     private let client: HTTPClient
 

--- a/Sources/Shared/Toolkit/HTTP/HTTPContainer.swift
+++ b/Sources/Shared/Toolkit/HTTP/HTTPContainer.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Fetches remote resources with HTTP.
-public final class HTTPContainer: Container {
+public final class HTTPContainer: Container, Sendable {
     /// HTTP client used to perform HTTP requests.
     private let client: HTTPClient
 

--- a/Sources/Shared/Toolkit/PDF/CGPDF.swift
+++ b/Sources/Shared/Toolkit/PDF/CGPDF.swift
@@ -238,11 +238,7 @@ public final class CGPDFDocumentFactory: PDFDocumentFactory, Loggable, Sendable 
         return try open(document: document, password: password)
     }
 
-    private class DataHolder {
-        var data: Data = .init()
-    }
-
-    public func open<HREF: URLConvertible>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument {
+    public func open<HREF: URLConvertible & Sendable>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument {
         if let file = resource.sourceURL?.fileURL {
             return try await open(file: file, password: password)
         }
@@ -260,12 +256,14 @@ public final class CGPDFDocumentFactory: PDFDocumentFactory, Loggable, Sendable 
                     return 0
                 }
 
+                let resource = context.resource
+                let offset = context.offset
+                let resultData = Mutex<Data>(Data())
                 let semaphore = DispatchSemaphore(value: 0)
-                let holder = DataHolder()
                 Task {
-                    switch await context.resource.read(range: context.offset ..< end) {
+                    switch await resource.read(range: offset ..< end) {
                     case let .success(result):
-                        holder.data = result
+                        resultData.withLock { $0 = result }
                     case let .failure(error):
                         CGPDFDocumentFactory.log(.error, error)
                     }
@@ -274,7 +272,7 @@ public final class CGPDFDocumentFactory: PDFDocumentFactory, Loggable, Sendable 
 
                 _ = semaphore.wait(timeout: .distantFuture)
 
-                let data = holder.data
+                let data = resultData.withLock { $0 }
                 if !data.isEmpty {
                     data.copyBytes(to: buffer.assumingMemoryBound(to: UInt8.self), count: data.count)
                     context.offset += UInt64(data.count)

--- a/Sources/Shared/Toolkit/PDF/CGPDF.swift
+++ b/Sources/Shared/Toolkit/PDF/CGPDF.swift
@@ -227,7 +227,7 @@ extension CGPDFDocument: PDFDocument {
 
 /// Creates a `PDFDocument` using Core Graphics.
 @available(*, deprecated, renamed: "PDFKitPDFDocumentFactory", message: "The PDFKitPDFDocumentFactory is more capable")
-public final class CGPDFDocumentFactory: PDFDocumentFactory, Loggable, Sendable {
+public final class CGPDFDocumentFactory: PDFDocumentFactory, Loggable {
     public init() {}
 
     public func open(file: FileURL, password: String?) async throws -> PDFDocument {

--- a/Sources/Shared/Toolkit/PDF/PDFDocument.swift
+++ b/Sources/Shared/Toolkit/PDF/PDFDocument.swift
@@ -19,7 +19,7 @@ public enum PDFDocumentError: Error, Sendable {
 /// Represents a PDF document.
 ///
 /// This is not used to render a PDF document, only to access its metadata.
-public protocol PDFDocument {
+public protocol PDFDocument: Sendable {
     /// Permanent identifier based on the contents of the file at the time it was originally
     /// created.
     func identifier() async throws -> String?
@@ -59,12 +59,12 @@ public protocol PDFDocumentTextProviding: PDFDocument {
     func pageText(at pageIndex: Int) async throws -> String?
 }
 
-public protocol PDFDocumentFactory {
+public protocol PDFDocumentFactory: Sendable {
     /// Opens a PDF from a local file path.
     func open(file: FileURL, password: String?) async throws -> PDFDocument
 
     /// Opens a PDF from a `Resource` located at the given `href`.
-    func open<HREF: URLConvertible>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument
+    func open<HREF: URLConvertible & Sendable>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument
 }
 
 public final class DefaultPDFDocumentFactory: PDFDocumentFactory, Loggable, Sendable {
@@ -76,14 +76,14 @@ public final class DefaultPDFDocumentFactory: PDFDocumentFactory, Loggable, Send
         try await factory.open(file: file, password: password)
     }
 
-    public func open<HREF: URLConvertible>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument {
+    public func open<HREF: URLConvertible & Sendable>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument {
         try await factory.open(resource: resource, at: href, password: password)
     }
 }
 
 /// A PDF document factory which will iterate over a list of factories until one works.
 @available(*, deprecated, message: "Not used anymore")
-public final class CompositePDFDocumentFactory: PDFDocumentFactory, Loggable {
+public final class CompositePDFDocumentFactory: PDFDocumentFactory, Loggable, Sendable {
     private let factories: [PDFDocumentFactory]
 
     public init(factories: [PDFDocumentFactory]) {
@@ -94,7 +94,7 @@ public final class CompositePDFDocumentFactory: PDFDocumentFactory, Loggable {
         try await eachFactory { try await $0.open(file: file, password: password) }
     }
 
-    public func open<HREF: URLConvertible>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument {
+    public func open<HREF: URLConvertible & Sendable>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument {
         try await eachFactory { try await $0.open(resource: resource, at: href, password: password) }
     }
 

--- a/Sources/Shared/Toolkit/PDF/PDFDocument.swift
+++ b/Sources/Shared/Toolkit/PDF/PDFDocument.swift
@@ -67,7 +67,7 @@ public protocol PDFDocumentFactory: Sendable {
     func open<HREF: URLConvertible & Sendable>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument
 }
 
-public final class DefaultPDFDocumentFactory: PDFDocumentFactory, Loggable, Sendable {
+public final class DefaultPDFDocumentFactory: PDFDocumentFactory, Loggable {
     private let factory = PDFKitPDFDocumentFactory()
 
     public init() {}
@@ -83,7 +83,7 @@ public final class DefaultPDFDocumentFactory: PDFDocumentFactory, Loggable, Send
 
 /// A PDF document factory which will iterate over a list of factories until one works.
 @available(*, deprecated, message: "Not used anymore")
-public final class CompositePDFDocumentFactory: PDFDocumentFactory, Loggable, Sendable {
+public final class CompositePDFDocumentFactory: PDFDocumentFactory, Loggable {
     private let factories: [PDFDocumentFactory]
 
     public init(factories: [PDFDocumentFactory]) {

--- a/Sources/Shared/Toolkit/PDF/PDFDocumentService.swift
+++ b/Sources/Shared/Toolkit/PDF/PDFDocumentService.swift
@@ -10,17 +10,17 @@ import Foundation
 ///
 /// Replaces `PDFPublicationService` and `PDFDocumentHolder`. Opens the PDF once per HREF
 /// and shares the result across the parser, navigator, and publication services.
-package protocol PDFDocumentService: PublicationService {
+package protocol PDFDocumentService: PublicationService & Sendable {
     /// Returns the cached document if `href` matches, otherwise opens through the underlying factory,
     /// caches the result, and returns it.
-    func openDocument<HREF: URLConvertible>(at href: HREF) async throws -> PDFDocument
+    func openDocument<HREF: URLConvertible & Sendable>(at href: HREF) async throws -> PDFDocument
 
     /// Returns the cached document if `href` matches, or `nil` otherwise.
-    func cachedDocument<HREF: URLConvertible>(at href: HREF) async -> PDFDocument?
+    func cachedDocument<HREF: URLConvertible & Sendable>(at href: HREF) async -> PDFDocument?
 
     /// Replaces the cached document. Use this to seed the cache (parser) or to override it with
     /// a different concrete type (navigator forcing PDFKit).
-    func setCachedDocument<HREF: URLConvertible>(_ document: PDFDocument?, at href: HREF) async
+    func setCachedDocument<HREF: URLConvertible & Sendable>(_ document: PDFDocument?, at href: HREF) async
 
     /// Clears all cached documents.
     func removeCachedDocuments() async
@@ -46,7 +46,7 @@ package actor DefaultPDFDocumentService: PDFDocumentService {
         }
     }
 
-    package func openDocument<HREF: URLConvertible>(at href: HREF) async throws -> PDFDocument {
+    package func openDocument<HREF: URLConvertible & Sendable>(at href: HREF) async throws -> PDFDocument {
         if let cached, let cachedHREF, cachedHREF.isEquivalentTo(href) {
             return cached
         }
@@ -61,14 +61,14 @@ package actor DefaultPDFDocumentService: PDFDocumentService {
         return document
     }
 
-    package func cachedDocument<HREF: URLConvertible>(at href: HREF) -> PDFDocument? {
+    package func cachedDocument<HREF: URLConvertible & Sendable>(at href: HREF) -> PDFDocument? {
         guard let cachedHREF, cachedHREF.isEquivalentTo(href) else {
             return nil
         }
         return cached
     }
 
-    package func setCachedDocument<HREF: URLConvertible>(_ document: PDFDocument?, at href: HREF) {
+    package func setCachedDocument<HREF: URLConvertible & Sendable>(_ document: PDFDocument?, at href: HREF) {
         cachedHREF = document != nil ? href.anyURL : nil
         cached = document
     }

--- a/Sources/Shared/Toolkit/PDF/PDFKit.swift
+++ b/Sources/Shared/Toolkit/PDF/PDFKit.swift
@@ -19,60 +19,6 @@ extension PDFKit.PDFDocument: PDFKitDocumentProviding {
     }
 }
 
-/// Extends PDFKit's `PDFDocument` with our shared `PDFDocument` protocol.
-///
-/// Unfortunately, PDFKit doesn't support streams, so we need to load the full document in memory.
-/// If this is an issue for you, use `CPDFDocumentFactory` instead.
-///
-/// Use `PDFKitPDFDocumentFactory` to create a `PDFDocument` from a `Resource`.
-/// Conforming system PDFKit.PDFDocument to Sendable requires @retroactive @unchecked Sendable.
-/// Apple's PDFDocument is thread-safe for the read-only operations performed by this toolkit,
-/// but it is not yet officially annotated as Sendable. The `@retroactive` attribute is used
-/// to silence warnings about conforming an imported type to a protocol.
-extension PDFKit.PDFDocument: @retroactive @unchecked Sendable, PDFDocument {
-    public func pageCount() async throws -> Int {
-        pageCount
-    }
-
-    public func identifier() async throws -> String? {
-        try await documentRef?.identifier()
-    }
-
-    public func cover() async throws -> UIImage? {
-        try await documentRef?.cover()
-    }
-
-    public func readingProgression() async throws -> ReadingProgression? {
-        try await documentRef?.readingProgression()
-    }
-
-    public func title() async throws -> String? {
-        try await documentRef?.title()
-    }
-
-    public func author() async throws -> String? {
-        try await documentRef?.author()
-    }
-
-    public func subject() async throws -> String? {
-        try await documentRef?.subject()
-    }
-
-    public func keywords() async throws -> [String] {
-        try await documentRef?.keywords() ?? []
-    }
-
-    public func tableOfContents() async throws -> [PDFOutlineNode] {
-        try await documentRef?.tableOfContents() ?? []
-    }
-}
-
-extension PDFKit.PDFDocument: PDFDocumentTextProviding {
-    public func pageText(at pageIndex: Int) async throws -> String? {
-        page(at: pageIndex)?.string
-    }
-}
-
 /// Creates a `PDFDocument` using PDFKit.
 public final class PDFKitPDFDocumentFactory: PDFDocumentFactory, Sendable {
     public init() {}
@@ -124,6 +70,70 @@ public final class PDFKitPDFDocumentFactory: PDFDocumentFactory, Sendable {
             }
         }
 
-        return document
+        return PDFKitPDFDocument(document)
+    }
+}
+
+/// Wraps a PDFKit `PDFDocument` to expose it through the toolkit's
+/// `PDFDocument` protocol.
+///
+/// Use `PDFKitPDFDocumentFactory` to create a `PDFKitPDFDocument` from a
+/// `Resource`.
+///
+/// ## Concurrency
+///
+/// `PDFKit.PDFDocument` is a reference type with mutable internal state and is
+/// not annotated as `Sendable` by Apple. Rather than retroactively asserting
+/// `@unchecked Sendable` on the system type – which would leak that unsound
+/// claim to *every* `PDFKit.PDFDocument` in the app – we confine the assertion
+/// to this wrapper. The toolkit only performs read-only operations on the
+/// document, and a given instance must not be mutated (e.g. by adding
+/// `PDFAnnotation`s) while it is shared across threads.
+// FIXME: Note that we share this instance with the PDF navigator through the `PDFDocumentService`. For now this is safe as we only perform read-only operations on the document. But this might change when we start adding `PDFAnnotation`, for example. We might need to revisit this implementation and have a PDFDocument dedicated to the navigator.
+private final class PDFKitPDFDocument: PDFDocument, PDFDocumentTextProviding, PDFKitDocumentProviding, @unchecked Sendable {
+    let pdfKitDocument: PDFKit.PDFDocument
+
+    init(_ document: PDFKit.PDFDocument) {
+        pdfKitDocument = document
+    }
+
+    func pageCount() async throws -> Int {
+        pdfKitDocument.pageCount
+    }
+
+    func identifier() async throws -> String? {
+        try await pdfKitDocument.documentRef?.identifier()
+    }
+
+    func cover() async throws -> UIImage? {
+        try await pdfKitDocument.documentRef?.cover()
+    }
+
+    func readingProgression() async throws -> ReadingProgression? {
+        try await pdfKitDocument.documentRef?.readingProgression()
+    }
+
+    func title() async throws -> String? {
+        try await pdfKitDocument.documentRef?.title()
+    }
+
+    func author() async throws -> String? {
+        try await pdfKitDocument.documentRef?.author()
+    }
+
+    func subject() async throws -> String? {
+        try await pdfKitDocument.documentRef?.subject()
+    }
+
+    func keywords() async throws -> [String] {
+        try await pdfKitDocument.documentRef?.keywords() ?? []
+    }
+
+    func tableOfContents() async throws -> [PDFOutlineNode] {
+        try await pdfKitDocument.documentRef?.tableOfContents() ?? []
+    }
+
+    func pageText(at pageIndex: Int) async throws -> String? {
+        pdfKitDocument.page(at: pageIndex)?.string
     }
 }

--- a/Sources/Shared/Toolkit/PDF/PDFKit.swift
+++ b/Sources/Shared/Toolkit/PDF/PDFKit.swift
@@ -20,7 +20,7 @@ extension PDFKit.PDFDocument: PDFKitDocumentProviding {
 }
 
 /// Creates a `PDFDocument` using PDFKit.
-public final class PDFKitPDFDocumentFactory: PDFDocumentFactory, Sendable {
+public final class PDFKitPDFDocumentFactory: PDFDocumentFactory {
     public init() {}
 
     public func open(file: FileURL, password: String?) async throws -> PDFDocument {

--- a/Sources/Shared/Toolkit/PDF/PDFKit.swift
+++ b/Sources/Shared/Toolkit/PDF/PDFKit.swift
@@ -25,7 +25,11 @@ extension PDFKit.PDFDocument: PDFKitDocumentProviding {
 /// If this is an issue for you, use `CPDFDocumentFactory` instead.
 ///
 /// Use `PDFKitPDFDocumentFactory` to create a `PDFDocument` from a `Resource`.
-extension PDFKit.PDFDocument: PDFDocument {
+/// Conforming system PDFKit.PDFDocument to Sendable requires @retroactive @unchecked Sendable.
+/// Apple's PDFDocument is thread-safe for the read-only operations performed by this toolkit,
+/// but it is not yet officially annotated as Sendable. The `@retroactive` attribute is used
+/// to silence warnings about conforming an imported type to a protocol.
+extension PDFKit.PDFDocument: @retroactive @unchecked Sendable, PDFDocument {
     public func pageCount() async throws -> Int {
         pageCount
     }
@@ -81,7 +85,7 @@ public final class PDFKitPDFDocumentFactory: PDFDocumentFactory, Sendable {
         return try open(document: document, password: password)
     }
 
-    public func open<HREF: URLConvertible>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument {
+    public func open<HREF: URLConvertible & Sendable>(resource: Resource, at href: HREF, password: String?) async throws -> PDFDocument {
         // Fast-path in case the resource actually references a file on the
         // disk.
         if let file = resource.sourceURL?.fileURL {

--- a/Sources/Shared/Toolkit/ZIP/ZIPFoundation/ZIPFoundationArchiveFactory.swift
+++ b/Sources/Shared/Toolkit/ZIP/ZIPFoundation/ZIPFoundationArchiveFactory.swift
@@ -17,7 +17,7 @@ private let zipEOCDMaximumLength: UInt64 = 65557 + 76
 private let maximumZIPLengthToFullyCache = 5.MB
 
 /// Creates new ZIPFoundation ``Archive`` objects from a shared ``Resource``.
-final class ZIPFoundationArchiveFactory {
+final class ZIPFoundationArchiveFactory: Sendable {
     enum Source {
         case file(FileURL)
         case resource(Resource)

--- a/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
+++ b/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
@@ -82,7 +82,8 @@ final class EPUBDeobfuscator {
                                 if readPos + UInt64(i) >= obfuscatedLength {
                                     break
                                 }
-                                data[i] = data[i] ^ self.key[i % self.key.count]
+                                let keyIndex = Int((readPos + UInt64(i)) % UInt64(self.key.count))
+                                data[i] = data[i] ^ self.key[keyIndex]
                             }
                         }
 

--- a/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
+++ b/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
@@ -68,24 +68,26 @@ final class EPUBDeobfuscator {
         }
 
         func stream(range: Range<UInt64>?, consume: @escaping @Sendable (Data) -> Void) async -> ReadResult<Void> {
-            var readPosition = range?.lowerBound ?? 0
-            let obfuscatedLength = algorithm.obfuscatedLength
+            let readPosition = Mutex(range?.lowerBound ?? 0)
+            let obfuscatedLength = UInt64(algorithm.obfuscatedLength)
 
             return await resource.stream(
                 range: range,
                 consume: { data in
                     var data = data
 
-                    if readPosition < obfuscatedLength {
-                        for i in 0 ..< data.count {
-                            if readPosition + UInt64(i) >= obfuscatedLength {
-                                break
+                    readPosition.withLock { readPos in
+                        if readPos < obfuscatedLength {
+                            for i in 0 ..< data.count {
+                                if readPos + UInt64(i) >= obfuscatedLength {
+                                    break
+                                }
+                                data[i] = data[i] ^ self.key[i % self.key.count]
                             }
-                            data[i] = data[i] ^ self.key[i % self.key.count]
                         }
-                    }
 
-                    readPosition += UInt64(data.count)
+                        readPos += UInt64(data.count)
+                    }
 
                     consume(data)
                 }

--- a/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
+++ b/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
@@ -74,7 +74,10 @@ final class EPUBDeobfuscator {
             return await resource.stream(
                 range: range,
                 consume: { data in
-                    var data = data
+                    // The chunk may be a `Data` slice with non-zero start
+                    // indices (e.g. when streaming a sub-range), so we rebase
+                    // it to a zero-indexed buffer before mutating by position.
+                    var data = Data(data)
 
                     readPosition.withLock { readPos in
                         if readPos < obfuscatedLength {

--- a/TestApp/Sources/App/Readium.swift
+++ b/TestApp/Sources/App/Readium.swift
@@ -51,7 +51,7 @@ final class Readium {
         lazy var lcpAuthentication: LCPAuthenticating = LCPDialogAuthentication()
 
         /// Facade to the private R2LCPClient.framework.
-        class LCPClient: ReadiumLCP.LCPClient {
+        final class LCPClient: ReadiumLCP.LCPClient {
             func createContext(jsonLicense: String, hashedPassphrase: LCPPassphraseHash, pemCrl: String) throws -> LCPClientContext {
                 try R2LCPClient.createContext(jsonLicense: jsonLicense, hashedPassphrase: hashedPassphrase, pemCrl: pemCrl)
             }

--- a/Tests/SharedTests/ProxyContainer.swift
+++ b/Tests/SharedTests/ProxyContainer.swift
@@ -8,9 +8,9 @@ import Foundation
 import ReadiumShared
 
 final class ProxyContainer: Container {
-    private let retrieve: (AnyURL) -> Resource?
+    private let retrieve: @Sendable (AnyURL) -> (any Resource)?
 
-    init(entries: Set<AnyURL> = [], _ retrieve: @escaping (AnyURL) -> Resource?) {
+    init(entries: Set<AnyURL> = [], _ retrieve: @escaping @Sendable (AnyURL) -> (any Resource)?) {
         self.entries = Set(entries.map(\.normalized))
         self.retrieve = retrieve
     }

--- a/Tests/SharedTests/Publication/Services/Content Protection/ContentProtectionServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Content Protection/ContentProtectionServiceTests.swift
@@ -101,7 +101,7 @@ struct TestContentProtectionService: ContentProtectionService {
     }
 }
 
-final class TestUserRights: UserRights, Sendable {
+final class TestUserRights: UserRights {
     private let _copyCount: Mutex<Int>
     private let _printCount: Mutex<Int>
 

--- a/Tests/SharedTests/Publication/Services/Content Protection/ContentProtectionServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Content Protection/ContentProtectionServiceTests.swift
@@ -101,13 +101,21 @@ struct TestContentProtectionService: ContentProtectionService {
     }
 }
 
-final class TestUserRights: UserRights {
-    var copyCount: Int
-    var printCount: Int
+final class TestUserRights: UserRights, Sendable {
+    private let _copyCount: Mutex<Int>
+    private let _printCount: Mutex<Int>
+
+    var copyCount: Int {
+        _copyCount.withLock { $0 }
+    }
+
+    var printCount: Int {
+        _printCount.withLock { $0 }
+    }
 
     init(copyCount: Int = 10, printCount: Int = 10) {
-        self.copyCount = copyCount
-        self.printCount = printCount
+        _copyCount = Mutex(copyCount)
+        _printCount = Mutex(printCount)
     }
 
     var canCopy: Bool {
@@ -119,11 +127,13 @@ final class TestUserRights: UserRights {
     }
 
     func copy(text: String) -> Bool {
-        guard canCopy(text: text) else {
-            return false
+        _copyCount.withLock { count in
+            guard count >= text.count else {
+                return false
+            }
+            count -= text.count
+            return true
         }
-        copyCount -= text.count
-        return true
     }
 
     var canPrint: Bool {
@@ -135,10 +145,12 @@ final class TestUserRights: UserRights {
     }
 
     func print(pageCount: Int) -> Bool {
-        guard canPrint(pageCount: pageCount) else {
-            return false
+        _printCount.withLock { count in
+            guard count >= pageCount else {
+                return false
+            }
+            count -= pageCount
+            return true
         }
-        printCount -= pageCount
-        return true
     }
 }

--- a/Tests/SharedTests/Publication/Services/Content/Iterators/PDFResourceContentIteratorTests.swift
+++ b/Tests/SharedTests/Publication/Services/Content/Iterators/PDFResourceContentIteratorTests.swift
@@ -313,16 +313,19 @@ private func makeIterator(
 
 // MARK: - Mock PDF Documents
 
-private class MockPDFDocument: PDFDocumentTextProviding {
+private final class MockPDFDocument: PDFDocumentTextProviding, Sendable {
     private let texts: [String?]
-    private(set) var requestedPageIndices: [Int] = []
+    private let _requestedPageIndices = Mutex<[Int]>([])
+    var requestedPageIndices: [Int] {
+        _requestedPageIndices.withLock { $0 }
+    }
 
     init(texts: [String?]) {
         self.texts = texts
     }
 
     func resetTracking() {
-        requestedPageIndices = []
+        _requestedPageIndices.withLock { $0 = [] }
     }
 
     func identifier() async throws -> String? {
@@ -362,12 +365,12 @@ private class MockPDFDocument: PDFDocumentTextProviding {
     }
 
     func pageText(at pageIndex: Int) async throws -> String? {
-        requestedPageIndices.append(pageIndex)
+        _requestedPageIndices.withLock { $0.append(pageIndex) }
         return texts.getOrNil(pageIndex) ?? nil
     }
 }
 
-private class MockNonTextPDFDocument: PDFDocument {
+private final class MockNonTextPDFDocument: PDFDocument, Sendable {
     func identifier() async throws -> String? {
         nil
     }

--- a/Tests/SharedTests/Publication/Services/Content/Iterators/PDFResourceContentIteratorTests.swift
+++ b/Tests/SharedTests/Publication/Services/Content/Iterators/PDFResourceContentIteratorTests.swift
@@ -313,7 +313,7 @@ private func makeIterator(
 
 // MARK: - Mock PDF Documents
 
-private final class MockPDFDocument: PDFDocumentTextProviding, Sendable {
+private final class MockPDFDocument: PDFDocumentTextProviding {
     private let texts: [String?]
     private let _requestedPageIndices = Mutex<[Int]>([])
     var requestedPageIndices: [Int] {
@@ -370,7 +370,7 @@ private final class MockPDFDocument: PDFDocumentTextProviding, Sendable {
     }
 }
 
-private final class MockNonTextPDFDocument: PDFDocument, Sendable {
+private final class MockNonTextPDFDocument: PDFDocument {
     func identifier() async throws -> String? {
         nil
     }

--- a/Tests/SharedTests/Toolkit/HTTP/HTTPResourceTests.swift
+++ b/Tests/SharedTests/Toolkit/HTTP/HTTPResourceTests.swift
@@ -11,25 +11,33 @@ import Testing
 struct HTTPResourceTests {
     private let url = HTTPURL(string: "http://example.com/book.epub")!
 
-    class MockHTTPClient: HTTPClient {
-        struct Response {
+    final class MockHTTPClient: HTTPClient, Sendable {
+        struct Response: Sendable {
             let response: HTTPResponse
             let body: Data
         }
 
-        var fetchResults: [String: HTTPResult<Response>] = [:]
-        var fetchCount = 0
+        private let _fetchResults = Mutex<[String: HTTPResult<Response>]>([:])
+        var fetchResults: [String: HTTPResult<Response>] {
+            get { _fetchResults.withLock { $0 } }
+            set { _fetchResults.withLock { $0 = newValue } }
+        }
+
+        private let _fetchCount = Mutex<Int>(0)
+        var fetchCount: Int {
+            _fetchCount.withLock { $0 }
+        }
 
         func stream(
-            _ request: HTTPRequestConvertible,
+            _ request: any HTTPRequestConvertible,
             onReceiveResponse: (@Sendable (HTTPResponse) async -> HTTPResult<Void>)?,
             consume: @Sendable (Data, Double?) -> HTTPResult<Void>
         ) async -> HTTPResult<HTTPResponse> {
             let req = try! request.httpRequest().get()
             let key = "\(req.method.rawValue) \(req.url.string)"
-            fetchCount += 1
+            _fetchCount.withLock { $0 += 1 }
 
-            if let result = fetchResults[key] {
+            if let result = _fetchResults.withLock({ $0[key] }) {
                 switch result {
                 case let .success(response):
                     if let onReceiveResponse = onReceiveResponse {

--- a/Tests/SharedTests/Toolkit/HTTP/HTTPResourceTests.swift
+++ b/Tests/SharedTests/Toolkit/HTTP/HTTPResourceTests.swift
@@ -11,7 +11,7 @@ import Testing
 struct HTTPResourceTests {
     private let url = HTTPURL(string: "http://example.com/book.epub")!
 
-    final class MockHTTPClient: HTTPClient, Sendable {
+    final class MockHTTPClient: HTTPClient {
         struct Response: Sendable {
             let response: HTTPResponse
             let body: Data

--- a/Tests/StreamerTests/Parser/EPUB/Resource Transformers/EPUBDeobfuscatorTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/Resource Transformers/EPUBDeobfuscatorTests.swift
@@ -19,14 +19,47 @@ class EPUBDeobfuscatorTests: XCTestCase {
 
     func testDeobfuscateIDPF() async throws {
         let sut = try sut(resourcePath: "cut-cut.obf.woff", algorithm: "http://www.idpf.org/2008/embedding")
-        let result = await sut.deobfuscate()
+        let result = await sut.deobfuscate(nil)
         XCTAssertEqual(result, .success(font))
     }
 
     func testDeobfuscateAdobe() async throws {
         let sut = try sut(resourcePath: "cut-cut.adb.woff", algorithm: "http://ns.adobe.com/pdf/enc#RC")
-        let result = await sut.deobfuscate()
+        let result = await sut.deobfuscate(nil)
         XCTAssertEqual(result, .success(font))
+    }
+
+    /// Reading a sub-range starting inside the obfuscated region must produce
+    /// the same bytes as the matching range of the clear-text resource.
+    ///
+    /// Regression test: the key index must be derived from the absolute
+    /// position in the resource, not from the offset within the streamed
+    /// chunk. We start at a position that is not aligned on the key length so
+    /// a chunk-local index would yield a different (wrong) key byte.
+    func testDeobfuscateRangeWithinObfuscatedRegion() async throws {
+        let range: Range<UInt64> = 105 ..< 400
+
+        for (path, algorithm) in [
+            ("cut-cut.obf.woff", "http://www.idpf.org/2008/embedding"),
+            ("cut-cut.adb.woff", "http://ns.adobe.com/pdf/enc#RC"),
+        ] {
+            let sut = try sut(resourcePath: path, algorithm: algorithm)
+            let result = await sut.deobfuscate(range)
+            let expected = Data(font[Int(range.lowerBound) ..< Int(range.upperBound)])
+            XCTAssertEqual(result, .success(expected), "algorithm: \(algorithm)")
+        }
+    }
+
+    /// Reading a range that spans the boundary of the obfuscated region must
+    /// deobfuscate only the bytes within the region and leave the rest intact.
+    func testDeobfuscateRangeAcrossObfuscatedBoundary() async throws {
+        // IDPF obfuscates the first 1040 bytes.
+        let range: Range<UInt64> = 1000 ..< 1100
+
+        let sut = try sut(resourcePath: "cut-cut.obf.woff", algorithm: "http://www.idpf.org/2008/embedding")
+        let result = await sut.deobfuscate(range)
+        let expected = Data(font[Int(range.lowerBound) ..< Int(range.upperBound)])
+        XCTAssertEqual(result, .success(expected))
     }
 
     /// Fix for https://github.com/readium/r2-streamer-swift/issues/208
@@ -34,11 +67,11 @@ class EPUBDeobfuscatorTests: XCTestCase {
         let file = fixtures.data(at: "nav.xhtml")
 
         var sut = try sut(publicationID: "urn:uuid:", resourcePath: "nav.xhtml", algorithm: "http://www.idpf.org/2008/embedding")
-        var result = await sut.deobfuscate()
+        var result = await sut.deobfuscate(nil)
         XCTAssertEqual(result, .success(file))
 
         sut = try self.sut(publicationID: "", resourcePath: "nav.xhtml", algorithm: "http://www.idpf.org/2008/embedding")
-        result = await sut.deobfuscate()
+        result = await sut.deobfuscate(nil)
         XCTAssertEqual(result, .success(file))
     }
 
@@ -47,7 +80,7 @@ class EPUBDeobfuscatorTests: XCTestCase {
         resourcePath path: String,
         algorithm: String
     ) throws -> (
-        deobfuscate: () async -> ReadResult<Data>,
+        deobfuscate: (Range<UInt64>?) async -> ReadResult<Data>,
         resource: DataResource,
         encryptions: [RelativeURL: Encryption]
     ) {
@@ -60,8 +93,8 @@ class EPUBDeobfuscatorTests: XCTestCase {
             encryptions: encryptions
         )
         return (
-            deobfuscate: {
-                await deobfuscator.deobfuscate(resource: resource, at: url.anyURL).read()
+            deobfuscate: { range in
+                await deobfuscator.deobfuscate(resource: resource, at: url.anyURL).read(range: range)
             },
             resource: resource,
             encryptions: [url: Encryption(algorithm: algorithm)]

--- a/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
@@ -348,7 +348,7 @@ private func makeProperties(layout: EPUBLayout? = nil, originalLength: Int? = ni
     return Properties(props)
 }
 
-private class MockContainer: Container {
+private final class MockContainer: Container, Sendable {
     private let readingOrder: [(UInt64, Link, ArchiveProperties?)]
 
     init(readingOrder: [(UInt64, Link, ArchiveProperties?)]) {

--- a/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
@@ -348,7 +348,7 @@ private func makeProperties(layout: EPUBLayout? = nil, originalLength: Int? = ni
     return Properties(props)
 }
 
-private final class MockContainer: Container, Sendable {
+private final class MockContainer: Container {
     private let readingOrder: [(UInt64, Link, ArchiveProperties?)]
 
     init(readingOrder: [(UInt64, Link, ArchiveProperties?)]) {


### PR DESCRIPTION
1. Silences warnings for system-owned types (`PDFKit.PDFDocument` and `CGPDFDocument`) using `@retroactive @unchecked Sendable`.
2. Constrains `HREF` generic parameters across PDF service APIs to `URLConvertible & Sendable`.
3. Refactors the `License` class to conform to `Sendable` by wrapping parts in a `Mutex` and utilizing weak closures.
4. Uses `Mutex` synchronization for mutable state in stream processing (like `EPUBDeobfuscator.readPosition`).
5. Isolates `LCPDefaultRenewDelegate` to `@MainActor` and uses `@preconcurrency` to bridge non-`Sendable` system protocols (`SFSafariViewControllerDelegate`).

### Public API Breaking Changes

1. `Container`, `HTTPClient`, `PDFDocument`, `PDFDocumentFactory`, `PDFDocumentService`, `LCPClient`, `LCPLicenseRepository`, `LCPRenewDelegate`, and `UserRights` all now conform to `Sendable`.
2. `LCPClientContext` typealias changed from `Any` to `Any & Sendable`.
3. `HREF` generic parameters in `PDFDocumentFactory.open(resource:at:password:)` and `PDFDocumentService` open methods now require `URLConvertible & Sendable`.
4. `ResourceTransformer` in `TransformingContainer` now requires `@Sendable`.
5. `LCPDefaultRenewDelegate` is now isolated to `@MainActor`.
6. `ProxyContainer` initializer closure parameters now require `@Sendable`.

Relates to #758.