### PR TITLE
Fix EPUB footnotes not being detected when tapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * ZIP entry names stored with a leading slash (e.g. `/001.jpg`, found in some CBZ comics) are now normalized to relative paths. Previously such entries resolved as absolute-path references against the base URL, causing them to fail.
 
+#### Navigator
+
+* Fixed EPUB footnotes never being detected when tapped, which prevented `EPUBNavigatorDelegate.navigator(_:shouldNavigateToNoteAt:content:referrer:)` from being called and made footnote references navigate to the note's location instead of being handled by the host. The note resource is now read through the publication's asynchronous resource API rather than a synchronous `String(contentsOf:)`, which could not read the `readium://` scheme the navigator serves resources on.
+
 
 ## [3.9.0] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 #### Navigator
 
-* Fixed EPUB footnotes never being detected when tapped, which prevented `EPUBNavigatorDelegate.navigator(_:shouldNavigateToNoteAt:content:referrer:)` from being called and made footnote references navigate to the note's location instead of being handled by the host. The note resource is now read through the publication's asynchronous resource API rather than a synchronous `String(contentsOf:)`, which could not read the `readium://` scheme the navigator serves resources on.
+* Fixed EPUB footnotes never being detected when tapped, which prevented `EPUBNavigatorDelegate.navigator(_:shouldNavigateToNoteAt:content:referrer:)` from being called and made footnote references navigate to the note's location instead of being handled by the host (contributed by [@raphi011](https://github.com/readium/swift-toolkit/pull/821)).
 
 
 ## [3.9.0] - 2026-05-12

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -1119,9 +1119,7 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
 
         Task {
             // Check to see if this was a noteref link and give delegate the
-            // opportunity to display it. Reading the note resource is async
-            // (it goes through the publication's `readium://` scheme), so the
-            // whole tap-handling flow runs in this task.
+            // opportunity to display it.
             if
                 let clickEvent = clickEvent,
                 let interactive = clickEvent.interactiveElement,
@@ -1164,39 +1162,24 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
             let anchorHref = try link.attr("href")
             guard href.hasSuffix(anchorHref) else { return nil }
 
-            let hashParts = href.split(separator: "#")
-            guard hashParts.count == 2 else {
+            guard
+                let url = AnyURL(string: href),
+                let id = url.fragment
+            else {
                 log(.warning, "Could not find hash in link \(href)")
                 return nil
             }
-            let id = String(hashParts[1])
-            var withoutFragment = String(hashParts[0])
-            if withoutFragment.hasPrefix("/") {
-                withoutFragment = String(withoutFragment.dropFirst())
-            }
 
             // Read the note's resource through the publication's resource API.
-            // A synchronous `String(contentsOf:)` cannot read the `readium://`
-            // scheme the navigator serves resources on (it is handled only by
-            // the in-WebView URL scheme handler), so the legacy path threw and
-            // every footnote silently fell through to plain link navigation.
-            guard
-                let resourceURL = AnyURL(string: withoutFragment),
-                let resourceLink = publication.linkWithHREF(resourceURL),
-                let resource = publication.get(resourceLink)
-            else {
-                log(.warning, "Could not open note resource: \(withoutFragment)")
+            guard let resource = publication.get(url.removingFragment()) else {
+                log(.warning, "Could not open note resource: \(href)")
                 return nil
             }
-            let data = try await resource.read().get()
-            guard let contents = String(data: data, encoding: .utf8) else {
-                log(.warning, "Note resource is not valid UTF-8: \(withoutFragment)")
-                return nil
-            }
+            let contents = try await resource.read().asString().get()
             let document = try parse(contents)
 
             guard let aside = try document.select("#\(id)").first() else {
-                log(.warning, "Could not find the element '#\(id)' in document \(withoutFragment)")
+                log(.warning, "Could not find the element '#\(id)' in document \(href)")
                 return nil
             }
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -1117,29 +1117,32 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
         }
         link.href = href
 
-        // Check to see if this was a noteref link and give delegate the opportunity to display it.
-        if
-            let clickEvent = clickEvent,
-            let interactive = clickEvent.interactiveElement,
-            let (note, referrer) = getNoteData(anchor: interactive, href: href),
-            let delegate = delegate
-        {
-            if !delegate.navigator(
-                self,
-                shouldNavigateToNoteAt: link,
-                content: note,
-                referrer: referrer
-            ) {
+        Task {
+            // Check to see if this was a noteref link and give delegate the
+            // opportunity to display it. Reading the note resource is async
+            // (it goes through the publication's `readium://` scheme), so the
+            // whole tap-handling flow runs in this task.
+            if
+                let clickEvent = clickEvent,
+                let interactive = clickEvent.interactiveElement,
+                let (note, referrer) = await getNoteData(anchor: interactive, href: href),
+                let delegate = delegate
+            {
+                if !delegate.navigator(
+                    self,
+                    shouldNavigateToNoteAt: link,
+                    content: note,
+                    referrer: referrer
+                ) {
+                    return
+                }
+            }
+
+            // Ask if we should navigate to the link
+            if let delegate = delegate, !delegate.navigator(self, shouldNavigateToLink: link) {
                 return
             }
-        }
 
-        // Ask if we should navigate to the link
-        if let delegate = delegate, !delegate.navigator(self, shouldNavigateToLink: link) {
-            return
-        }
-
-        Task {
             await go(to: link)
         }
     }
@@ -1153,7 +1156,7 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
     /// Uses `#id` when retrieving the body of the note, not `aside#id` because it may be a `<section>`.
     /// See https://idpf.github.io/epub-vocabs/structure/#footnotes
     /// and http://kb.daisy.org/publishing/docs/html/epub-type.html#ex
-    func getNoteData(anchor: String, href: String) -> (String, String)? {
+    func getNoteData(anchor: String, href: String) async -> (String, String)? {
         do {
             let doc = try parse(anchor)
             guard let link = try doc.select("a[epub:type=noteref]").first() else { return nil }
@@ -1172,20 +1175,28 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
                 withoutFragment = String(withoutFragment.dropFirst())
             }
 
+            // Read the note's resource through the publication's resource API.
+            // A synchronous `String(contentsOf:)` cannot read the `readium://`
+            // scheme the navigator serves resources on (it is handled only by
+            // the in-WebView URL scheme handler), so the legacy path threw and
+            // every footnote silently fell through to plain link navigation.
             guard
-                let url = RelativeURL(string: withoutFragment),
-                let absolute = viewModel.publicationBaseURL.resolve(url)
+                let resourceURL = AnyURL(string: withoutFragment),
+                let resourceLink = publication.linkWithHREF(resourceURL),
+                let resource = publication.get(resourceLink)
             else {
-                log(.warning, "Invalid URL: \(withoutFragment)")
+                log(.warning, "Could not open note resource: \(withoutFragment)")
                 return nil
             }
-
-            log(.debug, "Fetching note contents from \(absolute.string)")
-            let contents = try String(contentsOf: absolute.url)
+            let data = try await resource.read().get()
+            guard let contents = String(data: data, encoding: .utf8) else {
+                log(.warning, "Note resource is not valid UTF-8: \(withoutFragment)")
+                return nil
+            }
             let document = try parse(contents)
 
             guard let aside = try document.select("#\(id)").first() else {
-                log(.warning, "Could not find the element '#\(id)' in document \(absolute)")
+                log(.warning, "Could not find the element '#\(id)' in document \(withoutFragment)")
                 return nil
             }
 


### PR DESCRIPTION
## Summary

EPUB footnote taps were never recognized as footnotes, so `EPUBNavigatorDelegate.navigator(_:shouldNavigateToNoteAt:content:referrer:)` was never called and every footnote reference fell through to ordinary link navigation (jumping to the note's location) instead of giving the host app a chance to present it inline.

## Cause

`getNoteData(anchor:href:)` read the tapped note's resource synchronously with `String(contentsOf:)`:

```swift
let contents = try String(contentsOf: absolute.url)
```

The navigator serves publication resources over the `readium://` URL scheme, which is handled only by the in-`WKWebView` URL scheme handler — `String(contentsOf:)` cannot read it. The read therefore always threw, `getNoteData` returned `nil`, and `shouldNavigateToNoteAt` was never invoked.

## Fix

Read the note resource through the publication's own resource API instead, and make the tap-handling path `async`:

```swift
guard
    let resourceURL = AnyURL(string: withoutFragment),
    let resourceLink = publication.linkWithHREF(resourceURL),
    let resource = publication.get(resourceLink)
else { … }
let data = try await resource.read().get()
```

`getNoteData` becomes `async`; the noteref-detection + delegate flow in `spreadView(_:didTapAt:…)` now runs inside the existing `Task`. No public API signature changes.

## Testing

Verified in a downstream app (iOS 17+) shipping this patch: tapping an `epub:type="noteref"` link now invokes `shouldNavigateToNoteAt` with the note's content, and the host can present the footnote inline; returning `false` suppresses navigation as documented. Non-noteref links are unaffected.

## Notes

- Swift-only — no JavaScript bundle changes, so no `make scripts` needed.
- `make format` reports no changes.
- CHANGELOG updated under `## [Unreleased] → Fixed → Navigator`.
