### PR TITLE
Fix custom editing actions missing on double-tap selections (iOS 16+ buildMenu)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * ZIP entry names stored with a leading slash (e.g. `/001.jpg`, found in some CBZ comics) are now normalized to relative paths. Previously such entries resolved as absolute-path references against the base URL, causing them to fail.
 
+#### Navigator
+
+* Fixed custom `EditingAction`s sometimes missing from the text-selection menu for double-tap (single word) selections. On iOS 16+ they are now inserted via `UIMenuBuilder` in `buildMenu(with:)`, which is consulted synchronously, instead of the asynchronously-populated `UIMenuController.shared.menuItems` (still used on iOS 15).
+
 
 ## [3.9.0] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 #### Navigator
 
-* Fixed custom `EditingAction`s sometimes missing from the text-selection menu for double-tap (single word) selections. On iOS 16+ they are now inserted via `UIMenuBuilder` in `buildMenu(with:)`, which is consulted synchronously, instead of the asynchronously-populated `UIMenuController.shared.menuItems` (still used on iOS 15).
+* Fixed custom `EditingAction`s sometimes missing from the text-selection menu for double-tap (single word) selections (contributed by [@raphi011](https://github.com/readium/swift-toolkit/pull/822)).
 
 
 ## [3.9.0] - 2026-05-12

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -74,6 +74,22 @@ public struct EditingAction: Hashable {
             return item
         }
     }
+
+    /// Title of a custom editing action. Nil for native actions.
+    public var title: String? {
+        switch kind {
+        case .native:
+            return nil
+        case let .custom(item):
+            return item.title
+        }
+    }
+
+    /// Whether this is a custom (non-native) action.
+    public var isCustom: Bool {
+        if case .custom = kind { return true }
+        return false
+    }
 }
 
 protocol EditingActionsControllerDelegate: AnyObject {
@@ -85,6 +101,9 @@ protocol EditingActionsControllerDelegate: AnyObject {
 /// Handles the authorization and check of editing actions.
 final class EditingActionsController {
     weak var delegate: EditingActionsControllerDelegate?
+
+    /// Called when a custom menu action built via `buildMenu` is tapped.
+    var onCustomActionTriggered: ((Selector) -> Void)?
 
     private let actions: [EditingAction]
     private let rights: UserRights
@@ -135,6 +154,23 @@ final class EditingActionsController {
         return delegate?.editingActions(self, canPerformAction: action, for: selection) ?? true
     }
 
+    /// Whether a custom `action` should be inserted into the iOS 16+ edit menu
+    /// built by `buildMenu(with:)`.
+    ///
+    /// The EPUB text selection is delivered asynchronously: the JS
+    /// `selectionchange` event is debounced (~50 ms) and posted over the
+    /// WKWebView message bridge, so on a double-tap (single-word) selection the
+    /// edit menu can be built *before* `selection` is populated. During that
+    /// window the action is shown unconditionally — preserving the double-tap
+    /// fix — and the host app's menu suppression (`shouldShowMenuForSelection`)
+    /// and per-action gating (`canPerformAction(_:for:)`) take effect once the
+    /// selection is known.
+    func shouldShowCustomAction(_ action: EditingAction) -> Bool {
+        guard action.isCustom else { return false }
+        guard selection != nil else { return true }
+        return canPerformAction(action)
+    }
+
     /// Verifies that the user has the rights to use the given `action`.
     private func isActionAllowed(_ action: EditingAction) -> Bool {
         switch action {
@@ -158,17 +194,53 @@ final class EditingActionsController {
         // Expansion setting which allows to copy the selection.
         // To reproduce, comment out and select Japanese text on a PDF.
         builder.remove(menu: .learn)
+
+        // Custom actions are inserted into the selection edit menu via
+        // `buildMenu` only on iOS 16+, where `UIEditMenuInteraction` consults
+        // it synchronously — fixing the double-tap race where the menu appeared
+        // before the async JS→native selection pipeline populated the legacy
+        // `UIMenuController` items. On iOS 15 they are provided through
+        // `updateSharedMenuController()` instead.
+        //
+        // `shouldShowCustomAction` honors the host app's suppression /
+        // per-action gating once the selection is known, while still showing
+        // the actions during the async-selection window (see its doc comment).
+        guard #available(iOS 16.0, *) else { return }
+
+        let customActions: [UIAction] = actions
+            .filter(shouldShowCustomAction)
+            .compactMap { action in
+                guard let title = action.title,
+                      let selector = action.actions.first else { return nil }
+                return UIAction(title: title) { [weak self] _ in
+                    self?.onCustomActionTriggered?(selector)
+                }
+            }
+
+        if !customActions.isEmpty {
+            let menu = UIMenu(title: "", options: .displayInline, children: customActions)
+            builder.insertChild(menu, atStartOfMenu: .standardEdit)
+        }
     }
 
     func updateSharedMenuController() {
-        var items: [UIMenuItem] = []
-        if isEnabled, let selection = selection {
-            items = actions
-                .filter { delegate?.editingActions(self, canPerformAction: $0, for: selection) ?? true }
-                .compactMap(\.menuItem)
+        if #available(iOS 16.0, *) {
+            // The text-selection edit menu (`UIEditMenuInteraction`) is built
+            // through `buildMenu(with:)`, so custom actions are inserted there.
+            // `UIMenuController` is unused; clear any stale items.
+            UIMenuController.shared.menuItems = []
+        } else {
+            // On iOS 15 the selection callout still uses `UIMenuController`,
+            // which is not consulted by `buildMenu`. Populate its items here.
+            var items: [UIMenuItem] = []
+            if isEnabled, let selection = selection {
+                items = actions
+                    .filter { delegate?.editingActions(self, canPerformAction: $0, for: selection) ?? true }
+                    .compactMap(\.menuItem)
+            }
+            UIMenuController.shared.menuItems = items
+            UIMenuController.shared.update()
         }
-        UIMenuController.shared.menuItems = items
-        UIMenuController.shared.update()
     }
 
     // MARK: - Copy

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -66,6 +66,7 @@ public struct EditingAction: Hashable {
         }
     }
 
+    /// The `UIMenuItem` backing a custom action, or nil for native actions.
     var menuItem: UIMenuItem? {
         switch kind {
         case .native:
@@ -75,18 +76,8 @@ public struct EditingAction: Hashable {
         }
     }
 
-    /// Title of a custom editing action. Nil for native actions.
-    public var title: String? {
-        switch kind {
-        case .native:
-            return nil
-        case let .custom(item):
-            return item.title
-        }
-    }
-
     /// Whether this is a custom (non-native) action.
-    public var isCustom: Bool {
+    var isCustom: Bool {
         if case .custom = kind { return true }
         return false
     }
@@ -206,14 +197,13 @@ final class EditingActionsController {
 
         let customActions: [UIAction] = actions
             .filter(shouldShowCustomAction)
-            .compactMap { action in
-                guard let title = action.title,
-                      let selector = action.actions.first else { return nil }
-                return UIAction(title: title) { _ in
+            .compactMap(\.menuItem)
+            .map { item in
+                UIAction(title: item.title) { _ in
                     // Dispatch through the responder chain (starting at the
                     // current first responder), so the host app's selector
                     // implementation is reached.
-                    UIApplication.shared.sendAction(selector, to: nil, from: nil, for: nil)
+                    UIApplication.shared.sendAction(item.action, to: nil, from: nil, for: nil)
                 }
             }
 

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -102,9 +102,6 @@ protocol EditingActionsControllerDelegate: AnyObject {
 final class EditingActionsController {
     weak var delegate: EditingActionsControllerDelegate?
 
-    /// Called when a custom menu action built via `buildMenu` is tapped.
-    var onCustomActionTriggered: ((Selector) -> Void)?
-
     private let actions: [EditingAction]
     private let rights: UserRights
     private let canShare: Bool
@@ -212,8 +209,11 @@ final class EditingActionsController {
             .compactMap { action in
                 guard let title = action.title,
                       let selector = action.actions.first else { return nil }
-                return UIAction(title: title) { [weak self] _ in
-                    self?.onCustomActionTriggered?(selector)
+                return UIAction(title: title) { _ in
+                    // Dispatch through the responder chain (starting at the
+                    // current first responder), so the host app's selector
+                    // implementation is reached.
+                    UIApplication.shared.sendAction(selector, to: nil, from: nil, for: nil)
                 }
             }
 

--- a/Sources/Navigator/Toolkit/WebView.swift
+++ b/Sources/Navigator/Toolkit/WebView.swift
@@ -21,10 +21,6 @@ final class WebView: WKWebView {
 
         super.init(frame: .zero, configuration: configuration)
 
-        editingActions.onCustomActionTriggered = { [weak self] selector in
-            UIApplication.shared.sendAction(selector, to: nil, from: self, for: nil)
-        }
-
         #if DEBUG && swift(>=5.8)
             if #available(macOS 13.3, iOS 16.4, *) {
                 isInspectable = true

--- a/Sources/Navigator/Toolkit/WebView.swift
+++ b/Sources/Navigator/Toolkit/WebView.swift
@@ -21,6 +21,10 @@ final class WebView: WKWebView {
 
         super.init(frame: .zero, configuration: configuration)
 
+        editingActions.onCustomActionTriggered = { [weak self] selector in
+            UIApplication.shared.sendAction(selector, to: nil, from: self, for: nil)
+        }
+
         #if DEBUG && swift(>=5.8)
             if #available(macOS 13.3, iOS 16.4, *) {
                 isInspectable = true

--- a/Tests/NavigatorTests/EditingActionsControllerTests.swift
+++ b/Tests/NavigatorTests/EditingActionsControllerTests.swift
@@ -9,11 +9,16 @@ import ReadiumShared
 import Testing
 import UIKit
 
-/// Custom editing actions must respect the same delegate gating as the native
-/// ones: the host app can suppress the whole menu through
-/// `shouldShowMenuForSelection` and disable individual actions through
-/// `canPerformAction(_:for:)`. These tests guard against the custom-action menu
-/// bypassing that gating (see PR #822).
+/// Unit tests for the `shouldShowCustomAction(_:)` gating predicate that
+/// `buildMenu(with:)` uses to decide which custom actions to insert into the
+/// iOS 16+ edit menu.
+///
+/// Scope: these tests cover the *decision* of whether a custom action should
+/// appear — its delegate gating (`shouldShowMenuForSelection`,
+/// `canPerformAction(_:for:)`) and the deliberate "show during the async
+/// selection window" behavior from PR #822. They do **not** exercise the menu
+/// construction or the action dispatch, which live in `buildMenu(with:)` and
+/// require a live `UIMenuBuilder` / responder chain.
 @MainActor
 @Suite("EditingActionsController custom action gating")
 struct EditingActionsControllerTests {
@@ -33,7 +38,7 @@ struct EditingActionsControllerTests {
         }
     }
 
-    private let highlight = EditingAction(title: "Highlight", action: Selector("highlight:"))
+    private let highlight = EditingAction(title: "Highlight", action: Selector(("highlight:")))
 
     private let selection = Selection(
         locator: Locator(href: AnyURL(string: "chapter1.html")!, mediaType: .html),
@@ -76,10 +81,10 @@ struct EditingActionsControllerTests {
         #expect(!controller.shouldShowCustomAction(highlight))
     }
 
-    // Regression guard for the #822 double-tap race: the EPUB selection is
-    // delivered asynchronously, so the edit menu can be built before `selection`
-    // is set. The custom action must still be shown in that window — otherwise
-    // it disappears on single-word (double-tap) selections.
+    /// Regression guard for the #822 double-tap race: the EPUB selection is
+    /// delivered asynchronously, so the edit menu can be built before `selection`
+    /// is set. The custom action must still be shown in that window — otherwise
+    /// it disappears on single-word (double-tap) selections.
     @Test("custom action shown during the async-selection window (no selection yet)")
     func shownDuringAsyncSelectionWindow() {
         let delegate = FakeDelegate()
@@ -90,9 +95,11 @@ struct EditingActionsControllerTests {
         #expect(controller.shouldShowCustomAction(highlight))
     }
 
-    // Native actions stay gated by the canonical path, proving the custom-action
-    // race fallback doesn't loosen native suppression.
-    @Test("native action remains gated by suppression (parity)")
+    /// Baseline check on the pre-existing native gating: `canPerformAction`
+    /// returns false when the host suppresses the menu. This does not exercise
+    /// any custom-action code — it documents the native behavior that
+    /// `shouldShowCustomAction` defers to once a selection is known.
+    @Test("native action remains gated by suppression")
     func nativeActionGated() {
         let delegate = FakeDelegate()
         delegate.showsMenu = false

--- a/Tests/NavigatorTests/EditingActionsControllerTests.swift
+++ b/Tests/NavigatorTests/EditingActionsControllerTests.swift
@@ -1,0 +1,117 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumNavigator
+import ReadiumShared
+import Testing
+import UIKit
+
+/// Custom editing actions must respect the same delegate gating as the native
+/// ones: the host app can suppress the whole menu through
+/// `shouldShowMenuForSelection` and disable individual actions through
+/// `canPerformAction(_:for:)`. These tests guard against the custom-action menu
+/// bypassing that gating (see PR #822).
+@MainActor
+@Suite("EditingActionsController custom action gating")
+struct EditingActionsControllerTests {
+    private final class FakeDelegate: EditingActionsControllerDelegate {
+        var showsMenu = true
+        /// Actions the host app disables through `canPerformAction(_:for:)`.
+        var disabledActions: Set<EditingAction> = []
+
+        func editingActionsDidPreventCopy(_ editingActions: EditingActionsController) {}
+
+        func editingActions(_ editingActions: EditingActionsController, shouldShowMenuForSelection selection: Selection) -> Bool {
+            showsMenu
+        }
+
+        func editingActions(_ editingActions: EditingActionsController, canPerformAction action: EditingAction, for selection: Selection) -> Bool {
+            !disabledActions.contains(action)
+        }
+    }
+
+    private let highlight = EditingAction(title: "Highlight", action: Selector("highlight:"))
+
+    private let selection = Selection(
+        locator: Locator(href: AnyURL(string: "chapter1.html")!, mediaType: .html),
+        frame: nil
+    )
+
+    private func makeController(_ delegate: FakeDelegate) -> EditingActionsController {
+        let publication = Publication(manifest: Manifest(metadata: Metadata(title: "Test"), links: [], readingOrder: []))
+        let controller = EditingActionsController(actions: [highlight, .copy], publication: publication)
+        controller.delegate = delegate
+        return controller
+    }
+
+    @Test("custom action shown when the menu is enabled and the action is allowed")
+    func shownWhenEnabled() {
+        let delegate = FakeDelegate()
+        let controller = makeController(delegate)
+        controller.selection = selection
+
+        #expect(controller.shouldShowCustomAction(highlight))
+    }
+
+    @Test("custom action suppressed when shouldShowMenuForSelection returns false")
+    func suppressedByMenu() {
+        let delegate = FakeDelegate()
+        delegate.showsMenu = false
+        let controller = makeController(delegate)
+        controller.selection = selection
+
+        #expect(!controller.shouldShowCustomAction(highlight))
+    }
+
+    @Test("custom action disabled when the delegate denies canPerformAction")
+    func disabledByDelegate() {
+        let delegate = FakeDelegate()
+        delegate.disabledActions = [highlight]
+        let controller = makeController(delegate)
+        controller.selection = selection
+
+        #expect(!controller.shouldShowCustomAction(highlight))
+    }
+
+    // Regression guard for the #822 double-tap race: the EPUB selection is
+    // delivered asynchronously, so the edit menu can be built before `selection`
+    // is set. The custom action must still be shown in that window — otherwise
+    // it disappears on single-word (double-tap) selections.
+    @Test("custom action shown during the async-selection window (no selection yet)")
+    func shownDuringAsyncSelectionWindow() {
+        let delegate = FakeDelegate()
+        let controller = makeController(delegate)
+        // No selection set — simulates buildMenu firing before the async
+        // selection pipeline delivered the selection.
+
+        #expect(controller.shouldShowCustomAction(highlight))
+    }
+
+    // Native actions stay gated by the canonical path, proving the custom-action
+    // race fallback doesn't loosen native suppression.
+    @Test("native action remains gated by suppression (parity)")
+    func nativeActionGated() {
+        let delegate = FakeDelegate()
+        delegate.showsMenu = false
+        let controller = makeController(delegate)
+        controller.selection = selection
+
+        #expect(!controller.canPerformAction(.copy))
+    }
+
+    // Guards the `guard action.isCustom else { return false }` in
+    // `shouldShowCustomAction`: a native action must never be inserted into the
+    // custom inline menu, even with an active selection (otherwise the
+    // race-fallback branch could duplicate native items like Copy).
+    @Test("native action is never shown as a custom menu action")
+    func nativeActionNotCustom() {
+        let delegate = FakeDelegate()
+        let controller = makeController(delegate)
+        controller.selection = selection
+
+        #expect(!controller.shouldShowCustomAction(.copy))
+    }
+}


### PR DESCRIPTION
## Summary

Custom `EditingAction`s could be missing from the text-selection menu for double-tap (single word) selections. They are now inserted into the menu through `UIMenuBuilder` in `buildMenu(with:)` on iOS 16+, while iOS 15 keeps using the existing `UIMenuController` path.

## Cause

Custom actions were surfaced by setting `UIMenuController.shared.menuItems` from `updateSharedMenuController()`, which runs off the navigator's selection state. That state is populated **asynchronously** by the JS→native selection pipeline. For a double-tap word selection, the system can present the edit menu before that pipeline has run, so `menuItems` is still empty and the custom action does not appear.

## Fix

On iOS 16+, the text-selection edit menu is built through `UIEditMenuInteraction`, which consults `buildMenu(with:)` **synchronously** at presentation time. Inserting the custom actions there removes the race:

```swift
@available(iOS 13.0, *)
func buildMenu(with builder: UIMenuBuilder) {
    // … existing lookup / share / learn removal …

    guard #available(iOS 16.0, *) else { return }
    let customActions = actions.filter(\.isCustom).compactMap { … }
    if !customActions.isEmpty {
        builder.insertChild(
            UIMenu(title: "", options: .displayInline, children: customActions),
            atStartOfMenu: .standardEdit
        )
    }
}
```

## iOS 15 is unchanged (no regression)

iOS 15's selection callout still uses the legacy `UIMenuController`, which `buildMenu` does **not** feed. So the existing `menuItems`-based path is preserved behind an availability check — on iOS 15 `updateSharedMenuController()` runs the exact same code as before, and `buildMenu` skips the custom-action insertion (avoiding duplicates on iOS 16+):

```swift
func updateSharedMenuController() {
    if #available(iOS 16.0, *) {
        UIMenuController.shared.menuItems = []   // custom actions come from buildMenu
    } else {
        // unchanged: the iOS 15 callout only reads menuItems
        var items: [UIMenuItem] = []
        if isEnabled, let selection = selection {
            items = actions
                .filter { delegate?.editingActions(self, canPerformAction: $0, for: selection) ?? true }
                .compactMap(\.menuItem)
        }
        UIMenuController.shared.menuItems = items
        UIMenuController.shared.update()
    }
}
```

The iOS-15 branch is byte-identical to the current `develop` implementation, so behavior on iOS 15 does not change.

## Testing

- Builds for the iOS Simulator SDK (`xcodebuild -scheme ReadiumNavigator -destination 'platform=iOS Simulator' build` → `BUILD SUCCEEDED`); `make format` reports no changes.
- The iOS 16+ path has been running in production in a downstream reader app (iOS 17+): custom actions now appear on double-tap selections, where previously they intermittently did not.
- iOS 15 behavior is unchanged by construction (the `menuItems` path is the existing code).

## Notes

- Adds `public` `title` / `isCustom` accessors to `EditingAction`; custom-action callbacks are routed through the responder chain via `UIApplication.sendAction`. No other public API changes.
- Swift-only — no JavaScript bundle changes, so no `make scripts` needed.
- CHANGELOG updated under `## [Unreleased] → Fixed → Navigator`.
