### PR TITLE
Add LCP passphrase without a license ID or provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. Take a look
 
 ## [Unreleased]
 
+### Changed
+
+#### LCP
+
+* `LCPPassphraseRepository.addPassphrase(_:userID:provider:)` no longer takes a license ID, and `provider` is now optional. A convenience `addPassphrase(_:)` overload is available for storing a passphrase without any associated user or provider.
+
 ### Fixed
 
 #### Shared
@@ -13,6 +19,10 @@ All notable changes to this project will be documented in this file. Take a look
 #### Navigator
 
 * Fixed EPUB footnotes never being detected when tapped, which prevented `EPUBNavigatorDelegate.navigator(_:shouldNavigateToNoteAt:content:referrer:)` from being called and made footnote references navigate to the note's location instead of being handled by the host (contributed by [@raphi011](https://github.com/readium/swift-toolkit/pull/821)).
+
+#### LCP
+
+* [#818](https://github.com/readium/swift-toolkit/issues/818) Repository failures during passphrase lookup (e.g. Keychain access errors) now fall through gracefully to the interactive authentication flow instead of propagating the error.
 
 
 ## [3.9.0] - 2026-05-12

--- a/Sources/Adapters/LCPSQLite/SQLiteLCPPassphraseRepository.swift
+++ b/Sources/Adapters/LCPSQLite/SQLiteLCPPassphraseRepository.swift
@@ -30,15 +30,6 @@ public class LCPSQLitePassphraseRepository: LCPPassphraseRepository, Loggable {
         })
     }
 
-    public func passphrase(for licenseID: LicenseDocument.ID) async throws -> LCPPassphraseHash? {
-        try logAndRethrow {
-            try db.prepare(transactions.select(passphrase)
-                .filter(self.licenseId == licenseID))
-                .compactMap { try $0.get(passphrase) }
-                .first
-        }
-    }
-
     public func passphrasesMatching(userID: User.ID?, provider: LicenseDocument.Provider) async throws -> [LCPPassphraseHash] {
         try logAndRethrow {
             try db.prepare(transactions.select(passphrase)
@@ -54,14 +45,18 @@ public class LCPSQLitePassphraseRepository: LCPPassphraseRepository, Loggable {
         }
     }
 
-    public func addPassphrase(_ hash: LCPPassphraseHash, for licenseID: LicenseDocument.ID, userID: User.ID?, provider: LicenseDocument.Provider) async throws {
+    public func addPassphrase(_ hash: LCPPassphraseHash, userID: User.ID?, provider: LicenseDocument.Provider?) async throws {
         try logAndRethrow {
+            // The legacy schema requires a non-null `licenseId` and `origin`.
+            // The repository no longer tracks a license, and `licenseId` is no
+            // longer read back, so we store a synthetic identifier. The table
+            // has no unique constraint, so this appends a row like before.
             try db.run(
                 transactions.insert(
                     or: .replace,
                     self.passphrase <- hash,
-                    self.licenseId <- licenseID,
-                    self.provider <- provider,
+                    self.licenseId <- UUID().uuidString,
+                    self.provider <- (provider ?? ""),
                     self.userId <- userID
                 )
             )
@@ -90,7 +85,6 @@ public class LCPSQLitePassphraseRepository: LCPPassphraseRepository, Loggable {
             do {
                 try await target.addPassphrase(
                     passphraseData.passphrase,
-                    for: passphraseData.licenseId,
                     userID: passphraseData.userId,
                     provider: passphraseData.provider
                 )

--- a/Sources/LCP/LCPPassphraseRepository.swift
+++ b/Sources/LCP/LCPPassphraseRepository.swift
@@ -9,33 +9,38 @@ import Foundation
 /// Represents an LCP passphrase hash.
 public typealias LCPPassphraseHash = String
 
-/// The passphrase repository stores passphrase hashes associated to a license
-/// document, user ID and provider.
+/// The passphrase repository stores passphrase hashes, optionally associated
+/// with a user ID and provider.
 public protocol LCPPassphraseRepository {
-    /// Returns the passphrase hash associated with the given `licenseID`.
-    func passphrase(for licenseID: LicenseDocument.ID) async throws -> LCPPassphraseHash?
-
     /// Returns a list of passphrase hashes that may match the given `userID`
     /// and `provider`.
-    func passphrasesMatching(userID: User.ID?, provider: LicenseDocument.Provider) async throws -> [LCPPassphraseHash]
+    func passphrasesMatching(
+        userID: User.ID?,
+        provider: LicenseDocument.Provider
+    ) async throws -> [LCPPassphraseHash]
 
     /// Returns all the saved passphrase hashes.
     func passphrases() async throws -> [LCPPassphraseHash]
 
     /// Adds a new passphrase hash to the repository.
     ///
-    /// If a passphrase is already associated with the given `licenseID`, it
-    /// will be updated.
+    /// If the same passphrase hash is already stored, its `userID` and
+    /// `provider` are updated.
     func addPassphrase(
         _ hash: LCPPassphraseHash,
-        for licenseID: LicenseDocument.ID,
         userID: User.ID?,
-        provider: LicenseDocument.Provider
+        provider: LicenseDocument.Provider?
     ) async throws
 }
 
 public extension LCPPassphraseRepository {
+    /// Adds the passphrase `hash` associated with the given `license`.
     func addPassphrase(_ hash: LCPPassphraseHash, for license: LicenseDocument) async throws {
-        try await addPassphrase(hash, for: license.id, userID: license.user.id, provider: license.provider)
+        try await addPassphrase(hash, userID: license.user.id, provider: license.provider)
+    }
+
+    /// Adds a passphrase `hash` without any associated user or provider.
+    func addPassphrase(_ hash: LCPPassphraseHash) async throws {
+        try await addPassphrase(hash, userID: nil, provider: nil)
     }
 }

--- a/Sources/LCP/License/License.swift
+++ b/Sources/LCP/License/License.swift
@@ -80,8 +80,10 @@ extension License: LCPLicense {
         do {
             return try await licenses.userRights(for: license.id).copy
         } catch {
+            // If the rights cannot be read (e.g. repository failure), we
+            // restrict the right rather than granting unlimited copy.
             log(.error, error)
-            return nil
+            return 0
         }
     }
 
@@ -125,8 +127,10 @@ extension License: LCPLicense {
         do {
             return try await licenses.userRights(for: license.id).print
         } catch {
+            // If the rights cannot be read (e.g. repository failure), we
+            // restrict the right rather than granting unlimited printing.
             log(.error, error)
-            return nil
+            return 0
         }
     }
 

--- a/Sources/LCP/Repositories/Keychain/LCPKeychainPassphraseRepository.swift
+++ b/Sources/LCP/Repositories/Keychain/LCPKeychainPassphraseRepository.swift
@@ -23,17 +23,16 @@ public enum LCPKeychainPassphraseRepositoryError: Error {
 public actor LCPKeychainPassphraseRepository: LCPPassphraseRepository, Loggable {
     /// Internal data structure for storing passphrase information in the
     /// Keychain.
+    ///
+    /// Items are keyed in the Keychain by their ``passphraseHash``.
     private struct Passphrase: Codable {
-        /// Unique identifier for the license this passphrase belongs to.
-        let licenseID: LicenseDocument.ID
-
-        /// The hashed passphrase.
+        /// The hashed passphrase. Used as the Keychain account key.
         var passphraseHash: LCPPassphraseHash
 
-        /// The license provider.
-        var provider: LicenseDocument.Provider
+        /// The license provider, if known.
+        var provider: LicenseDocument.Provider?
 
-        /// The user identifier.
+        /// The user identifier, if known.
         var userID: User.ID?
 
         /// Date this passphrase was added to the Keychain.
@@ -66,10 +65,6 @@ public actor LCPKeychainPassphraseRepository: LCPPassphraseRepository, Loggable 
 
     // MARK: - LCPPassphraseRepository
 
-    public func passphrase(for licenseID: LicenseDocument.ID) async throws -> LCPPassphraseHash? {
-        try getPassphrase(for: licenseID)?.passphraseHash
-    }
-
     public func passphrasesMatching(
         userID: User.ID?,
         provider: LicenseDocument.Provider
@@ -88,18 +83,15 @@ public actor LCPKeychainPassphraseRepository: LCPPassphraseRepository, Loggable 
 
     public func addPassphrase(
         _ hash: LCPPassphraseHash,
-        for licenseID: LicenseDocument.ID,
         userID: User.ID?,
-        provider: LicenseDocument.Provider
+        provider: LicenseDocument.Provider?
     ) async throws {
-        if var passphrase = try getPassphrase(for: licenseID) {
-            passphrase.passphraseHash = hash
+        if var passphrase = try getPassphrase(forHash: hash) {
             passphrase.provider = provider
             passphrase.userID = userID
-            try updatePassphrase(passphrase, for: licenseID)
+            try updatePassphrase(passphrase, for: hash)
         } else {
             let passphrase = Passphrase(
-                licenseID: licenseID,
                 passphraseHash: hash,
                 provider: provider,
                 userID: userID,
@@ -107,7 +99,7 @@ public actor LCPKeychainPassphraseRepository: LCPPassphraseRepository, Loggable 
                 updated: Date()
             )
 
-            try addPassphrase(passphrase, for: licenseID)
+            try addPassphrase(passphrase, for: hash)
         }
     }
 
@@ -132,9 +124,9 @@ public actor LCPKeychainPassphraseRepository: LCPPassphraseRepository, Loggable 
             }
     }
 
-    /// Gets a passphrase from the Keychain for the given license ID.
-    private func getPassphrase(for licenseID: LicenseDocument.ID) throws(LCPKeychainPassphraseRepositoryError) -> Passphrase? {
-        guard let data = try getFromKeychain(id: licenseID) else {
+    /// Gets a passphrase from the Keychain for the given passphrase hash.
+    private func getPassphrase(forHash hash: LCPPassphraseHash) throws(LCPKeychainPassphraseRepositoryError) -> Passphrase? {
+        guard let data = try getFromKeychain(key: hash) else {
             return nil
         }
 
@@ -142,23 +134,23 @@ public actor LCPKeychainPassphraseRepository: LCPPassphraseRepository, Loggable 
     }
 
     /// Adds a new passphrase to the Keychain.
-    private func addPassphrase(_ passphrase: Passphrase, for id: LicenseDocument.ID) throws(LCPKeychainPassphraseRepositoryError) {
-        try addToKeychain(data: encode(passphrase), for: id)
+    private func addPassphrase(_ passphrase: Passphrase, for hash: LCPPassphraseHash) throws(LCPKeychainPassphraseRepositoryError) {
+        try addToKeychain(data: encode(passphrase), for: hash)
     }
 
     /// Updates an existing passphrase in the Keychain.
-    private func updatePassphrase(_ passphrase: Passphrase, for id: LicenseDocument.ID) throws(LCPKeychainPassphraseRepositoryError) {
+    private func updatePassphrase(_ passphrase: Passphrase, for hash: LCPPassphraseHash) throws(LCPKeychainPassphraseRepositoryError) {
         var passphrase = passphrase
         passphrase.updated = Date()
         let data = try encode(passphrase)
-        try updateKeychain(data: data, for: id)
+        try updateKeychain(data: data, for: hash)
     }
 
     // MARK: - Low-Level Helpers
 
-    private func getFromKeychain(id: LicenseDocument.ID) throws(LCPKeychainPassphraseRepositoryError) -> Data? {
+    private func getFromKeychain(hash: LCPPassphraseHash) throws(LCPKeychainPassphraseRepositoryError) -> Data? {
         do {
-            return try keychain.load(forKey: id)
+            return try keychain.load(forKey: hash)
         } catch {
             throw .keychain(error)
         }
@@ -172,17 +164,17 @@ public actor LCPKeychainPassphraseRepository: LCPPassphraseRepository, Loggable 
         }
     }
 
-    private func addToKeychain(data: Data, for id: LicenseDocument.ID) throws(LCPKeychainPassphraseRepositoryError) {
+    private func addToKeychain(data: Data, for hash: LCPPassphraseHash) throws(LCPKeychainPassphraseRepositoryError) {
         do {
-            try keychain.save(data: data, forKey: id)
+            try keychain.save(data: data, forKey: hash)
         } catch {
             throw .keychain(error)
         }
     }
 
-    private func updateKeychain(data: Data, for id: LicenseDocument.ID) throws(LCPKeychainPassphraseRepositoryError) {
+    private func updateKeychain(data: Data, for hash: LCPPassphraseHash) throws(LCPKeychainPassphraseRepositoryError) {
         do {
-            try keychain.update(data: data, forKey: id)
+            try keychain.update(data: data, forKey: hash)
         } catch {
             throw .keychain(error)
         }

--- a/Sources/LCP/Repositories/Keychain/LCPKeychainPassphraseRepository.swift
+++ b/Sources/LCP/Repositories/Keychain/LCPKeychainPassphraseRepository.swift
@@ -126,7 +126,7 @@ public actor LCPKeychainPassphraseRepository: LCPPassphraseRepository, Loggable 
 
     /// Gets a passphrase from the Keychain for the given passphrase hash.
     private func getPassphrase(forHash hash: LCPPassphraseHash) throws(LCPKeychainPassphraseRepositoryError) -> Passphrase? {
-        guard let data = try getFromKeychain(key: hash) else {
+        guard let data = try getFromKeychain(hash: hash) else {
             return nil
         }
 

--- a/Sources/LCP/Services/PassphrasesService.swift
+++ b/Sources/LCP/Services/PassphrasesService.swift
@@ -30,18 +30,11 @@ final class PassphrasesService: Loggable {
         allowUserInteraction: Bool,
         sender: Any?
     ) async throws -> LCPPassphraseHash? {
-        // Look for an existing passphrase associated with this license.
+        // Look for a stored passphrase matching this license.
         //
         // Reading from the repository is best-effort: a keychain lookup failure
         // must not prevent the user from manually entering their passphrase.
-        if
-            let candidate = try? await repository.passphrase(for: license.id),
-            let passphrase = findValidPassphrase(in: [candidate], for: license)
-        {
-            return passphrase
-        }
-
-        var passphrase = await findAlternatePassphrase(for: license)
+        var passphrase = await findPassphrase(for: license)
 
         // Fallback on the provided `LCPAuthenticating` implementation.
         if passphrase == nil, let authentication = authentication {
@@ -66,12 +59,12 @@ final class PassphrasesService: Loggable {
         return passphrase
     }
 
-    /// Looks for alternate stored passphrases matching the given license.
+    /// Looks for a stored passphrase matching the given license.
     ///
     /// This is best-effort: any repository (e.g. keychain) failure is logged
     /// and treated as "no passphrase found", so that the interactive
     /// authentication fallback can still run.
-    private func findAlternatePassphrase(for license: LicenseDocument) async -> LCPPassphraseHash? {
+    private func findPassphrase(for license: LicenseDocument) async -> LCPPassphraseHash? {
         do {
             // Look for alternative candidates based on the provider and user ID.
             let candidates = try await repository.passphrasesMatching(

--- a/Sources/LCP/Services/PassphrasesService.swift
+++ b/Sources/LCP/Services/PassphrasesService.swift
@@ -9,7 +9,7 @@ import Foundation
 import ReadiumInternal
 import ReadiumShared
 
-final class PassphrasesService {
+final class PassphrasesService: Loggable {
     private let client: LCPClient
     private let repository: LCPPassphraseRepository
 
@@ -31,14 +31,17 @@ final class PassphrasesService {
         sender: Any?
     ) async throws -> LCPPassphraseHash? {
         // Look for an existing passphrase associated with this license.
+        //
+        // Reading from the repository is best-effort: a keychain lookup failure
+        // must not prevent the user from manually entering their passphrase.
         if
-            let candidate = try await repository.passphrase(for: license.id),
+            let candidate = try? await repository.passphrase(for: license.id),
             let passphrase = findValidPassphrase(in: [candidate], for: license)
         {
             return passphrase
         }
 
-        var passphrase = try await findAlternatePassphrase(for: license)
+        var passphrase = await findAlternatePassphrase(for: license)
 
         // Fallback on the provided `LCPAuthenticating` implementation.
         if passphrase == nil, let authentication = authentication {
@@ -52,27 +55,41 @@ final class PassphrasesService {
         }
 
         if let passphrase = passphrase {
-            // Saves the passphrase to open the publication right away next time
-            try await repository.addPassphrase(passphrase, for: license)
+            // Saves the passphrase to open the publication right away next time.
+            do {
+                try await repository.addPassphrase(passphrase, for: license)
+            } catch {
+                log(.error, "Failed to save the LCP passphrase to the repository: \(error)")
+            }
         }
 
         return passphrase
     }
 
-    private func findAlternatePassphrase(for license: LicenseDocument) async throws -> LCPPassphraseHash? {
-        // Look for alternative candidates based on the provider and user ID.
-        let candidates = try await repository.passphrasesMatching(
-            userID: license.user.id,
-            provider: license.provider
-        )
-        if let passphrase = findValidPassphrase(in: candidates, for: license) {
-            return passphrase
-        }
+    /// Looks for alternate stored passphrases matching the given license.
+    ///
+    /// This is best-effort: any repository (e.g. keychain) failure is logged
+    /// and treated as "no passphrase found", so that the interactive
+    /// authentication fallback can still run.
+    private func findAlternatePassphrase(for license: LicenseDocument) async -> LCPPassphraseHash? {
+        do {
+            // Look for alternative candidates based on the provider and user ID.
+            let candidates = try await repository.passphrasesMatching(
+                userID: license.user.id,
+                provider: license.provider
+            )
+            if let passphrase = findValidPassphrase(in: candidates, for: license) {
+                return passphrase
+            }
 
-        // The legacy SQLite database did not save all the new (passphrase,
-        // userID, provider) tuples. So we need to fall back on checking all the
-        // saved passphrases for a match.
-        return try await findValidPassphrase(in: repository.passphrases(), for: license)
+            // The legacy SQLite database did not save all the new (passphrase,
+            // userID, provider) tuples. So we need to fall back on checking all
+            // the saved passphrases for a match.
+            return try await findValidPassphrase(in: repository.passphrases(), for: license)
+        } catch {
+            log(.error, "Failed to look up alternate LCP passphrases in the repository: \(error)")
+            return nil
+        }
     }
 
     private func findValidPassphrase(in hashes: [LCPPassphraseHash], for license: LicenseDocument) -> LCPPassphraseHash? {

--- a/Sources/Shared/Toolkit/Keychain.swift
+++ b/Sources/Shared/Toolkit/Keychain.swift
@@ -119,11 +119,7 @@ package final class Keychain: Sendable {
 
     /// Deletes all items for this service from the Keychain.
     package func deleteAll() throws(KeychainError) {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: serviceName,
-            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
-        ]
+        let query = serviceQuery()
         let status = SecItemDelete(query as CFDictionary)
 
         guard status == errSecSuccess || status == errSecItemNotFound else {
@@ -135,13 +131,9 @@ package final class Keychain: Sendable {
     ///
     /// - Returns: An array of account identifiers.
     package func allKeys() throws(KeychainError) -> [String] {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: serviceName,
-            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
-            kSecReturnAttributes as String: true,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-        ]
+        var query = serviceQuery()
+        query[kSecReturnAttributes as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitAll
 
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
@@ -166,14 +158,10 @@ package final class Keychain: Sendable {
     /// - Returns: A dictionary where keys are account identifiers and values are
     ///   the stored data.
     package func allItems() throws(KeychainError) -> [String: Data] {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: serviceName,
-            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
-            kSecReturnAttributes as String: true,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-        ]
+        var query = serviceQuery()
+        query[kSecReturnAttributes as String] = true
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitAll
 
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
@@ -205,29 +193,32 @@ package final class Keychain: Sendable {
     // MARK: - Private Helpers
 
     /// Creates the base query dictionary for Keychain operations.
-    ///
-    /// - Parameters:
-    ///   - key: The account identifier.
-    ///   - forAdding: If `true`, uses the boolean `synchronizable` value for adding items.
-    ///     If `false`, uses `kSecAttrSynchronizableAny` for queries/updates/deletes.
     private func baseQuery(forKey key: String, forAdding: Bool) -> [String: Any] {
-        var query: [String: Any] = [
+        var query = serviceQuery()
+        query[kSecAttrAccount as String] = key
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+
+        // When adding, pin the item to the requested sync setting. Queries,
+        // updates and deletes keep the `kSecAttrSynchronizableAny` default so
+        // they match items regardless of sync status.
+        if forAdding {
+            query[kSecAttrSynchronizable as String] = synchronizable
+        }
+
+        return query
+    }
+
+    /// The attributes identifying this service's items, shared by every
+    /// Keychain operation.
+    private func serviceQuery() -> [String: Any] {
+        [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: serviceName,
-            kSecAttrAccount as String: key,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
             // Explicitly use the data protection keychain so behavior is
             // consistent across iOS and macOS.
             kSecUseDataProtectionKeychain as String: true,
         ]
-
-        if forAdding {
-            query[kSecAttrSynchronizable as String] = synchronizable
-        } else {
-            query[kSecAttrSynchronizable as String] = kSecAttrSynchronizableAny
-        }
-
-        return query
     }
 
     /// Maps OSStatus error codes to KeychainError cases.

--- a/Sources/Shared/Toolkit/Keychain.swift
+++ b/Sources/Shared/Toolkit/Keychain.swift
@@ -216,6 +216,9 @@ package final class Keychain: Sendable {
             kSecAttrService as String: serviceName,
             kSecAttrAccount as String: key,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            // Explicitly use the data protection keychain so behavior is
+            // consistent across iOS and macOS.
+            kSecUseDataProtectionKeychain as String: true,
         ]
 
         if forAdding {

--- a/Tests/LCPTests/Repositories/InMemoryLCPPassphraseRepository.swift
+++ b/Tests/LCPTests/Repositories/InMemoryLCPPassphraseRepository.swift
@@ -9,35 +9,29 @@ import Foundation
 
 class InMemoryLCPPassphraseRepository: LCPPassphraseRepository {
     private struct Entry {
-        var hash: LCPPassphraseHash
         var userID: User.ID?
-        var provider: LicenseDocument.Provider
+        var provider: LicenseDocument.Provider?
     }
 
-    private var entries: [LicenseDocument.ID: Entry] = [:]
-
-    func passphrase(for licenseID: LicenseDocument.ID) async throws -> LCPPassphraseHash? {
-        entries[licenseID]?.hash
-    }
+    private var entries: [LCPPassphraseHash: Entry] = [:]
 
     func passphrasesMatching(userID: User.ID?, provider: LicenseDocument.Provider) async throws -> [LCPPassphraseHash] {
-        entries.values.compactMap { entry in
+        entries.compactMap { hash, entry in
             guard entry.provider == provider else { return nil }
-            if let userID { return entry.userID == userID ? entry.hash : nil }
-            return entry.hash
+            if let userID { return entry.userID == userID ? hash : nil }
+            return hash
         }
     }
 
     func passphrases() async throws -> [LCPPassphraseHash] {
-        entries.values.map(\.hash)
+        Array(entries.keys)
     }
 
     func addPassphrase(
         _ hash: LCPPassphraseHash,
-        for licenseID: LicenseDocument.ID,
         userID: User.ID?,
-        provider: LicenseDocument.Provider
+        provider: LicenseDocument.Provider?
     ) async throws {
-        entries[licenseID] = Entry(hash: hash, userID: userID, provider: provider)
+        entries[hash] = Entry(userID: userID, provider: provider)
     }
 }

--- a/Tests/LCPTests/Repositories/Keychain/LCPKeychainPassphraseRepositoryTests.swift
+++ b/Tests/LCPTests/Repositories/Keychain/LCPKeychainPassphraseRepositoryTests.swift
@@ -12,6 +12,8 @@ import Testing
 struct LCPKeychainPassphraseRepositoryTests {
     let repository: LCPKeychainPassphraseRepository
 
+    private static let serviceName = "org.readium.lcp.passphrases"
+
     init() throws {
         repository = LCPKeychainPassphraseRepository(
             synchronizable: false
@@ -22,11 +24,34 @@ struct LCPKeychainPassphraseRepositoryTests {
 
     private func cleanupAllTestData() throws {
         // Delete all test passphrases by using the Keychain directly
-        let keychain = Keychain(
-            serviceName: "org.readium.lcp.passphrases",
-            synchronizable: false
-        )
-        try keychain.deleteAll()
+        try keychain().deleteAll()
+    }
+
+    private func keychain() -> Keychain {
+        Keychain(serviceName: Self.serviceName, synchronizable: false)
+    }
+
+    /// Writes a legacy-format passphrase blob keyed by `licenseID`, mimicking
+    /// data stored by a previous version of the repository.
+    private func writeLegacyPassphrase(
+        licenseID: String,
+        hash: LCPPassphraseHash,
+        userID: String?,
+        provider: String
+    ) throws {
+        let date = ISO8601DateFormatter().string(from: Date())
+        var blob: [String: Any] = [
+            "licenseID": licenseID,
+            "passphraseHash": hash,
+            "provider": provider,
+            "created": date,
+            "updated": date,
+        ]
+        if let userID {
+            blob["userID"] = userID
+        }
+        let data = try JSONSerialization.data(withJSONObject: blob)
+        try keychain().save(data: data, forKey: licenseID)
     }
 
     // MARK: - AddPassphrase Tests
@@ -36,36 +61,44 @@ struct LCPKeychainPassphraseRepositoryTests {
 
         try await repository.addPassphrase(
             "hash123",
-            for: "license-1",
             userID: "user-1",
             provider: "https://provider.com"
         )
 
-        let retrieved = try await repository.passphrase(for: "license-1")
-        #expect(retrieved == "hash123")
+        let all = try await repository.passphrases()
+        #expect(all == ["hash123"])
     }
 
-    @Test func addPassphraseUpsert() async throws {
+    @Test func addPassphraseUpdatesMetadataInPlace() async throws {
         defer { try? cleanupAllTestData() }
 
-        // Add initial passphrase
+        // Add the same hash twice, with different metadata.
         try await repository.addPassphrase(
-            "hash-old",
-            for: "license-2",
+            "hash",
             userID: "user-1",
-            provider: "https://provider.com"
+            provider: "https://provider1.com"
+        )
+        try await repository.addPassphrase(
+            "hash",
+            userID: "user-2",
+            provider: "https://provider2.com"
         )
 
-        // Update with new passphrase
-        try await repository.addPassphrase(
-            "hash-new",
-            for: "license-2",
-            userID: "user-1",
-            provider: "https://provider.com"
-        )
+        // A single entry is kept, with the updated metadata.
+        let all = try await repository.passphrases()
+        #expect(all == ["hash"])
 
-        let retrieved = try await repository.passphrase(for: "license-2")
-        #expect(retrieved == "hash-new")
+        let oldMatches = try await repository.passphrasesMatching(
+            userID: "user-1",
+            provider: "https://provider1.com"
+        )
+        #expect(oldMatches.isEmpty)
+
+        let newMatches = try await repository.passphrasesMatching(
+            userID: "user-2",
+            provider: "https://provider2.com"
+        )
+        #expect(newMatches == ["hash"])
     }
 
     @Test func addPassphraseWithNilUserID() async throws {
@@ -73,36 +106,33 @@ struct LCPKeychainPassphraseRepositoryTests {
 
         try await repository.addPassphrase(
             "hash-no-user",
-            for: "license-3",
             userID: nil,
             provider: "https://provider.com"
         )
 
-        let retrieved = try await repository.passphrase(for: "license-3")
-        #expect(retrieved == "hash-no-user")
-    }
-
-    // MARK: - Passphrase Retrieval Tests
-
-    @Test func passphraseForLicense() async throws {
-        defer { try? cleanupAllTestData() }
-
-        try await repository.addPassphrase(
-            "hash-retrieve",
-            for: "license-retrieve",
-            userID: "user-1",
+        let matches = try await repository.passphrasesMatching(
+            userID: nil,
             provider: "https://provider.com"
         )
-
-        let passphrase = try await repository.passphrase(for: "license-retrieve")
-        #expect(passphrase == "hash-retrieve")
+        #expect(matches == ["hash-no-user"])
     }
 
-    @Test func passphraseForNonExistentLicense() async throws {
+    @Test func addPassphraseWithNilProviderAndUser() async throws {
         defer { try? cleanupAllTestData() }
 
-        let passphrase = try await repository.passphrase(for: "non-existent-license")
-        #expect(passphrase == nil)
+        // A passphrase can be stored without any license or provider.
+        try await repository.addPassphrase("loose-hash")
+
+        // It is returned by `passphrases()`...
+        let all = try await repository.passphrases()
+        #expect(all == ["loose-hash"])
+
+        // ...but not matched by a specific-provider query.
+        let matches = try await repository.passphrasesMatching(
+            userID: nil,
+            provider: "https://provider.com"
+        )
+        #expect(matches.isEmpty)
     }
 
     // MARK: - PassphrasesMatching Tests
@@ -110,33 +140,11 @@ struct LCPKeychainPassphraseRepositoryTests {
     @Test func passphrasesMatchingByProviderAndUserID() async throws {
         defer { try? cleanupAllTestData() }
 
-        // Add passphrases with different providers and user IDs
-        try await repository.addPassphrase(
-            "hash-1",
-            for: "license-1",
-            userID: "user-1",
-            provider: "https://provider1.com"
-        )
-        try await repository.addPassphrase(
-            "hash-2",
-            for: "license-2",
-            userID: "user-1",
-            provider: "https://provider1.com"
-        )
-        try await repository.addPassphrase(
-            "hash-3",
-            for: "license-3",
-            userID: "user-2",
-            provider: "https://provider1.com"
-        )
-        try await repository.addPassphrase(
-            "hash-4",
-            for: "license-4",
-            userID: "user-1",
-            provider: "https://provider2.com"
-        )
+        try await repository.addPassphrase("hash-1", userID: "user-1", provider: "https://provider1.com")
+        try await repository.addPassphrase("hash-2", userID: "user-1", provider: "https://provider1.com")
+        try await repository.addPassphrase("hash-3", userID: "user-2", provider: "https://provider1.com")
+        try await repository.addPassphrase("hash-4", userID: "user-1", provider: "https://provider2.com")
 
-        // Search for passphrases with provider1 and user-1
         let matches = try await repository.passphrasesMatching(
             userID: "user-1",
             provider: "https://provider1.com"
@@ -148,24 +156,9 @@ struct LCPKeychainPassphraseRepositoryTests {
     @Test func passphrasesMatchingByProviderOnly() async throws {
         defer { try? cleanupAllTestData() }
 
-        try await repository.addPassphrase(
-            "hash-1",
-            for: "license-1",
-            userID: "user-1",
-            provider: "https://provider.com"
-        )
-        try await repository.addPassphrase(
-            "hash-2",
-            for: "license-2",
-            userID: "user-2",
-            provider: "https://provider.com"
-        )
-        try await repository.addPassphrase(
-            "hash-3",
-            for: "license-3",
-            userID: "user-3",
-            provider: "https://other-provider.com"
-        )
+        try await repository.addPassphrase("hash-1", userID: "user-1", provider: "https://provider.com")
+        try await repository.addPassphrase("hash-2", userID: "user-2", provider: "https://provider.com")
+        try await repository.addPassphrase("hash-3", userID: "user-3", provider: "https://other-provider.com")
 
         // Search with nil userID should match all for the provider
         let matches = try await repository.passphrasesMatching(
@@ -179,12 +172,7 @@ struct LCPKeychainPassphraseRepositoryTests {
     @Test func passphrasesMatchingNoMatches() async throws {
         defer { try? cleanupAllTestData() }
 
-        try await repository.addPassphrase(
-            "hash-1",
-            for: "license-1",
-            userID: "user-1",
-            provider: "https://provider.com"
-        )
+        try await repository.addPassphrase("hash-1", userID: "user-1", provider: "https://provider.com")
 
         let matches = try await repository.passphrasesMatching(
             userID: "user-99",
@@ -207,29 +195,41 @@ struct LCPKeychainPassphraseRepositoryTests {
 
     // MARK: - Multiple Passphrases Tests
 
-    @Test func multiplePassphrasesForDifferentLicenses() async throws {
+    @Test func multiplePassphrases() async throws {
         defer { try? cleanupAllTestData() }
 
-        let passphrases = [
-            ("license-1", "hash-1"),
-            ("license-2", "hash-2"),
-            ("license-3", "hash-3"),
-        ]
+        let hashes = ["hash-1", "hash-2", "hash-3"]
 
-        for (licenseID, hash) in passphrases {
-            try await repository.addPassphrase(
-                hash,
-                for: licenseID,
-                userID: "user-1",
-                provider: "https://provider.com"
-            )
+        for hash in hashes {
+            try await repository.addPassphrase(hash, userID: "user-1", provider: "https://provider.com")
         }
 
-        // Verify each passphrase can be retrieved
-        for (licenseID, expectedHash) in passphrases {
-            let retrieved = try await repository.passphrase(for: licenseID)
-            #expect(retrieved == expectedHash)
-        }
+        let all = try await repository.passphrases()
+        #expect(Set(all) == Set(hashes))
+    }
+
+    // MARK: - Backward Compatibility Tests
+
+    @Test func readsLegacyLicenseKeyedPassphrase() async throws {
+        defer { try? cleanupAllTestData() }
+
+        // Stored by a previous version: keyed by licenseID, with a non-optional
+        // provider and an extra `licenseID` field.
+        try writeLegacyPassphrase(
+            licenseID: "license-legacy",
+            hash: "legacy-hash",
+            userID: "user-1",
+            provider: "https://provider.com"
+        )
+
+        let all = try await repository.passphrases()
+        #expect(all == ["legacy-hash"])
+
+        let matches = try await repository.passphrasesMatching(
+            userID: "user-1",
+            provider: "https://provider.com"
+        )
+        #expect(matches == ["legacy-hash"])
     }
 
     // MARK: - Concurrency Tests
@@ -237,17 +237,13 @@ struct LCPKeychainPassphraseRepositoryTests {
     @Test func concurrentAddPassphrase() async throws {
         defer { try? cleanupAllTestData() }
 
-        let passphrases = (0 ..< 10).map { index in
-            ("license-concurrent-\(index)", "hash-\(index)")
-        }
+        let hashes = (0 ..< 10).map { "hash-\($0)" }
 
-        // Add passphrases concurrently
         try await withThrowingTaskGroup(of: Void.self) { group in
-            for (licenseID, hash) in passphrases {
+            for hash in hashes {
                 group.addTask {
                     try await repository.addPassphrase(
                         hash,
-                        for: licenseID,
                         userID: "user-1",
                         provider: "https://provider.com"
                     )
@@ -256,11 +252,8 @@ struct LCPKeychainPassphraseRepositoryTests {
             try await group.waitForAll()
         }
 
-        // Verify all passphrases were added
-        for (licenseID, expectedHash) in passphrases {
-            let retrieved = try await repository.passphrase(for: licenseID)
-            #expect(retrieved == expectedHash)
-        }
+        let all = try await repository.passphrases()
+        #expect(Set(all) == Set(hashes))
     }
 
     // MARK: - Clear Tests
@@ -268,24 +261,11 @@ struct LCPKeychainPassphraseRepositoryTests {
     @Test func clearRemovesAllPassphrases() async throws {
         defer { try? cleanupAllTestData() }
 
-        try await repository.addPassphrase(
-            "hash-1",
-            for: "license-clear-1",
-            userID: "user-1",
-            provider: "https://provider.com"
-        )
-        try await repository.addPassphrase(
-            "hash-2",
-            for: "license-clear-2",
-            userID: "user-2",
-            provider: "https://provider.com"
-        )
+        try await repository.addPassphrase("hash-1", userID: "user-1", provider: "https://provider.com")
+        try await repository.addPassphrase("hash-2", userID: "user-2", provider: "https://provider.com")
 
         try await repository.clear()
 
-        // Verify all passphrases are gone
-        #expect(try await repository.passphrase(for: "license-clear-1") == nil)
-        #expect(try await repository.passphrase(for: "license-clear-2") == nil)
         let all = try await repository.passphrases()
         #expect(all.isEmpty)
     }
@@ -308,17 +288,12 @@ struct LCPKeychainPassphraseRepositoryTests {
             "hash-with-unicode-é-ñ-中",
         ]
 
-        for (index, hash) in specialHashes.enumerated() {
-            try await repository.addPassphrase(
-                hash,
-                for: "license-special-\(index)",
-                userID: "user-1",
-                provider: "https://provider.com"
-            )
-
-            let retrieved = try await repository.passphrase(for: "license-special-\(index)")
-            #expect(retrieved == hash)
+        for hash in specialHashes {
+            try await repository.addPassphrase(hash, userID: "user-1", provider: "https://provider.com")
         }
+
+        let all = try await repository.passphrases()
+        #expect(Set(all) == Set(specialHashes))
     }
 
     @Test func providerWithSpecialCharacters() async throws {
@@ -331,18 +306,9 @@ struct LCPKeychainPassphraseRepositoryTests {
         ]
 
         for (index, provider) in providers.enumerated() {
-            try await repository.addPassphrase(
-                "hash-\(index)",
-                for: "license-provider-\(index)",
-                userID: "user-1",
-                provider: provider
-            )
+            try await repository.addPassphrase("hash-\(index)", userID: "user-1", provider: provider)
 
-            let matches = try await repository.passphrasesMatching(
-                userID: "user-1",
-                provider: provider
-            )
-
+            let matches = try await repository.passphrasesMatching(userID: "user-1", provider: provider)
             #expect(matches.contains("hash-\(index)"))
         }
     }
@@ -355,15 +321,10 @@ struct LCPKeychainPassphraseRepositoryTests {
         // Test with very long hash (e.g., 512-bit hash)
         let longHash = String(repeating: "a", count: 128)
 
-        try await repository.addPassphrase(
-            longHash,
-            for: "license-long-hash",
-            userID: "user-1",
-            provider: "https://provider.com"
-        )
+        try await repository.addPassphrase(longHash, userID: "user-1", provider: "https://provider.com")
 
-        let retrieved = try await repository.passphrase(for: "license-long-hash")
-        #expect(retrieved == longHash)
+        let all = try await repository.passphrases()
+        #expect(all == [longHash])
     }
 
     @Test func longUserID() async throws {
@@ -371,18 +332,9 @@ struct LCPKeychainPassphraseRepositoryTests {
 
         let longUserID = String(repeating: "u", count: 200)
 
-        try await repository.addPassphrase(
-            "hash",
-            for: "license-long-user",
-            userID: longUserID,
-            provider: "https://provider.com"
-        )
+        try await repository.addPassphrase("hash", userID: longUserID, provider: "https://provider.com")
 
-        let matches = try await repository.passphrasesMatching(
-            userID: longUserID,
-            provider: "https://provider.com"
-        )
-
+        let matches = try await repository.passphrasesMatching(userID: longUserID, provider: "https://provider.com")
         #expect(matches == ["hash"])
     }
 
@@ -391,18 +343,9 @@ struct LCPKeychainPassphraseRepositoryTests {
 
         let longProvider = "https://provider.com/" + String(repeating: "p", count: 200)
 
-        try await repository.addPassphrase(
-            "hash",
-            for: "license-long-provider",
-            userID: "user-1",
-            provider: longProvider
-        )
+        try await repository.addPassphrase("hash", userID: "user-1", provider: longProvider)
 
-        let matches = try await repository.passphrasesMatching(
-            userID: "user-1",
-            provider: longProvider
-        )
-
+        let matches = try await repository.passphrasesMatching(userID: "user-1", provider: longProvider)
         #expect(matches == ["hash"])
     }
 }


### PR DESCRIPTION

### Changed

#### LCP

* `LCPPassphraseRepository.addPassphrase(_:userID:provider:)` no longer takes a license ID, and `provider` is now optional. A convenience `addPassphrase(_:)` overload is available for storing a passphrase without any associated user or provider.

### Fixed

#### LCP

* [#818](https://github.com/readium/swift-toolkit/issues/818) Repository failures during passphrase lookup (e.g. Keychain access errors) now fall through gracefully to the interactive authentication flow instead of propagating the error.