### PR TITLE
LCP Swift 6 Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * OPDS models (`Feed`, `Group`, `Facet`, `OpdsMetadata`) are now structs with value semantics.
 
+#### LCP
+
+* `LCPService.init` now requires an explicit `deviceName` parameter. We recommend passing `UIDevice.current.name`. See [the migration guide](docs/Migration%20Guide.md).
+
 
 ## [3.10.0] - 2026-06-24
 

--- a/Package.swift
+++ b/Package.swift
@@ -176,6 +176,7 @@ let swift6EnabledTargets: Set<String> = [
     "ReadiumStreamer",
     "ReadiumStreamerTests",
     "ReadiumLCP",
+    "ReadiumLCPTests",
 ]
 
 for target in package.targets {

--- a/Package.swift
+++ b/Package.swift
@@ -175,6 +175,7 @@ let swift6EnabledTargets: Set<String> = [
     "ReadiumSharedTests",
     "ReadiumStreamer",
     "ReadiumStreamerTests",
+    "ReadiumLCP",
 ]
 
 for target in package.targets {

--- a/Sources/LCP/Content Protection/LCPContentProtection.swift
+++ b/Sources/LCP/Content Protection/LCPContentProtection.swift
@@ -53,31 +53,40 @@ final class LCPContentProtection: ContentProtection, Loggable {
             return .failure(.assetNotSupported(DebugError("The asset does not appear to be an LCP License")))
         }
 
-        return await asset.resource.read()
+        let licenseDocumentResult = await asset.resource.read()
             .asLCPL()
-            .mapError { .reading($0) }
-            .asyncFlatMap { licenseDocument in
-                await assetRetriever.retrieve(link: licenseDocument.publicationLink)
-                    .flatMap { publicationAsset in
-                        switch publicationAsset {
-                        case .resource:
-                            return .failure(.assetNotSupported(DebugError("Cannot open the LCP-protected publication as a Container")))
-                        case let .container(container):
-                            return .success(container)
-                        }
-                    }
-                    .asyncFlatMap {
-                        await makeLCPAsset(
-                            from: $0,
-                            license: retrieveLicense(
-                                in: .resource(asset),
-                                credentials: credentials,
-                                allowUserInteraction: allowUserInteraction,
-                                sender: sender
-                            )
-                        )
-                    }
+            .mapError { ContentProtectionOpenError.reading($0) }
+
+        let licenseDocument: LicenseDocument
+        switch licenseDocumentResult {
+        case let .failure(error):
+            return .failure(error)
+        case let .success(doc):
+            licenseDocument = doc
+        }
+
+        let publicationAssetResult = await assetRetriever.retrieve(link: licenseDocument.publicationLink)
+        let container: ContainerAsset
+        switch publicationAssetResult {
+        case let .failure(error):
+            return .failure(error)
+        case let .success(publicationAsset):
+            switch publicationAsset {
+            case .resource:
+                return .failure(.assetNotSupported(DebugError("Cannot open the LCP-protected publication as a Container")))
+            case let .container(c):
+                container = c
             }
+        }
+
+        let licenseResult = await retrieveLicense(
+            in: .resource(asset),
+            credentials: credentials,
+            allowUserInteraction: allowUserInteraction,
+            sender: sender
+        )
+
+        return await makeLCPAsset(from: container, license: licenseResult)
     }
 
     func openPublication(

--- a/Sources/LCP/LCPLicenseRepository.swift
+++ b/Sources/LCP/LCPLicenseRepository.swift
@@ -32,10 +32,10 @@ public protocol LCPLicenseRepository: Sendable {
     func userRights(for id: LicenseDocument.ID) async throws -> LCPConsumableUserRights
 
     /// Updates the consumable user rights for the license with given `id`.
-    func updateUserRights(
+    func updateUserRights<T: Sendable>(
         for id: LicenseDocument.ID,
-        with changes: (inout LCPConsumableUserRights) -> Void
-    ) async throws
+        with changes: @Sendable (inout LCPConsumableUserRights) throws -> T
+    ) async throws -> T
 }
 
 /// Holds the current state of consumable user rights for a license.

--- a/Sources/LCP/LCPLicenseRepository.swift
+++ b/Sources/LCP/LCPLicenseRepository.swift
@@ -31,7 +31,16 @@ public protocol LCPLicenseRepository: Sendable {
     /// Returns the consumable user rights for the license with given `id`.
     func userRights(for id: LicenseDocument.ID) async throws -> LCPConsumableUserRights
 
-    /// Updates the consumable user rights for the license with given `id`.
+    /// Atomically reads, mutates, and persists the consumable user rights for
+    /// the license with the given `id`.
+    ///
+    /// The `changes` closure receives the license's current rights as an
+    /// `inout` value and may modify them in place; any modifications are
+    /// persisted once the closure returns. Use the closure's return value to
+    /// surface a result computed while the rights are held — for example,
+    /// whether a copy/print request was within the allowed budget.
+    ///
+    /// - Returns: The value returned by the `changes` closure.
     func updateUserRights<T: Sendable>(
         for id: LicenseDocument.ID,
         with changes: @Sendable (inout LCPConsumableUserRights) throws -> T

--- a/Sources/LCP/LCPPassphraseRepository.swift
+++ b/Sources/LCP/LCPPassphraseRepository.swift
@@ -11,7 +11,7 @@ public typealias LCPPassphraseHash = String
 
 /// The passphrase repository stores passphrase hashes, optionally associated
 /// with a user ID and provider.
-public protocol LCPPassphraseRepository {
+public protocol LCPPassphraseRepository: Sendable {
     /// Returns a list of passphrase hashes that may match the given `userID`
     /// and `provider`.
     func passphrasesMatching(

--- a/Sources/LCP/LCPService.swift
+++ b/Sources/LCP/LCPService.swift
@@ -63,7 +63,7 @@ public final class LCPService: Loggable {
             licenses: licenseRepository,
             crl: CRLService(httpClient: httpClient),
             device: DeviceService(
-                deviceName: deviceName ?? UIDevice.current.name,
+                deviceName: deviceName ?? MainActor.assumeIsolated { UIDevice.current.name },
                 deviceId: deviceId,
                 repository: licenseRepository,
                 httpClient: httpClient
@@ -82,7 +82,7 @@ public final class LCPService: Loggable {
     /// Acquires a protected publication from an LCPL.
     public func acquirePublication(
         from lcpl: LicenseDocumentSource,
-        onProgress: @escaping (LCPProgress) -> Void = { _ in }
+        onProgress: @escaping @Sendable (LCPProgress) -> Void = { _ in }
     ) async -> Result<LCPAcquiredPublication, LCPError> {
         await wrap {
             try await licenses.acquirePublication(from: lcpl, onProgress: onProgress)

--- a/Sources/LCP/LCPService.swift
+++ b/Sources/LCP/LCPService.swift
@@ -63,7 +63,13 @@ public final class LCPService: Loggable {
             licenses: licenseRepository,
             crl: CRLService(httpClient: httpClient),
             device: DeviceService(
-                deviceName: deviceName ?? MainActor.assumeIsolated { UIDevice.current.name },
+                deviceName: deviceName ?? {
+                    if Thread.isMainThread {
+                        return MainActor.assumeIsolated { UIDevice.current.name }
+                    } else {
+                        return "iOS"
+                    }
+                }(),
                 deviceId: deviceId,
                 repository: licenseRepository,
                 httpClient: httpClient

--- a/Sources/LCP/LCPService.swift
+++ b/Sources/LCP/LCPService.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import ReadiumShared
-import UIKit
 
 /// Service used to acquire and open publications protected with LCP.
 ///
@@ -23,27 +22,26 @@ public final class LCPService: Loggable {
 
     /// - Parameters:
     ///   - client: The LCP client used for core license operations.
+    ///   - deviceName: Device name used when registering a license to an LSD
+    ///     server. We recommend using `UIDevice.current.name` and adding the
+    ///     `com.apple.developer.device-information.user-assigned-device-name`
+    ///     entitlement.
+    ///   - deviceId: Device ID used when registering a license to an LSD
+    ///     server. You must ensure the identifier is unique and stable for the
+    ///     device (persist and reuse across app launches). If not provided, the
+    ///     device ID will be generated as a random UUID.
     ///   - licenseRepository: Repository for managing stored licenses.
     ///   - passphraseRepository: Repository for managing user passphrases.
     ///   - assetRetriever: The retriever used to fetch protected assets.
     ///   - httpClient: The HTTP client used for network requests to LSD/LCP servers.
-    ///   - deviceName: Device name used when registering a license to an LSD server.
-    ///     If not provided, the device name will be `UIDevice.current.name`. Since iOS 16,
-    ///     this returns a generic name (e.g. "iPhone") unless the
-    ///     `com.apple.developer.device-information.user-assigned-device-name` entitlement
-    ///     is added to your app.
-    ///   - deviceId: Device ID used when registering a license to an LSD server.
-    ///     You must ensure the identifier is unique and stable for the device (persist and
-    ///     reuse across app launches). If not provided, the device ID will be generated as
-    ///     a random UUID.
     public init(
         client: LCPClient,
+        deviceName: String,
+        deviceId: String? = nil,
         licenseRepository: LCPLicenseRepository,
         passphraseRepository: LCPPassphraseRepository,
         assetRetriever: AssetRetriever,
-        httpClient: HTTPClient,
-        deviceName: String? = nil,
-        deviceId: String? = nil
+        httpClient: HTTPClient
     ) {
         // Determine whether the embedded liblcp.a is in production mode, by attempting to open a production license.
         let isProduction: Bool = {
@@ -63,13 +61,7 @@ public final class LCPService: Loggable {
             licenses: licenseRepository,
             crl: CRLService(httpClient: httpClient),
             device: DeviceService(
-                deviceName: deviceName ?? {
-                    if Thread.isMainThread {
-                        return MainActor.assumeIsolated { UIDevice.current.name }
-                    } else {
-                        return "iOS"
-                    }
-                }(),
+                deviceName: deviceName,
                 deviceId: deviceId,
                 repository: licenseRepository,
                 httpClient: httpClient

--- a/Sources/LCP/LCPService.swift
+++ b/Sources/LCP/LCPService.swift
@@ -63,13 +63,7 @@ public final class LCPService: Loggable {
             licenses: licenseRepository,
             crl: CRLService(httpClient: httpClient),
             device: DeviceService(
-                deviceName: deviceName ?? {
-                    if Thread.isMainThread {
-                        return MainActor.assumeIsolated { UIDevice.current.name }
-                    } else {
-                        return "iOS"
-                    }
-                }(),
+                deviceName: deviceName ?? "iOS",
                 deviceId: deviceId,
                 repository: licenseRepository,
                 httpClient: httpClient

--- a/Sources/LCP/License/Container/ContainerLicenseContainer.swift
+++ b/Sources/LCP/License/Container/ContainerLicenseContainer.swift
@@ -9,8 +9,6 @@ import ReadiumShared
 import ReadiumZIPFoundation
 
 /// Access to a License Document stored in a ``Container``.
-/// Meant to be subclassed to customize the pathInZIP property,
-/// eg. ``EPUBLicenseContainer``.
 final class ContainerLicenseContainer: LicenseContainer {
     private let asset: ContainerAsset
     private let licensePath: RelativeURL

--- a/Sources/LCP/License/Container/ContainerLicenseContainer.swift
+++ b/Sources/LCP/License/Container/ContainerLicenseContainer.swift
@@ -11,7 +11,7 @@ import ReadiumZIPFoundation
 /// Access to a License Document stored in a ``Container``.
 /// Meant to be subclassed to customize the pathInZIP property,
 /// eg. ``EPUBLicenseContainer``.
-class ContainerLicenseContainer: LicenseContainer {
+final class ContainerLicenseContainer: LicenseContainer {
     private let asset: ContainerAsset
     private let licensePath: RelativeURL
 

--- a/Sources/LCP/License/Container/LicenseContainer.swift
+++ b/Sources/LCP/License/Container/LicenseContainer.swift
@@ -9,7 +9,7 @@ import ReadiumShared
 
 /// Encapsulates the read/write access to the packaged License Document (eg. in
 /// an EPUB container, or a standalone LCPL file)
-protocol LicenseContainer {
+protocol LicenseContainer: Sendable {
     /// Returns whether this container currently contains a License Document.
     ///
     /// For example, when fulfilling an EPUB publication, it initially doesn't contain the license.

--- a/Sources/LCP/License/License.swift
+++ b/Sources/LCP/License/License.swift
@@ -99,20 +99,17 @@ extension License: LCPLicense {
         guard !isRestricted else { return false }
 
         do {
-            var allowed = true
-            try await licenses.updateUserRights(for: license.id) { rights in
+            return try await licenses.updateUserRights(for: license.id) { rights in
                 guard let copyLeft = rights.copy else {
-                    return
+                    return true
                 }
                 guard text.count <= copyLeft else {
-                    allowed = false
-                    return
+                    return false
                 }
 
                 rights.copy = max(0, copyLeft - text.count)
+                return true
             }
-
-            return allowed
 
         } catch {
             log(.error, error)
@@ -146,20 +143,17 @@ extension License: LCPLicense {
         guard !isRestricted else { return false }
 
         do {
-            var allowed = true
-            try await licenses.updateUserRights(for: license.id) { rights in
+            return try await licenses.updateUserRights(for: license.id) { rights in
                 guard let printLeft = rights.print else {
-                    return
+                    return true
                 }
                 guard pageCount <= printLeft else {
-                    allowed = false
-                    return
+                    return false
                 }
 
                 rights.print = max(0, printLeft - pageCount)
+                return true
             }
-
-            return allowed
 
         } catch {
             log(.error, error)

--- a/Sources/LCP/License/LicenseValidation.swift
+++ b/Sources/LCP/License/LicenseValidation.swift
@@ -26,7 +26,7 @@ private let supportedProfiles = [
 typealias Context = Result<LCPClientContext, LCPError>
 
 /// Holds the License/Status Documents and the DRM context, once validated.
-struct ValidatedDocuments {
+struct ValidatedDocuments: Sendable {
     let license: LicenseDocument
     let context: Context
     let status: StatusDocument?
@@ -48,7 +48,7 @@ actor LicenseValidation: Loggable {
     fileprivate let client: LCPClient
     fileprivate let authentication: LCPAuthenticating?
     fileprivate let allowUserInteraction: Bool
-    fileprivate let sender: Any?
+    fileprivate let sender: UncheckedSendable<Any?>?
     fileprivate let crl: CRLService
     fileprivate let device: DeviceService
     fileprivate let httpClient: HTTPClient
@@ -57,7 +57,7 @@ actor LicenseValidation: Loggable {
     /// List of observers notified when the Documents are validated, or if an error occurred.
     fileprivate var observers: [(callback: Observer, policy: ObserverPolicy)] = []
 
-    fileprivate let onLicenseValidated: (LicenseDocument) async throws -> Void
+    fileprivate let onLicenseValidated: @Sendable (LicenseDocument) async throws -> Void
 
     /// Current state in the validation steps.
     private(set) var state: State = .start {
@@ -69,14 +69,14 @@ actor LicenseValidation: Loggable {
     init(
         authentication: LCPAuthenticating?,
         allowUserInteraction: Bool,
-        sender: Any?,
+        sender: UncheckedSendable<Any?>?,
         isProduction: Bool,
         client: LCPClient,
         crl: CRLService,
         device: DeviceService,
         httpClient: HTTPClient,
         passphrases: PassphrasesService,
-        onLicenseValidated: @escaping (LicenseDocument) async throws -> Void
+        onLicenseValidated: @escaping @Sendable (LicenseDocument) async throws -> Void
     ) {
         self.authentication = authentication
         self.allowUserInteraction = allowUserInteraction
@@ -425,7 +425,7 @@ extension LicenseValidation {
 
 /// Validation observers
 extension LicenseValidation {
-    typealias Observer = (Result<ValidatedDocuments, Error>) -> Void
+    typealias Observer = @Sendable (Result<ValidatedDocuments, Error>) -> Void
 
     enum ObserverPolicy {
         /// The observer is automatically removed when called.

--- a/Sources/LCP/Repositories/Keychain/LCPKeychainLicenseRepository.swift
+++ b/Sources/LCP/Repositories/Keychain/LCPKeychainLicenseRepository.swift
@@ -124,10 +124,10 @@ public actor LCPKeychainLicenseRepository: LCPLicenseRepository, Loggable {
         )
     }
 
-    public func updateUserRights(
+    public func updateUserRights<T: Sendable>(
         for id: LicenseDocument.ID,
-        with changes: (inout LCPConsumableUserRights) -> Void
-    ) async throws {
+        with changes: @Sendable (inout LCPConsumableUserRights) throws -> T
+    ) async throws -> T {
         var license = try requireLicense(for: id)
 
         // Get current rights
@@ -137,13 +137,14 @@ public actor LCPKeychainLicenseRepository: LCPLicenseRepository, Loggable {
         )
 
         // Apply changes
-        changes(&currentRights)
+        let result = try changes(&currentRights)
 
         // Update the data
         license.printsLeft = currentRights.print
         license.copiesLeft = currentRights.copy
 
         try updateLicense(license, for: id)
+        return result
     }
 
     /// Removes all licenses from the repository.

--- a/Sources/LCP/Services/CRLService.swift
+++ b/Sources/LCP/Services/CRLService.swift
@@ -8,7 +8,7 @@ import Foundation
 import ReadiumShared
 
 /// Certificate Revocation List
-final class CRLService {
+final class CRLService: Sendable {
     /// Number of days before the CRL cache expires.
     private static let expiration = 7
 

--- a/Sources/LCP/Services/LicensesService.swift
+++ b/Sources/LCP/Services/LicensesService.swift
@@ -65,22 +65,21 @@ final class LicensesService: Loggable {
     ) async throws -> License {
         let initialData = try await container.read()
 
-        func onLicenseValidated(of license: LicenseDocument) async throws {
+        let onLicenseValidated: @Sendable (LicenseDocument) async throws -> Void = { [licenses, container, initialData] license in
             // Any errors are ignored to avoid blocking the publication.
-
             do {
                 try await licenses.addLicense(license)
             } catch {
-                log(.error, "Failed to add the LCP License to the local database: \(error)")
+                Self.log(.error, "Failed to add the LCP License to the local database: \(error)")
             }
 
             // Updates the License in the container if needed
             if license.jsonData != initialData {
                 do {
                     try await container.write(license)
-                    log(.debug, "Wrote updated License Document in container")
+                    Self.log(.debug, "Wrote updated License Document in container")
                 } catch {
-                    log(.error, "Failed to write updated License Document in container: \(error)")
+                    Self.log(.error, "Failed to write updated License Document in container: \(error)")
                 }
             }
         }
@@ -88,7 +87,7 @@ final class LicensesService: Loggable {
         let validation = LicenseValidation(
             authentication: authentication,
             allowUserInteraction: allowUserInteraction,
-            sender: sender,
+            sender: sender.map { UncheckedSendable($0) },
             isProduction: isProduction,
             client: client,
             crl: crl,
@@ -105,7 +104,7 @@ final class LicensesService: Loggable {
 
     func acquirePublication(
         from lcpl: LicenseDocumentSource,
-        onProgress: @escaping (LCPProgress) -> Void
+        onProgress: @escaping @Sendable (LCPProgress) -> Void
     ) async throws -> LCPAcquiredPublication {
         guard let license = try await readLicense(from: lcpl) else {
             throw LCPError.notALicenseDocument(lcpl)

--- a/Sources/LCP/Services/PassphrasesService.swift
+++ b/Sources/LCP/Services/PassphrasesService.swift
@@ -9,11 +9,9 @@ import Foundation
 import ReadiumInternal
 import ReadiumShared
 
-final class PassphrasesService: Loggable {
+final class PassphrasesService: Loggable, Sendable {
     private let client: LCPClient
     private let repository: LCPPassphraseRepository
-
-    private let sha256Predicate = NSPredicate(format: "SELF MATCHES[c] %@", "^([a-f0-9]{64})$")
 
     init(client: LCPClient, repository: LCPPassphraseRepository) {
         self.client = client
@@ -28,7 +26,7 @@ final class PassphrasesService: Loggable {
         for license: LicenseDocument,
         authentication: LCPAuthenticating?,
         allowUserInteraction: Bool,
-        sender: Any?
+        sender: UncheckedSendable<Any?>?
     ) async throws -> LCPPassphraseHash? {
         // Look for a stored passphrase matching this license.
         //
@@ -93,19 +91,20 @@ final class PassphrasesService: Loggable {
     }
 
     /// Called when the service can't find any valid passphrase in the repository, as a fallback.
+    @MainActor
     private func authenticate(
         for license: LicenseDocument,
         reason: LCPAuthenticationReason,
         using authentication: LCPAuthenticating,
         allowUserInteraction: Bool,
-        sender: Any?
+        sender: UncheckedSendable<Any?>?
     ) async throws -> LCPPassphraseHash? {
         let authenticatedLicense = LCPAuthenticatedLicense(document: license)
         guard let clearPassphrase = await authentication.retrievePassphrase(
             for: authenticatedLicense,
             reason: reason,
             allowUserInteraction: allowUserInteraction,
-            sender: sender
+            sender: sender?.value
         ) else {
             return nil
         }
@@ -114,7 +113,7 @@ final class PassphrasesService: Loggable {
         var passphrases = [hashedPassphrase]
         // Note: The C++ LCP lib crashes if we provide a passphrase that is not a valid
         // SHA-256 hash. So we check this beforehand.
-        if sha256Predicate.evaluate(with: clearPassphrase) {
+        if clearPassphrase.range(of: "^([a-f0-9]{64})$", options: [.regularExpression, .caseInsensitive]) != nil {
             passphrases.append(clearPassphrase)
         }
 

--- a/Sources/LCP/Services/PassphrasesService.swift
+++ b/Sources/LCP/Services/PassphrasesService.swift
@@ -91,7 +91,6 @@ final class PassphrasesService: Loggable, Sendable {
     }
 
     /// Called when the service can't find any valid passphrase in the repository, as a fallback.
-    @MainActor
     private func authenticate(
         for license: LicenseDocument,
         reason: LCPAuthenticationReason,
@@ -100,11 +99,12 @@ final class PassphrasesService: Loggable, Sendable {
         sender: UncheckedSendable<Any?>?
     ) async throws -> LCPPassphraseHash? {
         let authenticatedLicense = LCPAuthenticatedLicense(document: license)
-        guard let clearPassphrase = await authentication.retrievePassphrase(
+        guard let clearPassphrase = await retrievePassphrase(
+            using: authentication,
             for: authenticatedLicense,
             reason: reason,
             allowUserInteraction: allowUserInteraction,
-            sender: sender?.value
+            sender: sender
         ) else {
             return nil
         }
@@ -113,7 +113,7 @@ final class PassphrasesService: Loggable, Sendable {
         var passphrases = [hashedPassphrase]
         // Note: The C++ LCP lib crashes if we provide a passphrase that is not a valid
         // SHA-256 hash. So we check this beforehand.
-        if clearPassphrase.range(of: "^([a-f0-9]{64})$", options: [.regularExpression, .caseInsensitive]) != nil {
+        if clearPassphrase.count == 64, clearPassphrase.allSatisfy({ $0.isASCII && $0.isHexDigit }) {
             passphrases.append(clearPassphrase)
         }
 
@@ -135,5 +135,25 @@ final class PassphrasesService: Loggable, Sendable {
         }
 
         return passphrase
+    }
+
+    /// Prompts the user for a passphrase on the main actor.
+    ///
+    /// The non-`Sendable` `sender` is unwrapped here, inside the main actor, so
+    /// it never crosses an actor boundary.
+    @MainActor
+    private func retrievePassphrase(
+        using authentication: LCPAuthenticating,
+        for license: LCPAuthenticatedLicense,
+        reason: LCPAuthenticationReason,
+        allowUserInteraction: Bool,
+        sender: UncheckedSendable<Any?>?
+    ) async -> String? {
+        await authentication.retrievePassphrase(
+            for: license,
+            reason: reason,
+            allowUserInteraction: allowUserInteraction,
+            sender: sender?.value
+        )
     }
 }

--- a/TestApp/Sources/App/AppModule.swift
+++ b/TestApp/Sources/App/AppModule.swift
@@ -13,7 +13,7 @@ import UIKit
 
 /// Base module delegate, that sub-modules' delegate can extend.
 /// Provides basic shared functionalities.
-protocol ModuleDelegate: AnyObject {
+@MainActor protocol ModuleDelegate: AnyObject {
     func presentAlert(_ title: String, message: String, from viewController: UIViewController)
     func presentError(_ error: Error, from viewController: UIViewController)
 }
@@ -21,7 +21,7 @@ protocol ModuleDelegate: AnyObject {
 /// Main application module, it:
 /// - owns the sub-modules (library, reader, etc.)
 /// - orchestrates the communication between its sub-modules, through the modules' delegates.
-final class AppModule: Loggable {
+@MainActor final class AppModule: Loggable {
     // App modules
     var library: LibraryModuleAPI!
     var reader: ReaderModuleAPI!
@@ -29,7 +29,7 @@ final class AppModule: Loggable {
 
     let readium: Readium
 
-    init() throws {
+    @MainActor init() throws {
         let file = Paths.library.appendingPath("database.db", isDirectory: false)
         let db = try Database(file: file.url)
         print("Created database at \(file.path)")

--- a/TestApp/Sources/App/Readium.swift
+++ b/TestApp/Sources/App/Readium.swift
@@ -14,7 +14,7 @@ import ReadiumStreamer
     import ReadiumLCP
 #endif
 
-final class Readium {
+@MainActor final class Readium {
     lazy var httpClient: HTTPClient = DefaultHTTPClient()
 
     lazy var formatSniffer: FormatSniffer = DefaultFormatSniffer()
@@ -42,6 +42,7 @@ final class Readium {
 
         lazy var lcpService = LCPService(
             client: LCPClient(),
+            deviceName: UIDevice.current.name,
             licenseRepository: LCPKeychainLicenseRepository(),
             passphraseRepository: LCPKeychainPassphraseRepository(),
             assetRetriever: assetRetriever,

--- a/TestApp/Sources/LCP/LCPModule.swift
+++ b/TestApp/Sources/LCP/LCPModule.swift
@@ -21,7 +21,7 @@ struct LCPPublication {
     let suggestedFilename: String
 }
 
-protocol LCPModuleAPI {
+@MainActor protocol LCPModuleAPI {
     init(readium: Readium)
     func fulfill(_ file: FileURL, progress: @escaping (Double) -> Void) async throws -> LCPPublication
 }

--- a/TestApp/Sources/Library/LibraryModule.swift
+++ b/TestApp/Sources/Library/LibraryModule.swift
@@ -11,7 +11,7 @@ import ReadiumStreamer
 import UIKit
 
 /// The Library module handles the presentation of the bookshelf, and the publications' management.
-protocol LibraryModuleAPI {
+@MainActor protocol LibraryModuleAPI {
     var delegate: LibraryModuleDelegate? { get }
 
     /// Root navigation controller containing the Library.
@@ -29,7 +29,7 @@ protocol LibraryModuleAPI {
     ) async throws -> Book
 }
 
-protocol LibraryModuleDelegate: ModuleDelegate {
+@MainActor protocol LibraryModuleDelegate: ModuleDelegate {
     /// Called when the user tap on a publication in the library.
     func libraryDidSelectPublication(_ publication: Publication, book: Book)
 }

--- a/TestApp/Sources/Library/LibraryService.swift
+++ b/TestApp/Sources/Library/LibraryService.swift
@@ -15,7 +15,7 @@ import UIKit
 /// - Import new publications (`Book` in the database).
 /// - Remove existing publications from the bookshelf.
 /// - Open publications for presentation in a navigator.
-final class LibraryService: Loggable {
+@MainActor final class LibraryService: Loggable {
     private let books: BookRepository
     private let readium: Readium
     private let lcp: LCPModuleAPI

--- a/TestApp/Sources/OPDS/OPDSModule.swift
+++ b/TestApp/Sources/OPDS/OPDSModule.swift
@@ -15,7 +15,7 @@ enum OPDSError: Error {
 }
 
 /// The OPDS module handles the presentation of OPDS catalogs.
-protocol OPDSModuleAPI {
+@MainActor protocol OPDSModuleAPI {
     var delegate: OPDSModuleDelegate? { get }
 
     /// Root navigation controller containing the OPDS catalogs.
@@ -23,7 +23,7 @@ protocol OPDSModuleAPI {
     var rootViewController: UINavigationController { get }
 }
 
-protocol OPDSModuleDelegate: ModuleDelegate {
+@MainActor protocol OPDSModuleDelegate: ModuleDelegate {
     /// Called when an OPDS publication needs to be imported.
     func opdsDownloadPublication(
         _ publication: Publication?,

--- a/TestApp/Sources/Reader/ReaderModule.swift
+++ b/TestApp/Sources/Reader/ReaderModule.swift
@@ -11,7 +11,7 @@ import UIKit
 
 /// The ReaderModule handles the presentation of publications to be read by the user.
 /// It contains sub-modules implementing ReaderFormatModule to handle each format of publication (eg. CBZ, EPUB).
-protocol ReaderModuleAPI {
+@MainActor protocol ReaderModuleAPI {
     var delegate: ReaderModuleDelegate? { get }
 
     /// Presents the given publication to the user, inside the given navigation controller.
@@ -19,7 +19,7 @@ protocol ReaderModuleAPI {
     func presentPublication(publication: Publication, book: Book, in navigationController: UINavigationController)
 }
 
-protocol ReaderModuleDelegate: ModuleDelegate {}
+@MainActor protocol ReaderModuleDelegate: ModuleDelegate {}
 
 final class ReaderModule: ReaderModuleAPI {
     weak var delegate: ReaderModuleDelegate?
@@ -82,7 +82,7 @@ final class ReaderModule: ReaderModuleAPI {
                     highlights: highlights,
                     readium: readium
                 )
-                await present(readerViewController)
+                present(readerViewController)
             } catch {
                 delegate.presentError(error, from: navigationController)
             }

--- a/Tests/LCPTests/LCPDecryptionTests.swift
+++ b/Tests/LCPTests/LCPDecryptionTests.swift
@@ -21,6 +21,7 @@ struct LCPDecryptionTests {
 
         let service = LCPService(
             client: LCPTestClient(),
+            deviceName: "Test Device",
             licenseRepository: InMemoryLCPLicenseRepository(),
             passphraseRepository: InMemoryLCPPassphraseRepository(),
             assetRetriever: assetRetriever,

--- a/Tests/LCPTests/LCPTestClient.swift
+++ b/Tests/LCPTests/LCPTestClient.swift
@@ -5,10 +5,10 @@
 //
 
 import Foundation
-import R2LCPClient
+@preconcurrency import R2LCPClient
 import ReadiumLCP
 
-class LCPTestClient: LCPClient {
+final class LCPTestClient: LCPClient {
     func createContext(jsonLicense: String, hashedPassphrase: String, pemCrl: String) throws -> LCPClientContext {
         try R2LCPClient.createContext(jsonLicense: jsonLicense, hashedPassphrase: hashedPassphrase, pemCrl: pemCrl)
     }

--- a/Tests/LCPTests/Repositories/InMemoryLCPLicenseRepository.swift
+++ b/Tests/LCPTests/Repositories/InMemoryLCPLicenseRepository.swift
@@ -7,7 +7,7 @@
 import Foundation
 @testable import ReadiumLCP
 
-class InMemoryLCPLicenseRepository: LCPLicenseRepository {
+actor InMemoryLCPLicenseRepository: LCPLicenseRepository {
     private var licenses: [LicenseDocument.ID: LicenseDocument] = [:]
     private var registeredDevices: Set<LicenseDocument.ID> = []
     private var rights: [LicenseDocument.ID: LCPConsumableUserRights] = [:]
@@ -38,12 +38,13 @@ class InMemoryLCPLicenseRepository: LCPLicenseRepository {
         rights[id] ?? LCPConsumableUserRights(print: nil, copy: nil)
     }
 
-    func updateUserRights(
+    func updateUserRights<T: Sendable>(
         for id: LicenseDocument.ID,
-        with changes: (inout LCPConsumableUserRights) -> Void
-    ) async throws {
+        with changes: @Sendable (inout LCPConsumableUserRights) throws -> T
+    ) async throws -> T {
         var current = rights[id] ?? LCPConsumableUserRights(print: nil, copy: nil)
-        changes(&current)
+        let result = try changes(&current)
         rights[id] = current
+        return result
     }
 }

--- a/Tests/LCPTests/Repositories/InMemoryLCPPassphraseRepository.swift
+++ b/Tests/LCPTests/Repositories/InMemoryLCPPassphraseRepository.swift
@@ -7,7 +7,7 @@
 import Foundation
 @testable import ReadiumLCP
 
-class InMemoryLCPPassphraseRepository: LCPPassphraseRepository {
+actor InMemoryLCPPassphraseRepository: LCPPassphraseRepository {
     private struct Entry {
         var userID: User.ID?
         var provider: LicenseDocument.Provider?

--- a/Tests/LCPTests/Repositories/Keychain/LCPKeychainLicenseRepositoryTests.swift
+++ b/Tests/LCPTests/Repositories/Keychain/LCPKeychainLicenseRepositoryTests.swift
@@ -6,16 +6,15 @@
 
 import Foundation
 @testable import ReadiumLCP
-import ReadiumShared
+@testable import ReadiumShared
 import Testing
 
+@Suite(.serialized)
 struct LCPKeychainLicenseRepositoryTests {
     let repository: LCPKeychainLicenseRepository
 
     init() throws {
-        repository = LCPKeychainLicenseRepository(
-            synchronizable: false
-        )
+        repository = LCPKeychainLicenseRepository()
         // Clean up any existing test data
         try? cleanupAllTestData()
     }

--- a/Tests/LCPTests/Repositories/Keychain/LCPKeychainPassphraseRepositoryTests.swift
+++ b/Tests/LCPTests/Repositories/Keychain/LCPKeychainPassphraseRepositoryTests.swift
@@ -6,9 +6,10 @@
 
 import Foundation
 @testable import ReadiumLCP
-import ReadiumShared
+@testable import ReadiumShared
 import Testing
 
+@Suite(.serialized)
 struct LCPKeychainPassphraseRepositoryTests {
     let repository: LCPKeychainPassphraseRepository
 

--- a/docs/Migration Guide.md
+++ b/docs/Migration Guide.md
@@ -2,7 +2,22 @@
 
 All migration steps necessary in reading apps to upgrade to major versions of the Swift Readium toolkit will be documented in this file.
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Required `deviceName` in `LCPService`
+
+`LCPService.init` now requires an explicit `deviceName`. We recommend passing `UIDevice.current.name`:
+
+```diff
+ let lcpService = LCPService(
+     client: LCPClient(),
++    deviceName: UIDevice.current.name,
+     ...
+ )
+```
+
+> [!NOTE]
+> Since iOS 16, `UIDevice.current.name` returns a generic name (e.g. "iPhone") unless the `com.apple.developer.device-information.user-assigned-device-name` entitlement is added to your app.
 
 ## 3.9.0
 


### PR DESCRIPTION
1. Enabled Swift 6 language mode for the `ReadiumLCP` target in `Package.swift`.
2. Added `Sendable` conformance to `LCPPassphraseRepository` and `LicenseContainer` protocols.
3. Added `Sendable` conformance to `CRLService` and `PassphrasesService` classes.
4. Marked `ContainerLicenseContainer` as `final`.
5. Updated `updateUserRights` function signature in `LCPLicenseRepository` to be generic.
6. Refactored `copy(text:)` and `print(pageCount:)` in `License` to return their success status directly from the new generic `updateUserRights` closure.
7. In `LCPContentProtection`, refactored `openLicense` from `Result`-based monadic chaining to straight-line `async`/`await` control flow.
8. In `LicensesService`, converted the callback function `onLicenseValidated` to a `@Sendable` closure capturing only `Sendable` variables.
9. In `LicenseValidation`, converted the `Observer` callback `typealias` and `onLicenseValidated` parameter to be `@Sendable`.
10. Wraps the non-`Sendable` `sender: Any?` context parameter in `UncheckedSendable<Any?>?` across concurrent boundaries in `LicenseValidation`, `PassphrasesService`, and `LicensesService`.
11. Marked the `authenticate` function as `@MainActor` in `PassphrasesService`.
12. Removed the `sha256Predicate` instance property (of non-`Sendable` type `NSPredicate`) from `PassphrasesService`, replacing it with an inline regular expression check.

## Public API Breaking Changes

1. `LCPPassphraseRepository` protocol now conforms to `Sendable`.
2. The `LCPService.acquirePublication` function's `onProgress` callback parameter now requires the `@Sendable` constraint.
3. `LCPLicenseRepository.updateUserRights` changed from a void-returning method to a generic, throwing, and value-returning method:
```swift
func updateUserRights<T: Sendable>(for: with:) async throws -> T
```
4. The `LCPLicenseRepository.updateUserRights` `changes` closure changed from:
```swift
(inout LCPConsumableUserRights) -> Void
```
to:
```swift
@Sendable (inout LCPConsumableUserRights) throws -> T
```

Relates to https://github.com/readium/swift-toolkit/issues/758.