### PR TITLE
Add EPUBNavigatorDelegate.navigatorDidLoadSpread(_:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes to this project will be documented in this file. Take a look at [the migration guide](docs/Migration%20Guide.md) to upgrade between two major versions.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+#### Navigator
+
+* The EPUB navigator now calls the new `EPUBNavigatorDelegate.navigatorDidLoadSpread(_:)` delegate method when the currently visible spread finishes loading, just before its content is faded in. This lets a host app dismiss its own loading cover exactly when the visible content appears. The method has a default empty implementation, so existing conformers are unaffected.
+
 
 ## [3.10.0] - 2026-06-24
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -17,10 +17,22 @@ import WebKit
     // MARK: - WebView Customization
 
     func navigator(_ navigator: EPUBNavigatorViewController, setupUserScripts userContentController: WKUserContentController)
+
+    // MARK: - Loading
+
+    /// Called when the current spread has finished loading and is about to be
+    /// revealed: once when the publication opens, and again after each page turn.
+    /// Only the visible spread triggers it, not the preloaded adjacent ones.
+    ///
+    /// A host showing its own loading cover can dismiss it here without exposing
+    /// the navigator's loading indicator.
+    func navigatorDidLoadSpread(_ navigator: EPUBNavigatorViewController)
 }
 
 public extension EPUBNavigatorDelegate {
     func navigator(_ navigator: EPUBNavigatorViewController, setupUserScripts userContentController: WKUserContentController) {}
+
+    func navigatorDidLoadSpread(_ navigator: EPUBNavigatorViewController) {}
 }
 
 public typealias EPUBContentInsets = (top: CGFloat, bottom: CGFloat)
@@ -1082,6 +1094,12 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
         }
 
         await spreadView.evaluateScript("(function() {\n\(script)\n})();")
+
+        // Only the visible spread, not the adjacent spreads preloaded around it,
+        // which can finish loading before this one is revealed.
+        if spreadView === paginationView?.currentView {
+            delegate?.navigatorDidLoadSpread(self)
+        }
     }
 
     func spreadView(_ spreadView: EPUBSpreadView, didReceive event: PointerEvent) {


### PR DESCRIPTION
## Summary

Adds a new `EPUBNavigatorDelegate.navigatorDidLoadSpread(_:)` delegate method, called when the **currently visible** spread has finished loading its content and is about to be revealed (the navigator's per-spread activity indicator stops right after it returns).

## Motivation

A host app that shows its own loading cover currently has no precise signal for when the visible content is ready. Dismissing on `locationDidChange` is too early — it fires while the spread is still loading, briefly exposing the navigator's own activity indicator and the scroll to the initial location. This callback fires exactly when the visible content appears, so the host can dismiss its cover without any flash.

## Behavior

- Fired at the end of `spreadViewDidLoad`, one beat before `showSpread()` stops the activity indicator and fades the content in.
- **Current spread only** (`spreadView === paginationView.currentView`), not the adjacent spreads preloaded around it. Adjacent spreads load concurrently with the current spread's trailing settle delay (see `PaginationView.loadNextPage`); a fast neighbour can otherwise reach `spreadViewDidLoad` first, and firing for it would let a host dismiss its cover a beat before the visible spread is actually revealed.
- Fires once on open and again after each page turn (whenever the visible spread changes).

## API

```swift
public protocol EPUBNavigatorDelegate {
    // ...
    func navigatorDidLoadSpread(_ navigator: EPUBNavigatorViewController)
}

public extension EPUBNavigatorDelegate {
    func navigatorDidLoadSpread(_ navigator: EPUBNavigatorViewController) {}
}
```

Default empty implementation — **existing conformers are unaffected**, purely additive.

## Testing

- Builds for the iOS Simulator SDK (`ReadiumNavigator` scheme → `BUILD SUCCEEDED`); `make format` reports no changes.
- The callback has been running in production in a downstream reader app to dismiss a custom loading cover, with no flash of the navigator's indicator.

## Notes

- Swift-only — no JavaScript bundle changes.
- No unit test: the trigger is a UIKit/WebKit load-timing event on the spread view that the existing suite has no harness for; verified manually + in production.
