### PR TITLE
Add `LCPService.addPassphrase()` to preload passphrases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. Take a look
 
 ## [Unreleased]
 
+### Added
+
+#### LCP
+
+* `LCPService` has a new `addPassphrase(_:isHashed:userID:provider:)` method to store a passphrase candidate in the repository without opening a license first. Useful to preload a passphrase ahead of time (e.g. from a catalog).
+
 ### Fixed
 
 #### Navigator

--- a/Sources/LCP/LCPError.swift
+++ b/Sources/LCP/LCPError.swift
@@ -128,3 +128,12 @@ public enum ContainerError: Error {
     /// Can't write the file at given relative path in the Container.
     case writeFailed(path: String)
 }
+
+/// Errors thrown when preadding an LCP passphrase candidate.
+public enum LCPAddPassphraseError: Error {
+    /// The provided hashed passphrase is not a valid SHA-256 hash.
+    case invalidHash
+
+    /// An error occurred while accessing the passphrase repository.
+    case repository(Error)
+}

--- a/Sources/LCP/LCPService.swift
+++ b/Sources/LCP/LCPService.swift
@@ -19,6 +19,7 @@ import UIKit
 /// when presenting a dialog, for example.
 public final class LCPService: Loggable {
     private let licenses: LicensesService
+    private let passphrases: PassphrasesService
     private let assetRetriever: AssetRetriever
 
     /// - Parameters:
@@ -57,6 +58,11 @@ public final class LCPService: Loggable {
             return client.findOneValidPassphrase(jsonLicense: prodLicense, hashedPassphrases: [passphrase]) == passphrase
         }()
 
+        let passphrases = PassphrasesService(
+            client: client,
+            repository: passphraseRepository
+        )
+
         licenses = LicensesService(
             isProduction: isProduction,
             client: client,
@@ -70,13 +76,37 @@ public final class LCPService: Loggable {
             ),
             assetRetriever: assetRetriever,
             httpClient: httpClient,
-            passphrases: PassphrasesService(
-                client: client,
-                repository: passphraseRepository
-            )
+            passphrases: passphrases
         )
 
+        self.passphrases = passphrases
         self.assetRetriever = assetRetriever
+    }
+
+    /// Stores an LCP passphrase candidate in the repository, without
+    /// associating it with a specific license. Useful to preload a passphrase
+    /// ahead of time.
+    ///
+    /// - Parameters:
+    ///   - passphrase: The passphrase to store.
+    ///   - isHashed: Whether `passphrase` is already a SHA-256 hash. If
+    ///     `false`, it is hashed before being stored.
+    ///   - userID: The user identifier this passphrase is associated with, if
+    ///     known.
+    ///   - provider: The license provider this passphrase is associated with,
+    ///     if known.
+    public func addPassphrase(
+        _ passphrase: String,
+        isHashed: Bool,
+        userID: User.ID? = nil,
+        provider: LicenseDocument.Provider? = nil
+    ) async throws(LCPAddPassphraseError) {
+        try await passphrases.addPassphrase(
+            passphrase,
+            isHashed: isHashed,
+            userID: userID,
+            provider: provider
+        )
     }
 
     /// Acquires a protected publication from an LCPL.

--- a/Sources/LCP/Services/PassphrasesService.swift
+++ b/Sources/LCP/Services/PassphrasesService.swift
@@ -20,6 +20,40 @@ final class PassphrasesService: Loggable {
         self.repository = repository
     }
 
+    /// Stores a passphrase in the repository as a candidate, without
+    /// associating it with a specific license. `isHashed` indicates whether
+    /// `passphrase` is already a SHA-256 hash, otherwise it is hashed before
+    /// storage.
+    func addPassphrase(
+        _ passphrase: String,
+        isHashed: Bool,
+        userID: User.ID?,
+        provider: LicenseDocument.Provider?
+    ) async throws(LCPAddPassphraseError) {
+        let hash: LCPPassphraseHash
+        if isHashed {
+            guard sha256Predicate.evaluate(with: passphrase) else {
+                throw .invalidHash
+            }
+            // Normalize to lowercase to match `sha256()` output, so a hashed
+            // value and the hash of the matching cleartext de-duplicate.
+            hash = passphrase.lowercased()
+        } else {
+            hash = passphrase.sha256()
+        }
+
+        do {
+            // An already-stored passphrase is not re-added, to avoid
+            // overwriting its existing provider/userID association.
+            let existing = try await repository.passphrases()
+            guard !existing.contains(hash) else { return }
+
+            try await repository.addPassphrase(hash, userID: userID, provider: provider)
+        } catch {
+            throw .repository(error)
+        }
+    }
+
     /// Finds any valid passphrase for the given license in the passphrases repository.
     /// If none is found, requests a passphrase from the request delegate (ie. user prompt) until
     /// one is valid, or the request is cancelled.


### PR DESCRIPTION

### Added

#### LCP

* `LCPService` has a new `addPassphrase(_:isHashed:userID:provider:)` method to store a passphrase candidate in the repository without opening a license first. Useful to preload a passphrase ahead of time (e.g. from a catalog).