### PR TITLE
Improve CI and release tooling

### DIFF
--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -45,13 +45,21 @@ Omit the sub-section heading for cross-cutting changes.
 - Start each bullet with a past-tense verb or a noun phrase: "Added", "Fixed", "The X now…"
 - Be concise — one to three lines maximum per entry.
 - Mention the **public API surface** (type name, method name, protocol name) in backticks.
-- Do **not** explain implementation details; focus on what the developer observes or must do.
+- Do NOT explain implementation details; focus on what the developer observes or must do.
+- Do NOT document defensive validation (e.g. rejecting out-of-range values). Only document the positive behavior change that developers care about (e.g. "decimal values are now supported").
 - Link to an existing guide when the change is non-trivial to adopt:
   - Migration steps: `[the migration guide](docs/Migration%20Guide.md)` (or a specific anchor)
   - New feature guide: `[the user guide](docs/Guides/...)` if a guide exists
 - When the API is gated behind an experimental SPI, mention it.
 - Prefix Fixed entries with the GitHub issue: `- [#NNN](URL) Fixed ...`.
-- Contributions: append `(contributed by [@handle](PR URL))` when crediting external contributors.
+
+## Attributions
+
+For external contributions, we want to attribute the author. Follow these instructions:
+
+1. run `gh pr view --json number,title,url,author` to get the PR for the current branch and its author's login.
+2. Check if the author is a maintainer with `gh api repos/readium/kotlin-toolkit/collaborators --jq '.[].login'`.
+3. Only add a contribution credit if the author is **not** a maintainer, appending `(contributed by [@login](PR URL))`.
 
 ## Process
 

--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -58,7 +58,7 @@ Omit the sub-section heading for cross-cutting changes.
 For external contributions, we want to attribute the author. Follow these instructions:
 
 1. run `gh pr view --json number,title,url,author` to get the PR for the current branch and its author's login.
-2. Check if the author is a maintainer with `gh api repos/readium/kotlin-toolkit/collaborators --jq '.[].login'`.
+2. Check if the author is a maintainer with `gh api repos/readium/swift-toolkit/collaborators --jq '.[].login'`.
 3. Only add a contribution credit if the author is **not** a maintainer, appending `(contributed by [@login](PR URL))`.
 
 ## Process

--- a/.claude/skills/write-release-announcement/references/example-3.7.0.md
+++ b/.claude/skills/write-release-announcement/references/example-3.7.0.md
@@ -55,6 +55,8 @@
 
 We are pleased to release the Readium Swift Toolkit 3.7.0. This update brings significant improvements to how comics are handled, improves performance for large documents, and streamlines our localization sources.
 
+[Browse the full release on GitHub](https://github.com/readium/swift-toolkit/releases/tag/3.7.0)
+
 ### Improved reading for comics and image-based publications
 
 This release focuses heavily on improving the reading experience for image-based publications. Firstly, we have added support for JXL (JPEG XL) bitmap images, allowing for high-quality images at smaller file sizes. Please note that JXL is decoded natively on iOS 17+.

--- a/.claude/skills/write-release-announcement/references/example-3.8.0.md
+++ b/.claude/skills/write-release-announcement/references/example-3.8.0.md
@@ -46,6 +46,8 @@
 
 We are happy to announce a new update to the Swift toolkit, which focuses on strengthening the security of LCP repositories and improving the reading experience for Fixed-Layout (FXL) EPUBs.
 
+[Browse the full release on GitHub](https://github.com/readium/swift-toolkit/releases/tag/3.8.0)
+
 ### Secure LCP Repositories with Keychain
 
 This version introduces new `LCPKeychainLicenseRepository` and `LCPKeychainPassphraseRepository` implementations backed by the iOS Keychain. This move from a local database to the system Keychain offers several benefits:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,11 +41,11 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          xcodebuild build-for-testing -scheme "$scheme" -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
+          xcodebuild build-for-testing -scheme "$scheme" -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
       - name: Test
         run: |
           set -eo pipefail
-          xcodebuild test-without-building -scheme "$scheme" -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
+          xcodebuild test-without-building -scheme "$scheme" -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
       - name: Print Swift package versions
         run: |
           jq -r '.pins[] | "\(.identity): \(.state.version)"' Package.resolved
@@ -67,7 +67,7 @@ jobs:
   #       run: |
   #         set -eo pipefail
   #         make navigator-ui-tests-project
-  #         xcodebuild test -project Tests/NavigatorTests/UITests/NavigatorUITests.xcodeproj -scheme NavigatorTestHost -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
+  #         xcodebuild test -project Tests/NavigatorTests/UITests/NavigatorUITests.xcodeproj -scheme NavigatorTestHost -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
 
   playground:
     name: Playground
@@ -89,7 +89,7 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          xcodebuild build -scheme Playground -project Playground/Playground.xcodeproj -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
+          xcodebuild build -scheme Playground -project Playground/Playground.xcodeproj -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
 
   lint:
     name: Lint
@@ -147,7 +147,7 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
+          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
 
   int-spm:
     name: Integration (Swift Package Manager)
@@ -177,6 +177,6 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device" | if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi
+          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+The Readium Swift toolkit is used to develop reading apps for iOS, with support for EPUB, PDF, audiobooks and comics.
+
+## Testing
+
+- `scripts/test.sh` runs all tests
+- `scripts/test.sh ReadiumSharedTests` runs only the tests for the ReadiumShared package
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/scripts/release-common.sh
+++ b/scripts/release-common.sh
@@ -35,11 +35,11 @@ positional_args() {
 parse_flags() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --dry-run) DRY_RUN=1; shift ;;
-            --skip-git-checks) SKIP_GIT_CHECKS=1; shift ;;
+            --dry-run) DRY_RUN=1 ;;
+            --skip-git-checks) SKIP_GIT_CHECKS=1 ;;
             -*) error "Unknown argument: $1" ;;
-            *) break ;;
         esac
+        shift
     done
 }
 

--- a/scripts/release-prepare.sh
+++ b/scripts/release-prepare.sh
@@ -48,8 +48,9 @@ check_semver "$OLD_VERSION"
 info "Preparing release $OLD_VERSION → $VERSION"
 
 # Branch
-info "Creating branch '$VERSION'"
-git -C "$REPO_ROOT" checkout -b "$VERSION"
+BRANCH="release-$VERSION"
+info "Creating branch '$BRANCH'"
+git -C "$REPO_ROOT" checkout -b "$BRANCH"
 
 # Support/CocoaPods/Specs.swift
 info "Bumping version in Specs.swift"
@@ -90,12 +91,12 @@ else
 fi
 
 # Push + PR
-info "Pushing branch '$VERSION'"
+info "Pushing branch '$BRANCH'"
 if [[ $DRY_RUN -eq 1 ]]; then
-    dry_skip "git push -u origin $VERSION"
+    dry_skip "git push -u origin $BRANCH"
     dry_skip "gh pr create --base develop --title \"$VERSION\" --body \"\""
 else
-    git -C "$REPO_ROOT" push -u origin "$VERSION"
+    git -C "$REPO_ROOT" push -u origin "$BRANCH"
     PR_URL="$(gh pr create --base develop --title "$VERSION" --body "" | tail -1)"
     open "$PR_URL"
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test.sh [FILTER]
+# =============================================================================
+# Run the test suite.
+#
+# FILTER - Optional target to run (e.g. ReadiumSharedTests)
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DESTINATION="platform=iOS Simulator,name=iPad (A16)"
+FILTER="${1:-}"
+
+ARGS=(
+    -project "$REPO_ROOT/TestApp/TestApp.xcodeproj"
+    -scheme TestApp
+    -testPlan TestApp
+    -destination "$DESTINATION"
+)
+[ -n "$FILTER" ] && ARGS+=(-only-testing:"$FILTER")
+
+xcodebuild test "${ARGS[@]}" 2> /dev/null | xcbeautify --quieter --disable-logging | grep -Ev "^Executed |Test Suite 'All tests'|Test run started\.|Test session results:"; true


### PR DESCRIPTION
- Switches CI log formatting from `xcpretty` to `xcbeautify --renderer github-actions`.
- Adds an `AGENTS.md`/`CLAUDE.md` and a `scripts/test.sh` helper for running the suite.
- Hardens the release scripts: `parse_flags` now accepts flags and the version argument in any order, and the release branch is created as `release-$VERSION` to avoid clashing with the release tag.
- Refines the changelog and release-announcement skills.