### PR TITLE
Fix fonts declared with fontFamilyDeclarations never loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 * Fixed custom `EditingAction`s sometimes missing from the text-selection menu for double-tap (single word) selections (contributed by [@raphi011](https://github.com/readium/swift-toolkit/pull/822)).
 * Fixed memory leak in the `AudioNavigator`.
-* [#802](https://github.com/readium/swift-toolkit/issues/802) Fixed fonts declared with `fontFamilyDeclarations` never loading in the EPUB navigator: font files are served from a different origin than the publication and, unlike other resources, font fetches are CORS-gated by WebKit.
+* [#802](https://github.com/readium/swift-toolkit/issues/802) Fixed fonts declared with `fontFamilyDeclarations` never loading in the EPUB navigator. Font fetches were CORS-gated by WebKit (contributed by [@atani](https://github.com/readium/swift-toolkit/pull/845)).
 
 
 ## [3.10.0] - 2026-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 * Fixed custom `EditingAction`s sometimes missing from the text-selection menu for double-tap (single word) selections (contributed by [@raphi011](https://github.com/readium/swift-toolkit/pull/822)).
 * Fixed memory leak in the `AudioNavigator`.
+* [#802](https://github.com/readium/swift-toolkit/issues/802) Fixed fonts declared with `fontFamilyDeclarations` never loading in the EPUB navigator: font files are served from a different origin than the publication and, unlike other resources, font fetches are CORS-gated by WebKit.
 
 
 ## [3.10.0] - 2026-06-24

--- a/Sources/Navigator/EPUB/WebViewServer.swift
+++ b/Sources/Navigator/EPUB/WebViewServer.swift
@@ -151,7 +151,7 @@ import WebKit
                 guard route.baseURL.isEquivalentTo(requestURL) else {
                     continue
                 }
-                await serveFile(urlSchemeTask, at: file, requestURL: requestURL)
+                await serveFile(urlSchemeTask, at: file, requestURL: requestURL, allowCrossOrigin: true)
                 return
 
             case let .directory(directory):
@@ -162,7 +162,7 @@ import WebKit
                 else {
                     continue
                 }
-                await serveFile(urlSchemeTask, at: file, requestURL: requestURL)
+                await serveFile(urlSchemeTask, at: file, requestURL: requestURL, allowCrossOrigin: true)
                 return
 
             case let .resources(handler):
@@ -216,16 +216,22 @@ import WebKit
     }
 
     /// Reads a local file and sends it as a response.
+    ///
+    /// Local files are served for the static assets routes (Readium assets
+    /// and font files), which publication documents load cross-origin —
+    /// hence `allowCrossOrigin`.
     private func serveFile(
         _ urlSchemeTask: WKURLSchemeTask,
         at file: FileURL,
-        requestURL: URL
+        requestURL: URL,
+        allowCrossOrigin: Bool
     ) async {
         await serveResource(
             FileResource(file: file),
             with: urlSchemeTask,
             mediaType: mediaTypeFromURL(file),
-            requestURL: requestURL
+            requestURL: requestURL,
+            allowCrossOrigin: allowCrossOrigin
         )
     }
 
@@ -233,7 +239,8 @@ import WebKit
         _ resource: Resource,
         with urlSchemeTask: WKURLSchemeTask,
         mediaType: MediaType?,
-        requestURL: URL
+        requestURL: URL,
+        allowCrossOrigin: Bool = false
     ) async {
         // Try to serve a byte range if the client requested one and the
         // resource length is known.
@@ -244,7 +251,7 @@ import WebKit
             let result = await resource.read(range: range)
             switch result {
             case let .success(data):
-                await respond(urlSchemeTask, with: data, range: range, totalLength: totalLength, mediaType: mediaType, url: requestURL)
+                await respond(urlSchemeTask, with: data, range: range, totalLength: totalLength, mediaType: mediaType, url: requestURL, allowCrossOrigin: allowCrossOrigin)
             case let .failure(error):
                 log(.error, "Failed to read resource \(requestURL.path) range \(range): \(error)")
                 await fail(urlSchemeTask, with: URLError(.resourceUnavailable))
@@ -256,7 +263,7 @@ import WebKit
         let result = await resource.read()
         switch result {
         case let .success(data):
-            await respond(urlSchemeTask, with: data, range: nil, totalLength: UInt64(data.count), mediaType: mediaType, url: requestURL)
+            await respond(urlSchemeTask, with: data, range: nil, totalLength: UInt64(data.count), mediaType: mediaType, url: requestURL, allowCrossOrigin: allowCrossOrigin)
         case let .failure(error):
             log(.error, "Failed to read resource \(requestURL.path): \(error)")
             await fail(urlSchemeTask, with: URLError(.resourceUnavailable))
@@ -286,12 +293,24 @@ import WebKit
         range: Range<UInt64>?,
         totalLength: UInt64,
         mediaType: MediaType?,
-        url: URL
+        url: URL,
+        allowCrossOrigin: Bool
     ) async {
         var headers: [String: String] = [
             "Content-Length": "\(data.count)",
             "Accept-Ranges": "bytes",
         ]
+
+        if allowCrossOrigin {
+            // Static assets (e.g. fonts declared with
+            // `fontFamilyDeclarations`) are served under a different origin
+            // than the publication documents referencing them
+            // (readium://assets vs readium://{uuid}). Unlike stylesheets or
+            // images, font fetches are CORS-gated by WebKit, so fonts never
+            // load without this header. Mirrors `allowCors()` in the Kotlin
+            // toolkit's WebViewServer. See issue #802.
+            headers["Access-Control-Allow-Origin"] = "*"
+        }
 
         if let mediaType {
             headers["Content-Type"] = mediaType.string


### PR DESCRIPTION
Fixes #802

## Root cause

Since the switch from the HTTP server to `WKURLSchemeHandler` (#723, 3.8.0):

- Publication pages are served from `readium://{uuid}/…`, while font files are served from `readium://assets/fonts/…` — a different host, hence a different origin.
- `WebViewServer`'s responses carry no `Access-Control-Allow-Origin` header.
- Unlike stylesheets, scripts and images, font fetches are CORS-gated (CSS Fonts spec), so WebKit silently refuses every URL-based `@font-face` source and falls back to the default font. Everything else keeps working, which makes the failure easy to miss.

This matches the original report that <= 3.7.0 (GCDWebServer, single HTTP origin) worked, and it reproduces with the toolkit's own preloaded OpenDyslexic as well as custom declarations. More details in https://github.com/readium/swift-toolkit/issues/802#issuecomment-4898183921

## Fix

Add `Access-Control-Allow-Origin: *` to responses for the static asset routes (`serve(file:at:)` / `serve(directory:at:)`) only — publication resources are untouched. This mirrors `allowCors()` in the Kotlin toolkit's `WebViewServer`, which applies the header to its assets branch only.

No preflight concerns: font fetches are safelisted GETs in anonymous mode, and the `readium://` scheme carries no credentials, so `*` passes the CORS check.

## Verification

- Before: on 3.9.0 (iOS 26.5 simulator), a custom `CSSFontFamilyDeclaration` (user-imported .ttf) and the built-in OpenDyslexic both never render; WebKit falls back to the default font.
- After: with this branch swapped in via a local package override in a real reader app, the same URL-based declaration renders correctly.
- Control experiment: embedding the same font bytes as a `data:` URI (no cross-origin fetch, same injection point) renders correctly on unpatched 3.9.0, isolating the failure to the cross-origin fetch.

`xcodebuild build -scheme ReadiumNavigator` succeeds. `WebViewServer` has no existing unit tests to extend.
