### PR TITLE
Fix poorly-authored EPUB links not navigating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Fixed
 
+#### Shared
+
+* EPUB HREFs that are not percent-encoded but carry a fragment or query (e.g. `chapter one.xhtml#section`, with a space in the filename) now keep their `#fragment`/`?query` instead of encoding the separators into the path. This fixes table of contents and Media Overlays links failing to resolve and navigate in poorly-authored EPUBs.
+
 #### Navigator
 
 * Fixed custom `EditingAction`s sometimes missing from the text-selection menu for double-tap (single word) selections (contributed by [@raphi011](https://github.com/readium/swift-toolkit/pull/822)).

--- a/Sources/Shared/Publication/Link.swift
+++ b/Sources/Shared/Publication/Link.swift
@@ -224,15 +224,26 @@ public extension [Link] {
     }
 
     /// Finds the first link matching the given HREF.
+    ///
+    /// Falls back to ignoring the query and fragment of `href`, to stay
+    /// consistent with `Manifest.linkWithHREF`.
     func firstWithHREF<T: URLConvertible>(_ href: T) -> Link? {
-        let href = href.anyURL.normalized.string
-        return first { $0.url().normalized.string == href }
+        firstIndexWithHREF(href).map { self[$0] }
     }
 
     /// Finds the index of the first link matching the given HREF.
+    ///
+    /// Falls back to ignoring the query and fragment of `href`, to stay
+    /// consistent with `Manifest.linkWithHREF`.
     func firstIndexWithHREF<T: URLConvertible>(_ href: T) -> Int? {
-        let href = href.anyURL.normalized.string
-        return firstIndex { $0.url().normalized.string == href }
+        let href = href.anyURL.normalized
+
+        func index(matchingHREF href: String) -> Int? {
+            firstIndex { $0.url().normalized.string == href }
+        }
+
+        return index(matchingHREF: href.string)
+            ?? index(matchingHREF: href.removingQuery().removingFragment().string)
     }
 
     /// Finds the first link matching the given media type.

--- a/Sources/Shared/Toolkit/URL/RelativeURL.swift
+++ b/Sources/Shared/Toolkit/URL/RelativeURL.swift
@@ -137,10 +137,37 @@ public extension RelativeURL {
     ///
     /// As a workaround, we assume the HREFs are valid percent-encoded URLs,
     /// and fallback to decoded paths if we can't parse the URL.
+    ///
+    /// When falling back to a decoded path, only the path portion is
+    /// percent-encoded: any `?query` and `#fragment` are split off and
+    /// reattached verbatim. This keeps their `?`/`#` separators intact (a plain
+    /// path encoding would turn them into `%3F`/`%23`) and preserves any
+    /// existing encoding in the query or fragment instead of double-encoding it.
     init?(epubHREF: String) {
-        guard let uri = RelativeURL(string: epubHREF) ?? RelativeURL(path: epubHREF) else {
+        // A well-formed HREF is already a valid percent-encoded URL.
+        if let url = RelativeURL(string: epubHREF) {
+            self = url
+            return
+        }
+
+        // Otherwise the HREF is not a valid URL (e.g. a decoded path containing
+        // spaces). Split off the query and fragment, encode only the path, then
+        // reassemble. The fragment is split first so that a `?` occurring inside
+        // a fragment is not mistaken for a query separator.
+        var pathPart = epubHREF
+        var suffix = ""
+        if let hashIndex = pathPart.firstIndex(of: "#") {
+            suffix = String(pathPart[hashIndex...])
+            pathPart = String(pathPart[..<hashIndex])
+        }
+        if let queryIndex = pathPart.firstIndex(of: "?") {
+            suffix = pathPart[queryIndex...] + suffix
+            pathPart = String(pathPart[..<queryIndex])
+        }
+
+        guard let pathURL = RelativeURL(path: pathPart) else {
             return nil
         }
-        self = uri
+        self = RelativeURL(string: pathURL.string + suffix) ?? pathURL
     }
 }

--- a/Tests/SharedTests/Publication/LinkArrayTests.swift
+++ b/Tests/SharedTests/Publication/LinkArrayTests.swift
@@ -82,6 +82,29 @@ class LinkArrayTests: XCTestCase {
         XCTAssertNil(try links.firstIndexWithHREF(XCTUnwrap(AnyURL(string: "unknown"))))
     }
 
+    /// Falls back to ignoring the query and fragment when no exact match is
+    /// found, consistent with `Manifest.linkWithHREF`.
+    func testFirstWithHREFIgnoringQueryAndFragment() throws {
+        let links = [Link(href: "l1"), Link(href: "l2")]
+
+        XCTAssertEqual(try links.firstWithHREF(XCTUnwrap(AnyURL(string: "l2#fragment"))), Link(href: "l2"))
+        XCTAssertEqual(try links.firstWithHREF(XCTUnwrap(AnyURL(string: "l2?query=1"))), Link(href: "l2"))
+        XCTAssertEqual(try links.firstWithHREF(XCTUnwrap(AnyURL(string: "l2?query=1#fragment"))), Link(href: "l2"))
+    }
+
+    /// An exact match takes precedence over the query/fragment-stripped fallback.
+    func testFirstWithHREFPrefersExactMatch() throws {
+        let links = [Link(href: "l2"), Link(href: "l2?query=1")]
+        XCTAssertEqual(try links.firstIndexWithHREF(XCTUnwrap(AnyURL(string: "l2?query=1"))), 1)
+    }
+
+    func testFirstIndexWithHREFIgnoringQueryAndFragment() throws {
+        let links = [Link(href: "l1"), Link(href: "l2")]
+
+        XCTAssertEqual(try links.firstIndexWithHREF(XCTUnwrap(AnyURL(string: "l2#fragment"))), 1)
+        XCTAssertEqual(try links.firstIndexWithHREF(XCTUnwrap(AnyURL(string: "l2?query=1#fragment"))), 1)
+    }
+
     /// Finds the first `Link` with a `type` matching the given `mediaType`.
     func testFirstWithMediaType() {
         let links = [

--- a/Tests/SharedTests/Toolkit/URL/RelativeURLTests.swift
+++ b/Tests/SharedTests/Toolkit/URL/RelativeURLTests.swift
@@ -245,4 +245,56 @@ enum RelativeURLTests {
             #expect(try base.relativize(#require(FileURL(string: "file:///foo"))) == nil)
         }
     }
+
+    struct EPUBHREF {
+        @Test("valid percent-encoded HREFs are used as-is")
+        func validHREFs() {
+            #expect(RelativeURL(epubHREF: "dir/chapter.xhtml")?.string == "dir/chapter.xhtml")
+            #expect(RelativeURL(epubHREF: "dir/chapter.xhtml#frag")?.string == "dir/chapter.xhtml#frag")
+            #expect(RelativeURL(epubHREF: "dir/chapter.xhtml?q=1#frag")?.string == "dir/chapter.xhtml?q=1#frag")
+            // Already-encoded characters are not re-encoded.
+            #expect(RelativeURL(epubHREF: "dir/chapter%20one.xhtml#frag")?.string == "dir/chapter%20one.xhtml#frag")
+        }
+
+        @Test("decoded paths without separators are percent-encoded")
+        func decodedPaths() {
+            #expect(RelativeURL(epubHREF: "dir/chapter one.xhtml")?.string == "dir/chapter%20one.xhtml")
+            #expect(RelativeURL(epubHREF: "/dir/chapter one.xhtml")?.string == "/dir/chapter%20one.xhtml")
+        }
+
+        @Test("returns nil for an empty HREF")
+        func emptyHREF() {
+            #expect(RelativeURL(epubHREF: "") == nil)
+        }
+
+        /// When an HREF's path is not percent-encoded, only the path is encoded
+        /// while the `?query` and `#fragment` — and their separators — are
+        /// preserved verbatim.
+        struct PathOnlyEncoding {
+            @Test("the fragment separator is preserved")
+            func withFragment() {
+                #expect(
+                    RelativeURL(epubHREF: "../content/Harry Potter 1.xhtml#fragment-01")?.string
+                        == "../content/Harry%20Potter%201.xhtml#fragment-01"
+                )
+                #expect(RelativeURL(epubHREF: "/dir/my file.xhtml#frag")?.string == "/dir/my%20file.xhtml#frag")
+            }
+
+            @Test("the query separator is preserved")
+            func withQuery() {
+                #expect(RelativeURL(epubHREF: "dir/my file.xhtml?q=1")?.string == "dir/my%20file.xhtml?q=1")
+                #expect(RelativeURL(epubHREF: "dir/my file.xhtml?q=1#frag")?.string == "dir/my%20file.xhtml?q=1#frag")
+            }
+
+            @Test("an already-encoded fragment is not double-encoded")
+            func encodedFragmentIsPreserved() {
+                #expect(RelativeURL(epubHREF: "hello world#properly%20encoded")?.string == "hello%20world#properly%20encoded")
+            }
+
+            @Test("a question mark inside the fragment is kept in the fragment")
+            func questionMarkInFragment() {
+                #expect(RelativeURL(epubHREF: "dir/a b.xhtml#f?x")?.string == "dir/a%20b.xhtml#f?x")
+            }
+        }
+    }
 }

--- a/Tests/StreamerTests/Fixtures/Navigation Documents/nav-unencoded.ncx
+++ b/Tests/StreamerTests/Fixtures/Navigation Documents/nav-unencoded.ncx
@@ -1,0 +1,23 @@
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+  <docTitle>
+    <text>Document Title</text>
+  </docTitle>
+
+  <!-- `src` values are NOT percent-encoded (they contain spaces) yet carry
+       URI fragments and queries. Readium must keep the `#`/`?` as separators
+       instead of encoding them into the path. -->
+  <navMap>
+    <navPoint>
+      <navLabel><text>Chapter 1</text></navLabel>
+      <content src="content/chapter one 1.xhtml#fragment-01"/>
+    </navPoint>
+    <navPoint>
+      <navLabel><text>Chapter 2</text></navLabel>
+      <content src="content/chapter two 2.xhtml?title=intro#fragment-02"/>
+    </navPoint>
+    <navPoint>
+      <navLabel><text>Chapter 1, again</text></navLabel>
+      <content src="../content/chapter one 1.xhtml#fragment-03"/>
+    </navPoint>
+  </navMap>
+</ncx>

--- a/Tests/StreamerTests/Fixtures/Navigation Documents/nav-unencoded.xhtml
+++ b/Tests/StreamerTests/Fixtures/Navigation Documents/nav-unencoded.xhtml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head>
+  <meta charset="utf-8" />
+</head>
+<body>
+  <!-- HREFs are NOT percent-encoded (they contain spaces) yet carry URI
+       fragments and queries. Poorly authored EPUBs like this exist in the
+       wild, so Readium must keep the `#`/`?` as separators instead of
+       encoding them into the path. -->
+  <nav epub:type="toc">
+    <h2>Table of Contents</h2>
+    <ol>
+      <li><a href="content/chapter one 1.xhtml#fragment-01">Chapter 1</a></li>
+      <li><a href="content/chapter two 2.xhtml?title=intro#fragment-02">Chapter 2</a></li>
+      <li><a href="../content/chapter one 1.xhtml#fragment-03">Chapter 1, again</a></li>
+    </ol>
+  </nav>
+</body>
+</html>

--- a/Tests/StreamerTests/Fixtures/SMIL/seq-textref-unencoded.smil
+++ b/Tests/StreamerTests/Fixtures/SMIL/seq-textref-unencoded.smil
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<smil xmlns="http://www.w3.org/ns/SMIL" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0">
+  <body>
+    <!-- The textref and text src are NOT percent-encoded (they contain spaces)
+         yet carry a URI fragment. This reproduces Media Overlays authored by
+         Storyteller. The `#` must be kept as a fragment separator, not encoded
+         into the path. -->
+    <seq id="s1" epub:textref="../content/chapter one 1.xhtml#fragment-01" epub:type="chapter">
+      <par id="p1"><text src="../content/chapter one 1.xhtml#fragment-01"/></par>
+    </seq>
+  </body>
+</smil>

--- a/Tests/StreamerTests/Parser/EPUB/NCXParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/NCXParserTests.swift
@@ -6,16 +6,16 @@
 
 import ReadiumShared
 @testable import ReadiumStreamer
-import XCTest
+import Testing
 
-class NCXParserTests: XCTestCase {
+struct NCXParserTests {
     let fixtures = Fixtures(path: "Navigation Documents")
 
-    func testParseTOC() {
+    @Test func parseTOC() {
         let document = parseNCX("nav")
         let sut = document.links(for: .tableOfContents)
 
-        XCTAssertEqual(sut, [
+        #expect(sut == [
             Link(href: "/base/ch1.xhtml", title: "Chapter 1"),
             Link(href: "/base/ch2.xhtml", title: "Chapter 2"),
             Link(href: "#", title: "Unlinked section with nested HTML elements", children: [
@@ -28,21 +28,35 @@ class NCXParserTests: XCTestCase {
         ])
     }
 
-    func testParsePageList() {
+    @Test func parsePageList() {
         let document = parseNCX("nav")
         let sut = document.links(for: .pageList)
 
-        XCTAssertEqual(sut, [
+        #expect(sut == [
             Link(href: "/base/ch1.xhtml#page1", title: "1"),
             Link(href: "/base/ch1.xhtml#page2", title: "2"),
         ])
     }
 
-    func testParseNotFound() {
+    @Test func parseNotFound() {
         let document = parseNCX("nav-empty")
         let sut = document.links(for: .tableOfContents)
 
-        XCTAssertEqual(sut, [])
+        #expect(sut == [])
+    }
+
+    /// `src` values that are not percent-encoded (they contain spaces) but
+    /// carry URI fragments and queries must keep the `#`/`?` as separators
+    /// instead of encoding them into the path.
+    @Test func parseTOCWithUnencodedHREFs() {
+        let document = parseNCX("nav-unencoded")
+        let sut = document.links(for: .tableOfContents)
+
+        #expect(sut == [
+            Link(href: "/base/content/chapter%20one%201.xhtml#fragment-01", title: "Chapter 1"),
+            Link(href: "/base/content/chapter%20two%202.xhtml?title=intro#fragment-02", title: "Chapter 2"),
+            Link(href: "/content/chapter%20one%201.xhtml#fragment-03", title: "Chapter 1, again"),
+        ])
     }
 
     // MARK: - Toolkit

--- a/Tests/StreamerTests/Parser/EPUB/NavigationDocumentParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/NavigationDocumentParserTests.swift
@@ -6,16 +6,16 @@
 
 import ReadiumShared
 @testable import ReadiumStreamer
-import XCTest
+import Testing
 
-class NavigationDocumentParserTests: XCTestCase {
+struct NavigationDocumentParserTests {
     let fixtures = Fixtures(path: "Navigation Documents")
 
-    func testParseTOC() {
+    @Test func parseTOC() {
         let document = parseNavDocument("nav")
         let sut = document.links(for: .tableOfContents)
 
-        XCTAssertEqual(sut, [
+        #expect(sut == [
             Link(href: "/base/ch1.xhtml", title: "Chapter 1"),
             Link(href: "/base/ch2.xhtml", title: "Chapter 2"),
             Link(href: "#", title: "Unlinked section with nested HTML elements", children: [
@@ -28,43 +28,59 @@ class NavigationDocumentParserTests: XCTestCase {
         ])
     }
 
-    func testParseLandmarks() {
+    @Test func parseLandmarks() {
         let document = parseNavDocument("nav")
         let sut = document.links(for: .landmarks)
 
-        XCTAssertEqual(sut, [
+        #expect(sut == [
             Link(href: "/base/nav.xhtml#toc", title: "Table of Contents", rel: .contents),
             Link(href: "/base/ch1.xhtml", title: "Begin Reading", rel: .start),
         ])
     }
 
-    func testParseNotFound() {
+    @Test func parseNotFound() {
         let document = parseNavDocument("nav")
         let sut = document.links(for: .listOfVideos)
 
-        XCTAssertEqual(sut, [])
+        #expect(sut == [])
     }
 
-    func testParseTOCWithSection() {
+    @Test func parseTOCWithSection() {
         let document = parseNavDocument("nav-section")
         let sut = document.links(for: .tableOfContents)
 
-        XCTAssertEqual(sut, [
+        #expect(sut == [
             Link(href: "/base/ch1.xhtml", title: "Chapter 1"),
             Link(href: "/base/ch2.xhtml", title: "Chapter 2"),
         ])
     }
 
-    func testParseLandmarksWithSection() {
+    @Test func parseLandmarksWithSection() {
         let document = parseNavDocument("nav-section")
         let sut = document.links(for: .landmarks)
 
-        XCTAssertEqual(sut, [
+        #expect(sut == [
             Link(href: "/base/cover.xhtml", title: "Cover", rel: .cover),
             Link(href: "/base/nav.xhtml#toc", title: "Table of Contents", rel: .contents),
             Link(href: "/base/ch1.xhtml", title: "Begin Reading", rel: .start),
             Link(href: "/base/index.xhtml", title: "Index", rel: "http://idpf.org/epub/vocab/structure/#index"),
             Link(href: "/base/glossary.xhtml", title: "Glossary", rel: "http://idpf.org/epub/vocab/structure/#glossary"),
+        ])
+    }
+
+    /// HREFs that are not percent-encoded (they contain spaces) but carry URI
+    /// fragments and queries must keep the `#`/`?` as separators instead of
+    /// encoding them into the path.
+    ///
+    /// See https://github.com/readium/swift-toolkit non-encoded HREF workaround.
+    @Test func parseTOCWithUnencodedHREFs() {
+        let document = parseNavDocument("nav-unencoded")
+        let sut = document.links(for: .tableOfContents)
+
+        #expect(sut == [
+            Link(href: "/base/content/chapter%20one%201.xhtml#fragment-01", title: "Chapter 1"),
+            Link(href: "/base/content/chapter%20two%202.xhtml?title=intro#fragment-02", title: "Chapter 2"),
+            Link(href: "/content/chapter%20one%201.xhtml#fragment-03", title: "Chapter 1, again"),
         ])
     }
 

--- a/Tests/StreamerTests/Parser/EPUB/NavigationDocumentParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/NavigationDocumentParserTests.swift
@@ -71,8 +71,6 @@ struct NavigationDocumentParserTests {
     /// HREFs that are not percent-encoded (they contain spaces) but carry URI
     /// fragments and queries must keep the `#`/`?` as separators instead of
     /// encoding them into the path.
-    ///
-    /// See https://github.com/readium/swift-toolkit non-encoded HREF workaround.
     @Test func parseTOCWithUnencodedHREFs() {
         let document = parseNavDocument("nav-unencoded")
         let sut = document.links(for: .tableOfContents)

--- a/Tests/StreamerTests/Parser/EPUB/SMIL/SMILParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/SMIL/SMILParserTests.swift
@@ -176,6 +176,17 @@ enum SMILParserTests {
             #expect(s2?.refs?.text == AnyURL(string: "OEBPS/chapter01.xhtml#sec1"))
         }
 
+        /// `textref`/`src` values that are not percent-encoded (they contain
+        /// spaces) but carry a URI fragment must keep the `#` as a fragment
+        /// separator instead of encoding it into the path.
+        @Test func seqWithUnencodedTextref() throws {
+            let doc = try SMILParserTests.parse("seq-textref-unencoded.smil")
+            let s1 = doc?.guided.first { $0.id == "s1" }
+            #expect(s1?.refs?.text == AnyURL(string: "content/chapter%20one%201.xhtml#fragment-01"))
+            let p1 = s1?.children.first
+            #expect(p1?.refs?.text == AnyURL(string: "content/chapter%20one%201.xhtml#fragment-01"))
+        }
+
         @Test func emptySeqIsSkipped() throws {
             let doc = try SMILParserTests.parse("empty-seq.smil")
             // The empty seq must be dropped; only s-valid survives.


### PR DESCRIPTION
### Fixed

#### Shared

* EPUB HREFs that are not percent-encoded but carry a fragment or query (e.g. `chapter one.xhtml#section`, with a space in the filename) now keep their `#fragment`/`?query` instead of encoding the separators into the path. This fixes table of contents and Media Overlays links failing to resolve and navigate in poorly-authored EPUBs.

---

Here's a sample EPUB that can be used to reproduce the issue: 
[unencoded-hrefs.epub.zip](https://github.com/user-attachments/files/29794898/unencoded-hrefs.epub.zip)
