### PR TITLE
Add opt-in synthetic font weight for fonts without bold faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 ### Added
 
+#### Navigator
+
+* [#853](https://github.com/readium/swift-toolkit/issues/853) Added an opt-in `fontWeightSynthesis` EPUB preference. When enabled, `fontWeight` values above 1.0 synthesize a heavier weight using an em-based text stroke, which restores the effect of `fontWeight` for single-face fonts (e.g. custom fonts declared with `fontFamilyDeclarations`) that WebKit cannot bolden on its own. Disabled by default, so existing apps are unaffected.
+
 #### LCP
 
 * `LCPService` has a new `addPassphrase(_:isHashed:userID:provider:)` method to store a passphrase candidate in the repository without opening a license first. Useful to preload a passphrase ahead of time (e.g. from a catalog).

--- a/Sources/Navigator/EPUB/CSS/ReadiumCSS.swift
+++ b/Sources/Navigator/EPUB/CSS/ReadiumCSS.swift
@@ -69,6 +69,22 @@ extension ReadiumCSS {
                 "font-weight": settings.fontWeight
                     .map { String(format: "%.0f", (Double(CSSStandardFontWeight.normal.rawValue) * $0).clamped(to: 1 ... 1000)) }
                     ?? "",
+                // Gradual synthetic bolding for fonts that lack a bold face
+                // (e.g. single-face custom fonts, which WebKit does not
+                // synthesize bolding for). Opt-in through `fontWeightSynthesis`.
+                // The stroke width is expressed in `em` so it tracks the font
+                // size, and we only thicken (weight > 1.0) because a stroke can
+                // add to glyph outlines but cannot thin them. No stroke color is
+                // emitted on purpose: `-webkit-text-stroke-color` defaults to
+                // `currentColor`, which matches the text color across all themes.
+                // An empty value clears any previously applied stroke on live
+                // settings changes, matching the "font-weight" entry above.
+                "-webkit-text-stroke-width": {
+                    guard settings.fontWeightSynthesis, let weight = settings.fontWeight, weight > 1.0 else {
+                        return ""
+                    }
+                    return String(format: "%.4fem", (min(weight, 2.5) - 1.0) / 1.5 * 0.035)
+                }(),
             ]
         )
     }

--- a/Sources/Navigator/EPUB/Preferences/EPUBPreferences.swift
+++ b/Sources/Navigator/EPUB/Preferences/EPUBPreferences.swift
@@ -34,6 +34,13 @@ public struct EPUBPreferences: ConfigurablePreferences {
     /// Default boldness for the text.
     public var fontWeight: Double?
 
+    /// Synthesize a heavier weight for fonts that lack a bold face.
+    ///
+    /// Opt-in. When enabled, `fontWeight` values above 1.0 thicken glyphs
+    /// using a text stroke, which is useful for single-face custom fonts that
+    /// WebKit cannot synthesize bolding for.
+    public var fontWeightSynthesis: Bool?
+
     /// Enable hyphenation.
     public var hyphens: Bool?
 
@@ -114,6 +121,7 @@ public struct EPUBPreferences: ConfigurablePreferences {
         fontFamily: FontFamily? = nil,
         fontSize: Double? = nil,
         fontWeight: Double? = nil,
+        fontWeightSynthesis: Bool? = nil,
         hyphens: Bool? = nil,
         imageFilter: ImageFilter? = nil,
         language: Language? = nil,
@@ -142,6 +150,7 @@ public struct EPUBPreferences: ConfigurablePreferences {
         self.fontFamily = fontFamily
         self.fontSize = fontSize.map { max($0, 0) }
         self.fontWeight = fontWeight?.clamped(to: 0.0 ... 2.5)
+        self.fontWeightSynthesis = fontWeightSynthesis
         self.hyphens = hyphens
         self.imageFilter = imageFilter
         self.language = language
@@ -173,6 +182,7 @@ public struct EPUBPreferences: ConfigurablePreferences {
             fontFamily: other.fontFamily ?? fontFamily,
             fontSize: other.fontSize ?? fontSize,
             fontWeight: other.fontWeight ?? fontWeight,
+            fontWeightSynthesis: other.fontWeightSynthesis ?? fontWeightSynthesis,
             hyphens: other.hyphens ?? hyphens,
             imageFilter: other.imageFilter ?? imageFilter,
             language: other.language ?? language,

--- a/Sources/Navigator/EPUB/Preferences/EPUBPreferencesEditor.swift
+++ b/Sources/Navigator/EPUB/Preferences/EPUBPreferencesEditor.swift
@@ -124,6 +124,21 @@ public final class EPUBPreferencesEditor: StatefulPreferencesEditor<EPUBPreferen
             format: \.percentageString
         )
 
+    /// Synthesize a heavier weight for fonts that lack a bold face.
+    ///
+    /// Opt-in and off by default. When enabled, `fontWeight` values above 1.0
+    /// thicken glyphs using a text stroke, which is useful for single-face
+    /// custom fonts that WebKit cannot synthesize bolding for.
+    ///
+    /// Only effective with reflowable publications.
+    public lazy var fontWeightSynthesis: AnyPreference<Bool> =
+        preference(
+            preference: \.fontWeightSynthesis,
+            setting: \.fontWeightSynthesis,
+            defaultEffectiveValue: defaults.fontWeightSynthesis ?? false,
+            isEffective: { [layout] _ in layout == .reflowable }
+        )
+
     /// Enable hyphenation for latin languages.
     ///
     /// Only effective when:

--- a/Sources/Navigator/EPUB/Preferences/EPUBSettings.swift
+++ b/Sources/Navigator/EPUB/Preferences/EPUBSettings.swift
@@ -17,6 +17,7 @@ public struct EPUBSettings: ConfigurableSettings {
     public var fontFamily: FontFamily?
     public var fontSize: Double
     public var fontWeight: Double?
+    public var fontWeightSynthesis: Bool
     public var hyphens: Bool?
     public var imageFilter: ImageFilter?
     public var language: Language?
@@ -52,6 +53,7 @@ public struct EPUBSettings: ConfigurableSettings {
         fontFamily: FontFamily?,
         fontSize: Double,
         fontWeight: Double?,
+        fontWeightSynthesis: Bool,
         hyphens: Bool?,
         imageFilter: ImageFilter?,
         language: Language?,
@@ -80,6 +82,7 @@ public struct EPUBSettings: ConfigurableSettings {
         self.fontFamily = fontFamily
         self.fontSize = fontSize
         self.fontWeight = fontWeight
+        self.fontWeightSynthesis = fontWeightSynthesis
         self.hyphens = hyphens
         self.imageFilter = imageFilter
         self.language = language
@@ -154,6 +157,9 @@ public struct EPUBSettings: ConfigurableSettings {
                 ?? 1.0,
             fontWeight: preferences.fontWeight
                 ?? defaults.fontWeight,
+            fontWeightSynthesis: preferences.fontWeightSynthesis
+                ?? defaults.fontWeightSynthesis
+                ?? false,
             hyphens: preferences.hyphens
                 ?? defaults.hyphens,
             imageFilter: preferences.imageFilter
@@ -210,6 +216,7 @@ public struct EPUBDefaults {
     public var fit: Fit?
     public var fontSize: Double?
     public var fontWeight: Double?
+    public var fontWeightSynthesis: Bool?
     public var hyphens: Bool?
     public var imageFilter: ImageFilter?
     public var language: Language?
@@ -234,6 +241,7 @@ public struct EPUBDefaults {
         fit: Fit? = nil,
         fontSize: Double? = nil,
         fontWeight: Double? = nil,
+        fontWeightSynthesis: Bool? = nil,
         hyphens: Bool? = nil,
         imageFilter: ImageFilter? = nil,
         language: Language? = nil,
@@ -257,6 +265,7 @@ public struct EPUBDefaults {
         self.fit = fit
         self.fontSize = fontSize
         self.fontWeight = fontWeight
+        self.fontWeightSynthesis = fontWeightSynthesis
         self.hyphens = hyphens
         self.imageFilter = imageFilter
         self.language = language

--- a/Tests/NavigatorTests/EPUB/CSS/ReadiumCSSTests.swift
+++ b/Tests/NavigatorTests/EPUB/CSS/ReadiumCSSTests.swift
@@ -385,4 +385,44 @@ class ReadiumCSSTests: XCTestCase {
             """
         )
     }
+
+    // MARK: - Synthetic font weight
+
+    /// Resolves the `-webkit-text-stroke-width` override produced by
+    /// `update(with:)` for the given font weight and synthesis preferences.
+    private func syntheticStrokeWidth(fontWeight: Double?, synthesis: Bool?) -> String? {
+        let settings = EPUBSettings(
+            preferences: EPUBPreferences(fontWeight: fontWeight, fontWeightSynthesis: synthesis),
+            defaults: EPUBDefaults(),
+            metadata: Metadata(title: "Fake title")
+        )
+        var css = ReadiumCSS(baseURL: baseURL)
+        css.update(with: settings)
+        return css.userProperties.overrides["-webkit-text-stroke-width"] ?? nil
+    }
+
+    func testNoSyntheticStrokeWhenSynthesisIsOff() {
+        XCTAssertEqual(syntheticStrokeWidth(fontWeight: 1.75, synthesis: nil), "")
+        XCTAssertEqual(syntheticStrokeWidth(fontWeight: 1.75, synthesis: false), "")
+    }
+
+    func testNoSyntheticStrokeWhenWeightIsNotSet() {
+        XCTAssertEqual(syntheticStrokeWidth(fontWeight: nil, synthesis: true), "")
+    }
+
+    func testNoSyntheticStrokeWhenWeightIsNormalOrLighter() {
+        XCTAssertEqual(syntheticStrokeWidth(fontWeight: 1.0, synthesis: true), "")
+        XCTAssertEqual(syntheticStrokeWidth(fontWeight: 0.5, synthesis: true), "")
+    }
+
+    func testSyntheticStrokeScalesWithWeight() {
+        XCTAssertEqual(syntheticStrokeWidth(fontWeight: 1.75, synthesis: true), "0.0175em")
+        XCTAssertEqual(syntheticStrokeWidth(fontWeight: 2.5, synthesis: true), "0.0350em")
+    }
+
+    func testSyntheticStrokeIsClampedAboveRange() {
+        // `fontWeight` is clamped to a maximum of 2.5, so an out-of-range weight
+        // produces the same stroke as the maximum weight.
+        XCTAssertEqual(syntheticStrokeWidth(fontWeight: 3.0, synthesis: true), "0.0350em")
+    }
 }


### PR DESCRIPTION
Fixes readium/css#239.

## Problem

`EPUBPreferences.fontWeight` maps to a CSS `font-weight` override injected into the page. WebKit can only apply a heavier weight when the font actually ships a bold face. For single-face fonts — most notably custom fonts declared through `fontFamilyDeclarations` — WebKit does not synthesize bolding, so `fontWeight` has no visible effect. Rendering the same passage at `fontWeight` 1.0 and 1.5 with a single-face font produces pixel-identical output.

This is an engine limitation, so `font-weight` alone cannot fix it. We need a separate channel to thicken glyphs.

## Approach

Add an opt-in `fontWeightSynthesis: Bool` EPUB preference, defaulting to off (`nil` / `false`). When it is enabled and `fontWeight` is greater than 1.0, `ReadiumCSS` emits a `-webkit-text-stroke-width` override alongside the existing `font-weight` entry:

```
(min(fontWeight, 2.5) - 1.0) / 1.5 * 0.035  // em
```

Notes on the design:

- **Opt-in, zero default change.** With the preference off (the default), no stroke is emitted and the output is identical to before, so existing apps are unaffected.
- **`em`-based.** The stroke width scales with the font size instead of being a fixed pixel value.
- **Only thickens.** A text stroke can add to glyph outlines but cannot thin them, so synthesis is limited to weights above 1.0.
- **No stroke color.** `-webkit-text-stroke-color` is intentionally left unset; it defaults to `currentColor`, which tracks the text color across the light, dark and sepia themes.
- **Reuses the existing injection channel.** User properties are injected inline on `<html>` and updated live through `readium.setCSSProperties`. `-webkit-text-stroke` inherits, so applying it on `<html>` covers all text, and an empty value clears it on live settings changes (mirroring the `font-weight` entry). Both call sites handle the new key without changes.

The preference is wired through `EPUBPreferences`, `EPUBSettings`, `EPUBDefaults` and `EPUBPreferencesEditor`, following the exact pattern of `textNormalization`.

## Tests

Added `ReadiumCSSTests` cases covering the `update(with:)` mapping: synthesis off emits no stroke; on with weight not above 1.0 or unset emits none; on with weight 1.75 gives `0.0175em`; on with weight 2.5 gives `0.0350em`; and an out-of-range weight is clamped to the 2.5 result.

## Verification

- `xcodebuild test -scheme Readium-Package -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:ReadiumNavigatorTests` — 110 tests pass, including the 5 new cases.
- `swift run --package-path BuildTools swiftformat --lint .` — clean.
