### PR TITLE
Add contentRuleLists to the EPUB navigator's Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file. Take a look at [the migration guide](docs/Migration%20Guide.md) to upgrade between two major versions.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+#### Navigator
+
+* The EPUB navigator's `Configuration` has a new `contentRuleLists` property. The provided `WKContentRuleList`s are applied to every web view before it loads any content—for example to block external resource loads (tracking pixels, remote fonts) for privacy.
 
 ## [3.11.0] - 2026-07-17
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -96,6 +96,16 @@ open class EPUBNavigatorViewController: InputObservableViewController,
         /// Logs the state changes when true.
         public var debugState: Bool
 
+        /// Content rule lists to apply to every web view created by the navigator.
+        ///
+        /// Each list is added to the web view's `WKUserContentController` before the
+        /// web view is created and loads any content. This lets you, for example,
+        /// block external resource loads (tracking pixels, remote fonts) for privacy,
+        /// without racing the first resource load.
+        ///
+        /// See `WKContentRuleListStore` to compile a rule list from a JSON rule set.
+        public var contentRuleLists: [WKContentRuleList]
+
         public init(
             preferences: EPUBPreferences = .empty,
             defaults: EPUBDefaults = EPUBDefaults(),
@@ -110,7 +120,8 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             decorationTemplates: [Decoration.Style.Id: HTMLDecorationTemplate] = HTMLDecorationTemplate.defaultTemplates(),
             fontFamilyDeclarations: [AnyHTMLFontFamilyDeclaration] = [],
             readiumCSSRSProperties: CSSRSProperties = CSSRSProperties(),
-            debugState: Bool = false
+            debugState: Bool = false,
+            contentRuleLists: [WKContentRuleList] = []
         ) {
             self.preferences = preferences
             self.defaults = defaults
@@ -123,6 +134,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             self.fontFamilyDeclarations = fontFamilyDeclarations
             self.readiumCSSRSProperties = readiumCSSRSProperties
             self.debugState = debugState
+            self.contentRuleLists = contentRuleLists
         }
 
         func contentInset(for sizeClass: UIUserInterfaceSizeClass) -> EPUBContentInsets {

--- a/Sources/Navigator/EPUB/EPUBSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBSpreadView.swift
@@ -81,6 +81,12 @@ class EPUBSpreadView: UIView, Loggable, PageView {
             config.writingToolsBehavior = .none
         }
 
+        // Apply the app-provided content rule lists (e.g. a blocker for external
+        // resources) before the web view is created and starts loading any resource.
+        for ruleList in viewModel.config.contentRuleLists {
+            config.userContentController.add(ruleList)
+        }
+
         webView = WebView(editingActions: viewModel.editingActions, configuration: config)
 
         super.init(frame: .zero)


### PR DESCRIPTION
Adds a `contentRuleLists: [WKContentRuleList]` property to `EPUBNavigatorViewController.Configuration`. Each list is added to the spread web view's `WKUserContentController` in `EPUBSpreadView.init`, before the `WKWebView` is created and before it loads anything. Defaults to `[]` (source-compatible).

## Use case

For a packaged EPUB, all book resources are served in-process through the navigator's `readium://` scheme handler, so any `http(s)` request is necessarily an external one — a tracking pixel, a remote font, an analytics beacon — that leaks the reader's IP. A `WKContentRuleList` compiled from `[{ "trigger": { "url-filter": "^https?://" }, "action": { "type": "block" } }]` blocks those while in-process `readium://` resources are unaffected. Content rule lists apply to sub-frames, so the fixed-layout iframe is covered too.

The list must be installed before the first load. The insertion point is the base `EPUBSpreadView.init`, so it covers both reflowable and fixed-layout spreads (both call `super.init`) and every recreation — preload, chapter change, settings reload, and the spread views rebuilt after a WebKit content-process termination — since `PaginationView` builds them all through the same factory.

## Notes

- Defaults to `[]`, so no behavior change for existing integrators.
- The navigator keeps ownership of the `WKWebViewConfiguration` (scheme handler, `userContentController`, message handlers), so integrators can't accidentally break those invariants.
- Remote publications served from an `http(s)` `baseURL` (`EPUBNavigatorViewModel` uses it directly rather than `readium://`) should scope the rule list to third-party origins (e.g. `unless-top-url` / `if-domain`) rather than blocking all `http(s)`.

## Testing

`ReadiumNavigator` builds for iOS with the change; `swiftformat` reports no changes. Happy to add a UITest under `Tests/NavigatorTests/UITests` if you'd like — `WKUserContentController` doesn't expose its rule lists for a unit assertion, so it needs the WebView-driven host.
