### PR TITLE
Supersede EPUB 2 meta tags with their EPUB 3 equivalents in `otherMetadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ All notable changes to this project will be documented in this file. Take a look
 * The deprecated `ReadiumAdapterGCDWebServer` and `ReadiumAdapterLCPSQLite` adapter packages have been removed.
 * The `ReadiumInternal` package has been removed. Its utilities were internal helpers and are now folded into `ReadiumShared` with `package` visibility. If you imported `ReadiumInternal` directly, remove the import.
 
+### Fixed
+
+#### Streamer
+
+* When an OPF package document declares the same property with both a legacy EPUB 2 `<meta name=>` tag and a structured element (EPUB 3 `<meta property=>` or `<dc:x>`), the structured one now supersedes the legacy one in `otherMetadata`, instead of both values being kept ([#85](https://github.com/readium/swift-toolkit/issues/85)).
+
 
 <!-- ## [Unreleased] -->
 

--- a/Sources/Streamer/Parser/EPUB/OPFMeta.swift
+++ b/Sources/Streamer/Parser/EPUB/OPFMeta.swift
@@ -130,6 +130,20 @@ enum OPFVocabulary: String {
 
 /// Represents a `meta` tag in an OPF document.
 struct OPFMeta {
+    /// Syntax used to express the metadata in the OPF document.
+    ///
+    /// Note that `<dc:x>` elements are valid in EPUB 2 as well, so this doesn't strictly
+    /// distinguish EPUB versions. A legacy meta is superseded by a structured element with the
+    /// same property, even in a pure EPUB 2 publication, as the structured element is the more
+    /// authoritative expression of the metadata.
+    enum Syntax {
+        /// Legacy `<meta name="..." content="...">` tag (EPUB 2).
+        case legacy
+        /// Structured `<meta property="...">` (EPUB 3) or `<dc:x>` element.
+        case structured
+    }
+
+    let syntax: Syntax
     let property: String
     /// URI of the property's vocabulary.
     let vocabularyURI: String
@@ -173,6 +187,7 @@ struct OPFMetaList {
                         var refinedID = meta.attr("refines")
                         refinedID?.removeFirst() // Get rid of the # before the ID.
                         return OPFMeta(
+                            syntax: .structured,
                             property: property, vocabularyURI: vocabularyURI,
                             content: meta.stringValue.trimmingCharacters(in: .whitespacesAndNewlines),
                             id: meta.attr("id"), refines: refinedID, element: meta
@@ -181,6 +196,7 @@ struct OPFMetaList {
                     } else if let property = meta.attr("name") {
                         let (property, vocabularyURI) = OPFVocabulary.parse(property: property, prefixes: prefixes)
                         return OPFMeta(
+                            syntax: .legacy,
                             property: property, vocabularyURI: vocabularyURI,
                             content: meta.attr("content")?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
                             id: nil, refines: nil, element: meta
@@ -195,6 +211,7 @@ struct OPFMetaList {
                         return nil
                     }
                     return OPFMeta(
+                        syntax: .structured,
                         property: property,
                         vocabularyURI: OPFVocabulary.dcterms.uri,
                         content: meta.stringValue.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -258,11 +275,25 @@ struct OPFMetaList {
     var otherMetadata: [String: JSONValue] {
         var metadata: [String: NSMutableOrderedSet] = [:]
 
+        // Properties expressed with a structured element, which supersede the equivalent legacy
+        // `<meta name= content=>` tags.
+        // https://github.com/readium/swift-toolkit/issues/85
+        let structuredProperties = Set(
+            metas.compactMap { meta in
+                (meta.syntax == .structured && meta.refines == nil)
+                    ? meta.vocabularyURI + meta.property
+                    : nil
+            }
+        )
+
         for meta in metas {
             guard meta.refines == nil, !isRWPMProperty(meta) else {
                 continue
             }
             let key = meta.vocabularyURI + meta.property
+            guard meta.syntax == .structured || !structuredProperties.contains(key) else {
+                continue
+            }
             let values = metadata[key] ?? NSMutableOrderedSet()
             values.add(value(for: meta))
             metadata[key] = values

--- a/Tests/StreamerTests/Fixtures/OPF/other-metadata-precedence.opf
+++ b/Tests/StreamerTests/Fixtures/OPF/other-metadata-precedence.opf
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Alice's Adventures in Wonderland</dc:title>
+    <!-- The EPUB 3 meta supersedes the equivalent EPUB 2 one. -->
+    <meta property="presentation">EPUB 3 presentation</meta>
+    <meta name="presentation" content="EPUB 2 presentation" />
+    <!-- Order of appearance doesn't matter. -->
+    <meta name="generator" content="EPUB 2 generator" />
+    <meta property="generator">EPUB 3 generator</meta>
+    <!-- An EPUB 2 meta without any EPUB 3 equivalent is kept. -->
+    <meta name="legacy-only" content="EPUB 2 legacy" />
+    <!-- An EPUB 3 refining meta with the same property doesn't supersede an EPUB 2 one. -->
+    <meta property="schema" refines="#pub-id">refined schema</meta>
+    <meta name="schema" content="EPUB 2 schema" />
+  </metadata>
+  <manifest>
+    <item id="chapter01" href="chapter01.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter01"/>
+  </spine>
+</package>

--- a/Tests/StreamerTests/Parser/EPUB/EPUBManifestParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/EPUBManifestParserTests.swift
@@ -52,7 +52,6 @@ class EPUBManifestParserTests: XCTestCase {
                                 "@value": .string("Web"),
                                 "http://my.url/#scheme": .string("http"),
                             ]),
-                            .string("Internet"),
                         ]),
                         "http://purl.org/dc/terms/rights": .string("Public Domain"),
                         "http://idpf.org/epub/vocab/package/#type": .string("article"),

--- a/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/EPUBMetadataParserTests.swift
@@ -45,7 +45,6 @@ class EPUBMetadataParserTests: XCTestCase {
                         "@value": .string("Web"),
                         "http://my.url/#scheme": .string("http"),
                     ]),
-                    .string("Internet"),
                 ]),
                 "http://purl.org/dc/terms/rights": .string("Public Domain"),
                 "http://idpf.org/epub/vocab/package/#type": .string("article"),
@@ -391,6 +390,27 @@ class EPUBMetadataParserTests: XCTestCase {
         XCTAssertNil(sut.otherMetadata["\(mediaVocab)duration"])
         // The synthesized mediaOverlay key must be stored in otherMetadata
         XCTAssertNotNil(sut.otherMetadata["mediaOverlay"])
+    }
+
+    // MARK: - Other Metadata
+
+    /// An EPUB 2 `<meta name= content=>` tag is superseded by an EPUB 3 `<meta property=>` tag
+    /// with the same property.
+    /// https://github.com/readium/swift-toolkit/issues/85
+    func testEPUB2MetaSupersededByEPUB3Meta() throws {
+        let sut = try parseMetadata("other-metadata-precedence")
+        let vocab = "http://idpf.org/epub/vocab/package/#"
+
+        XCTAssertEqual(sut.otherMetadata, [
+            // The EPUB 3 metas take precedence over the equivalent EPUB 2 ones, regardless of
+            // their order of appearance.
+            "\(vocab)presentation": .string("EPUB 3 presentation"),
+            "\(vocab)generator": .string("EPUB 3 generator"),
+            // An EPUB 2 meta without any EPUB 3 equivalent is kept.
+            "\(vocab)legacy-only": .string("EPUB 2 legacy"),
+            // An EPUB 3 refining meta with the same property doesn't supersede an EPUB 2 one.
+            "\(vocab)schema": .string("EPUB 2 schema"),
+        ])
     }
 
     // MARK: - Toolkit


### PR DESCRIPTION
Fixes #85.

When an OPF package document declares the same property with both an EPUB 2 `<meta name= content=>` tag and an EPUB 3 `<meta property=>` (or `<dc:x>`) tag, `otherMetadata` now keeps only the EPUB 3 value instead of both. `OPFMeta` records whether a meta came from the legacy `<meta name= content=>` syntax or a structured element (`<meta property=>` / `<dc:x>`), and `OPFMetaList.otherMetadata` drops legacy metas whose property is also expressed by a non-refining structured element. Legacy-only properties are preserved, and refining EPUB 3 metas do not supersede top-level legacy ones.

Includes a new OPF fixture and unit test, plus updated expectations for the `full-metadata` fixture which exercised the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)