### PR TITLE
Verify the SHA-256 hash of publications acquired through LCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file. Take a look
 
 ## [Unreleased: swift6]
 
+### Added
+
+#### LCP
+
+* [#28](https://github.com/readium/swift-toolkit/issues/28) The SHA-256 hash of a publication downloaded during an LCP acquisition is now verified against the `hash` declared in the License Document, when available. A corrupted download fails with the new `LCPError.publicationHashMismatch` error.
+
 ### Changed
 
 * The toolkit is migrated to Swift 6 with strict concurrency checking. All packages compile in the Swift 6 language mode. See [the migration guide](docs/Migration%20Guide.md).

--- a/Sources/LCP/LCPError.swift
+++ b/Sources/LCP/LCPError.swift
@@ -14,6 +14,11 @@ public enum LCPError: Error, Sendable {
     /// The given file is not an LCP License Document (LCPL).
     case notALicenseDocument(LicenseDocumentSource)
 
+    /// The SHA-256 hash of the acquired publication does not match the hash
+    /// declared in the License Document, or the declared hash could not be
+    /// parsed. The downloaded file is likely corrupted or incomplete.
+    case publicationHashMismatch
+
     /// The operation can't be done right now because another License operation is running.
     case licenseIsBusy
 

--- a/Sources/LCP/Services/LicensesService.swift
+++ b/Sources/LCP/Services/LicensesService.swift
@@ -111,6 +111,8 @@ final class LicensesService: Loggable {
             onProgress: { onProgress(.percent(Float($0))) }
         ).get()
 
+        try await verifyIntegrity(of: download.location, with: license)
+
         let format = try await injectLicenseAndGetFormat(
             license,
             in: download.location,
@@ -123,6 +125,28 @@ final class LicensesService: Loggable {
             suggestedFilename: format.fileExtension.appendedToFilename(license.id),
             licenseDocument: license
         )
+    }
+
+    /// Verifies the integrity of the acquired publication at `file`, when the
+    /// License Document declares the SHA-256 hash of the Protected
+    /// Publication.
+    ///
+    /// See https://readium.org/lcp-specs/releases/lcp/latest.html#acquiring-the-publication
+    private func verifyIntegrity(of file: FileURL, with license: LicenseDocument) async throws {
+        guard let hash = license.publicationLink.hash else {
+            return
+        }
+
+        guard
+            let expectedHash = Data(sha256: hash),
+            try await Data.sha256(of: file) == expectedHash
+        else {
+            // An unparseable hash fails the verification as well: silently
+            // skipping it would defeat the integrity check exactly when the
+            // metadata is suspicious.
+            try? FileManager.default.removeItem(at: file.url)
+            throw LCPError.publicationHashMismatch
+        }
     }
 
     func injectLicenseDocument(

--- a/Sources/LCP/Toolkit/Data+SHA256.swift
+++ b/Sources/LCP/Toolkit/Data+SHA256.swift
@@ -1,0 +1,75 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import CryptoKit
+import Foundation
+import ReadiumShared
+
+extension Data {
+    /// Parses a SHA-256 digest from its string representation.
+    ///
+    /// The LCP specification mandates a base 64 encoding, but the Readium
+    /// LCP server historically produced hexadecimal digests, so both
+    /// encodings are accepted.
+    /// See https://github.com/readium/lcp-specs/issues/52
+    init?(sha256: String) {
+        let string = sha256.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if string.count == 64, let digest = Data(hexadecimal: string) {
+            self = digest
+        } else if let digest = Data(base64Encoded: string), digest.count == SHA256.byteCount {
+            self = digest
+        } else {
+            return nil
+        }
+    }
+
+    /// Parses a string of hexadecimal digits into bytes.
+    private init?(hexadecimal string: String) {
+        // `UInt8.init(_:radix:)` accepts leading `+`/`-` signs, so we
+        // explicitly restrict the alphabet to hexadecimal digits.
+        guard
+            string.count % 2 == 0,
+            string.allSatisfy({ $0.isASCII && $0.isHexDigit })
+        else {
+            return nil
+        }
+
+        var data = Data(capacity: string.count / 2)
+        var index = string.startIndex
+        while index < string.endIndex {
+            let nextIndex = string.index(index, offsetBy: 2)
+            guard let byte = UInt8(string[index ..< nextIndex], radix: 16) else {
+                return nil
+            }
+            data.append(byte)
+            index = nextIndex
+        }
+
+        self = data
+    }
+
+    /// Computes the SHA-256 digest of the file at `file`, reading it in
+    /// chunks to keep a low memory footprint.
+    @concurrent static func sha256(of file: FileURL) async throws -> Data {
+        let handle = try FileHandle(forReadingFrom: file.url)
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        let chunkSize = 512 * 1024
+
+        while true {
+            try Task.checkCancellation()
+            guard let chunk = try handle.read(upToCount: chunkSize), !chunk.isEmpty else {
+                break
+            }
+            hasher.update(data: chunk)
+            await Task.yield()
+        }
+
+        return Data(hasher.finalize())
+    }
+}

--- a/TestApp/Sources/App/Readium.swift
+++ b/TestApp/Sources/App/Readium.swift
@@ -250,6 +250,8 @@ extension ReadiumNavigator.TTSError: UserErrorConvertible {
                     return "lcp_error_missing_passphrase".localized
                 case .notALicenseDocument, .licenseIntegrity, .licenseProfileNotSupported, .parsing:
                     return "lcp_error_invalid_license".localized
+                case .publicationHashMismatch:
+                    return "lcp_error_publication_hash_mismatch".localized
                 case .licenseIsBusy, .licenseInteractionNotAvailable:
                     return "lcp_error_invalid_operation".localized
                 case .licenseContainer:

--- a/TestApp/Sources/Resources/en.lproj/Localizable.strings
+++ b/TestApp/Sources/Resources/en.lproj/Localizable.strings
@@ -151,6 +151,7 @@
 "lcp_error_invalid_operation" = "This action cannot be performed.";
 "lcp_error_container" = "Failed to read or write the LCP license.";
 "lcp_error_network" = "A networking error occurred.";
+"lcp_error_publication_hash_mismatch" = "The downloaded publication seems corrupted, please try again.";
 "lcp_error_status_cancelled" = "This license was cancelled on %@.";
 "lcp_error_status_returned" = "This license has been returned on %@.";
 "lcp_error_status_expired_start" = "This license starts on %@.";

--- a/Tests/LCPTests/KeychainTests.swift
+++ b/Tests/LCPTests/KeychainTests.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-@testable import ReadiumInternal
+import ReadiumShared
 import Testing
 
 struct KeychainTests {

--- a/Tests/LCPTests/Toolkit/DataSHA256Tests.swift
+++ b/Tests/LCPTests/Toolkit/DataSHA256Tests.swift
@@ -1,0 +1,102 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+@testable import ReadiumLCP
+import ReadiumShared
+import Testing
+
+struct DataSHA256Tests {
+    struct Decoding {
+        @Test func hexadecimal() {
+            #expect(Data(sha256: readiumDigestHex) == readiumDigest)
+        }
+
+        @Test func uppercaseHexadecimal() {
+            #expect(Data(sha256: readiumDigestHex.uppercased()) == readiumDigest)
+        }
+
+        @Test func base64() {
+            #expect(Data(sha256: readiumDigestBase64) == readiumDigest)
+        }
+
+        @Test func surroundingWhitespaceIsIgnored() {
+            #expect(Data(sha256: " \(readiumDigestHex)\n") == readiumDigest)
+            #expect(Data(sha256: " \(readiumDigestBase64)\n") == readiumDigest)
+        }
+
+        @Test(arguments: [
+            "", // empty
+            "not a hash",
+            "0ea28c743883275f2454370a2e719a7f", // hex, too short (MD5 length)
+            "0ea28c743883275f2454370a2e719a7f3d9f36116cd12c9c8e832d1f118a218b00", // hex, too long
+            "zza28c743883275f2454370a2e719a7f3d9f36116cd12c9c8e832d1f118a218b", // 64 characters, but not hex nor valid base64
+            "+126b3a0e22dfb6c7f894086e5f9653795f921e119c421580d2ec26d1796db32", // 64 characters, but a `+` sign accepted by `UInt8.init(_:radix:)` is not a hex digit
+            "-126b3a0e22dfb6c7f894086e5f9653795f921e119c421580d2ec26d1796db32", // 64 characters, but a `-` sign accepted by `UInt8.init(_:radix:)` is not a hex digit
+            "DqKMdDiDJ18kVDcKLnGafz2fNhE=", // valid base64, but not 32 bytes
+        ])
+        func invalidHash(string: String) {
+            #expect(Data(sha256: string) == nil)
+        }
+    }
+
+    struct FileDigest {
+        @Test func computesTheDigestOfAFile() async throws {
+            let file = try makeTemporaryFile(containing: Data("readium".utf8))
+            defer { try? FileManager.default.removeItem(at: file.url) }
+
+            let digest = try await Data.sha256(of: file)
+            #expect(digest == readiumDigest)
+        }
+
+        @Test func computesTheDigestOfAnEmptyFile() async throws {
+            let file = try makeTemporaryFile(containing: Data())
+            defer { try? FileManager.default.removeItem(at: file.url) }
+
+            let digest = try await Data.sha256(of: file)
+            // SHA-256 of an empty input.
+            #expect(digest == Data(sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+        }
+
+        @Test func computesTheDigestOfAFileLargerThanASingleChunk() async throws {
+            // 2 MB, larger than the 512 KB read chunks.
+            let data = Data(repeating: 0xAB, count: 2 * 1024 * 1024)
+            let file = try makeTemporaryFile(containing: data)
+            defer { try? FileManager.default.removeItem(at: file.url) }
+
+            let digest = try await Data.sha256(of: file)
+            #expect(digest == Data(sha256: "5e7c321a44769c5389419a685860088ec70bd6e28d8a5c68665cb8937ac305a0"))
+        }
+
+        @Test func failsIfTheFileDoesNotExist() async throws {
+            let file = FileURL(url: URL(fileURLWithPath: "/does/not/exist-\(UUID().uuidString)"))!
+
+            await #expect(throws: Error.self) {
+                try await Data.sha256(of: file)
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+/// SHA-256 digest of the UTF-8 string "readium".
+private let readiumDigest = Data([
+    0x21, 0x26, 0xb3, 0xa0, 0xe2, 0x2d, 0xfb, 0x6c,
+    0x7f, 0x89, 0x40, 0x86, 0xe5, 0xf9, 0x65, 0x37,
+    0x95, 0xf9, 0x21, 0xe1, 0x19, 0xc4, 0x21, 0x58,
+    0x0d, 0x2e, 0xc2, 0x6d, 0x17, 0x96, 0xdb, 0x32,
+])
+
+private let readiumDigestHex = "2126b3a0e22dfb6c7f894086e5f9653795f921e119c421580d2ec26d1796db32"
+private let readiumDigestBase64 = "ISazoOIt+2x/iUCG5fllN5X5IeEZxCFYDS7CbReW2zI="
+
+private func makeTemporaryFile(containing data: Data) throws -> FileURL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("DataSHA256Tests-\(UUID().uuidString)")
+    try data.write(to: url)
+    return FileURL(url: url)!
+}


### PR DESCRIPTION
Fixes #28.

After downloading a protected publication, ReadiumLCP now compares its SHA-256 digest against the `hash` declared on the license's `publication` link (base64 per the spec, or hex as emitted by the Go LCP server). On mismatch — or when the declared hash is unparseable — the corrupted download is deleted and acquisition fails with a new `LCPError.publicationHashMismatch`. Verification is skipped when the license declares no hash.

The digest is computed with CryptoKit in 512 KB chunks on a background executor, with cooperative cancellation. Includes unit tests for the hash parsing and file digest computation, TestApp error mapping/localization, and a changelog entry.

Also fixes a stale `@testable import ReadiumInternal` in `KeychainTests` which prevented the LCP test target from compiling since the `ReadiumInternal` package was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)