### PR TITLE
Add support for deciphering encrypted LCP user fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file. Take a look
 
 ## [Unreleased: swift6]
 
+### Added
+
+#### LCP
+
+* [#147](https://github.com/readium/swift-toolkit/issues/147) You can now decipher the user fields encrypted in a License Document (e.g. the user name or email) with `LCPLicense.decipheredUser()`. This requires:
+    * an `R2LCPClient` (liblcp) version providing `decryptField()`, such as 4.3.0
+    * forwarding `R2LCPClient.decryptField()` in your `LCPClient` facade:
+        ```swift
+        func decryptField(field: Data, using context: LCPClientContext) -> Data? {
+            R2LCPClient.decryptField(field: field, using: context as! DRMContext)
+        }
+        ```
+
 ### Changed
 
 * The toolkit is migrated to Swift 6 with strict concurrency checking. All packages compile in the Swift 6 language mode. See [the migration guide](docs/Migration%20Guide.md).
@@ -22,6 +35,7 @@ All notable changes to this project will be documented in this file. Take a look
 
 #### LCP
 
+* `LCPClient.getSupportedLCPProfileURIs()` and the new `LCPClient.decryptField(field:using:)` are hard requirements of the facade: their backward-compatible default implementations were removed. See [the migration guide](docs/Migration%20Guide.md).
 * `LCPService.init` now requires an explicit `deviceName` parameter. We recommend passing `UIDevice.current.name`. See [the migration guide](docs/Migration%20Guide.md).
 * `LCPDialogAuthentication` no longer takes a `sender` view controller. It now presents its passphrase dialog through a new `LCPDialogAuthenticationDelegate` that you implement and retain for the lifetime of the authentication. See [the Readium LCP guide](docs/Guides/Readium%20LCP.md) and [the migration guide](docs/Migration%20Guide.md).
 

--- a/Sources/LCP/LCPClient.swift
+++ b/Sources/LCP/LCPClient.swift
@@ -28,6 +28,10 @@ import Foundation
 ///              return R2LCPClient.findOneValidPassphrase(jsonLicense: jsonLicense, hashedPassphrases: hashedPassphrases)
 ///          }
 ///
+///          func decryptField(field: Data, using context: LCPClientContext) -> Data? {
+///              return R2LCPClient.decryptField(field: field, using: context as! DRMContext)
+///          }
+///
 ///          func getSupportedLCPProfileURIs() -> [String] {
 ///              return R2LCPClient.getSupportedLCPProfileURIs() ?? []
 ///          }
@@ -40,31 +44,19 @@ public protocol LCPClient: Sendable {
     /// Decrypt provided content, given a valid context is provided.
     func decrypt(data: Data, using context: LCPClientContext) -> Data?
 
+    /// Decrypts a License Document field (e.g. the user name or email), which
+    /// is encrypted with the user key, unlike publication resources which are
+    /// encrypted with the content key.
+    ///
+    /// `field` is the raw encrypted value, after decoding the Base64 string
+    /// found in the License Document.
+    func decryptField(field: Data, using context: LCPClientContext) -> Data?
+
     /// Given an array of possible password hashes, return a valid password hash for the lcpl licence.
     func findOneValidPassphrase(jsonLicense: String, hashedPassphrases: [LCPPassphraseHash]) -> LCPPassphraseHash?
 
     /// Returns the LCP profile URIs supported by the underlying liblcp build.
     func getSupportedLCPProfileURIs() -> [String]
-}
-
-public extension LCPClient {
-    // FIXME: This default implementation preserves source compatibility for facades that predate `getSupportedLCPProfileURIs()`. Remove it in the next breaking release and make the method a hard protocol requirement, so the supported profiles always come from liblcp instead of this stale hardcoded list.
-    func getSupportedLCPProfileURIs() -> [String] {
-        [
-            "http://readium.org/lcp/basic-profile",
-            "http://readium.org/lcp/profile-1.0",
-            "http://readium.org/lcp/profile-2.0",
-            "http://readium.org/lcp/profile-2.1",
-            "http://readium.org/lcp/profile-2.2",
-            "http://readium.org/lcp/profile-2.3",
-            "http://readium.org/lcp/profile-2.4",
-            "http://readium.org/lcp/profile-2.5",
-            "http://readium.org/lcp/profile-2.6",
-            "http://readium.org/lcp/profile-2.7",
-            "http://readium.org/lcp/profile-2.8",
-            "http://readium.org/lcp/profile-2.9",
-        ]
-    }
 }
 
 public typealias LCPClientContext = Any & Sendable

--- a/Sources/LCP/LCPLicense.swift
+++ b/Sources/LCP/LCPLicense.swift
@@ -25,6 +25,17 @@ public protocol LCPLicense: UserRights {
     /// Deciphers the given encrypted data to be displayed in the reader.
     func decipher(_ data: Data) throws -> Data?
 
+    /// Deciphers the given License Document field (e.g. the user name or
+    /// email), which is encrypted with the user key, unlike publication
+    /// resources which are encrypted with the content key.
+    ///
+    /// `data` is the raw encrypted value, after decoding the Base64 string
+    /// found in the License Document.
+    ///
+    /// Returns nil if the field cannot be deciphered, and throws when the
+    /// license is restricted (e.g. missing passphrase or invalid license).
+    func decipherUserField(_ data: Data) throws -> Data?
+
     /// Number of remaining characters allowed to be copied by the user.
     /// If nil, there's no limit.
     func charactersToCopyLeft() async -> Int?
@@ -61,5 +72,19 @@ public protocol LCPLicense: UserRights {
 public extension LCPLicense {
     func renewLoan(with delegate: LCPRenewDelegate) async -> Result<Void, LCPError> {
         await renewLoan(with: delegate, prefersWebPage: false)
+    }
+
+    /// Returns the license user information, after deciphering the fields
+    /// encrypted with the user key (e.g. the user name or email).
+    ///
+    /// Fields that cannot be deciphered are left untouched and still listed
+    /// in `User.encrypted`.
+    ///
+    /// Throws when the license is restricted (e.g. missing passphrase or
+    /// invalid license).
+    func decipheredUser() throws -> User {
+        try license.user.decrypted { data in
+            try decipherUserField(data)
+        }
     }
 }

--- a/Sources/LCP/License/License.swift
+++ b/Sources/LCP/License/License.swift
@@ -73,6 +73,11 @@ extension License: LCPLicense {
         return client.decrypt(data: data, using: context)
     }
 
+    func decipherUserField(_ data: Data) throws -> Data? {
+        let context = try documents.withLock { $0.context }.get()
+        return client.decryptField(field: data, using: context)
+    }
+
     func charactersToCopyLeft() async -> Int? {
         guard !isRestricted else { return 0 }
 

--- a/Sources/LCP/License/Model/Components/LCP/User.swift
+++ b/Sources/LCP/License/Model/Components/LCP/User.swift
@@ -49,3 +49,67 @@ public struct User: JSONValueDecodable, Sendable {
         extensions = dict
     }
 }
+
+extension User {
+    /// Returns a copy of this User after deciphering the fields listed in
+    /// `encrypted` with the given closure.
+    ///
+    /// `decrypt` receives the raw encrypted value (after Base64 decoding) and
+    /// returns the deciphered plain text data, or nil if the field cannot be
+    /// deciphered.
+    ///
+    /// Fields that cannot be deciphered are left untouched and still listed
+    /// in `encrypted`.
+    func decrypted(_ decrypt: (Data) throws -> Data?) rethrows -> User {
+        func decryptedString(from value: String?) throws -> String? {
+            guard
+                let value = value,
+                let encryptedData = Data(base64Encoded: value),
+                let decryptedData = try decrypt(encryptedData)
+            else {
+                return nil
+            }
+            return String(data: decryptedData, encoding: .utf8)
+        }
+
+        var id = id
+        var email = email
+        var name = name
+        var extensions = extensions
+        var stillEncrypted: [String] = []
+
+        for field in encrypted.removingDuplicates() {
+            switch field {
+            case "id":
+                if let value = try decryptedString(from: id) {
+                    id = value
+                    continue
+                }
+            case "email":
+                if let value = try decryptedString(from: email) {
+                    email = value
+                    continue
+                }
+            case "name":
+                if let value = try decryptedString(from: name) {
+                    name = value
+                    continue
+                }
+            default:
+                if let value = try decryptedString(from: extensions[field]?.string) {
+                    extensions[field] = .string(value)
+                    continue
+                }
+            }
+            stillEncrypted.append(field)
+        }
+
+        return User(
+            id: id,
+            email: email,
+            name: name,
+            extensions: extensions,
+            encrypted: stillEncrypted
+        )
+    }
+}

--- a/TestApp/Sources/App/Readium.swift
+++ b/TestApp/Sources/App/Readium.swift
@@ -82,6 +82,10 @@ import UIKit
                 R2LCPClient.findOneValidPassphrase(jsonLicense: jsonLicense, hashedPassphrases: hashedPassphrases)
             }
 
+            func decryptField(field: Data, using context: LCPClientContext) -> Data? {
+                R2LCPClient.decryptField(field: field, using: context as! DRMContext)
+            }
+
             func getSupportedLCPProfileURIs() -> [String] {
                 R2LCPClient.getSupportedLCPProfileURIs() ?? []
             }

--- a/Tests/LCPTests/LCPTestClient.swift
+++ b/Tests/LCPTests/LCPTestClient.swift
@@ -21,6 +21,10 @@ final class LCPTestClient: LCPClient {
         R2LCPClient.findOneValidPassphrase(jsonLicense: jsonLicense, hashedPassphrases: hashedPassphrases)
     }
 
+    func decryptField(field: Data, using context: LCPClientContext) -> Data? {
+        R2LCPClient.decryptField(field: field, using: context as! DRMContext)
+    }
+
     func getSupportedLCPProfileURIs() -> [String] {
         R2LCPClient.getSupportedLCPProfileURIs() ?? []
     }

--- a/Tests/LCPTests/UserTests.swift
+++ b/Tests/LCPTests/UserTests.swift
@@ -1,0 +1,164 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+@testable import ReadiumLCP
+import ReadiumShared
+import Testing
+
+enum UserTests {
+    struct Decrypted {
+        @Test func decryptsEncryptedFields() throws {
+            let user = User(
+                id: "1234",
+                email: base64("secret:john@example.com"),
+                name: base64("secret:John"),
+                encrypted: ["email", "name"]
+            )
+
+            let decrypted = try user.decrypted(revealSecret)
+
+            #expect(decrypted.id == "1234")
+            #expect(decrypted.email == "john@example.com")
+            #expect(decrypted.name == "John")
+            #expect(decrypted.encrypted.isEmpty)
+        }
+
+        @Test func leavesClearFieldsUntouched() throws {
+            let user = User(
+                id: "1234",
+                email: "john@example.com",
+                name: base64("secret:John"),
+                encrypted: ["name"]
+            )
+
+            let decrypted = try user.decrypted(revealSecret)
+
+            #expect(decrypted.email == "john@example.com")
+            #expect(decrypted.name == "John")
+            #expect(decrypted.encrypted.isEmpty)
+        }
+
+        @Test func decryptsIDAndExtensions() throws {
+            let user = User(
+                id: base64("secret:1234"),
+                extensions: [
+                    "http://example.com/subscription": JSONValue.string(base64("secret:premium")),
+                    "http://example.com/age": JSONValue.integer(42),
+                ],
+                encrypted: ["id", "http://example.com/subscription"]
+            )
+
+            let decrypted = try user.decrypted(revealSecret)
+
+            #expect(decrypted.id == "1234")
+            #expect(decrypted.extensions == [
+                "http://example.com/subscription": JSONValue.string("premium"),
+                "http://example.com/age": JSONValue.integer(42),
+            ])
+            #expect(decrypted.encrypted.isEmpty)
+        }
+
+        @Test func keepsFieldsThatCannotBeDeciphered() throws {
+            let user = User(
+                email: base64("secret:john@example.com"),
+                name: base64("secret:John"),
+                encrypted: ["email", "name"]
+            )
+
+            // Refuses to decrypt the email.
+            let decrypted = try user.decrypted { data in
+                let string = String(data: data, encoding: .utf8)!
+                return string.contains("john") ? nil : revealSecret(data)
+            }
+
+            #expect(decrypted.email == base64("secret:john@example.com"))
+            #expect(decrypted.name == "John")
+            #expect(decrypted.encrypted == ["email"])
+        }
+
+        @Test func keepsFieldsWhenDecryptionAlwaysFails() throws {
+            let user = User(
+                email: base64("secret:john@example.com"),
+                name: base64("secret:John"),
+                encrypted: ["email", "name"]
+            )
+
+            // Emulates a liblcp build unable to decipher the fields.
+            let decrypted = try user.decrypted { _ in nil }
+
+            #expect(decrypted.email == user.email)
+            #expect(decrypted.name == user.name)
+            #expect(decrypted.encrypted == ["email", "name"])
+        }
+
+        @Test func keepsFieldsThatAreNotValidBase64() throws {
+            let user = User(
+                name: "n o t b a s e 6 4",
+                encrypted: ["name"]
+            )
+
+            let decrypted = try user.decrypted(revealSecret)
+
+            #expect(decrypted.name == "n o t b a s e 6 4")
+            #expect(decrypted.encrypted == ["name"])
+        }
+
+        @Test func ignoresDuplicateEncryptedFields() throws {
+            let user = User(
+                name: base64("secret:John"),
+                encrypted: ["name", "name"]
+            )
+
+            let decrypted = try user.decrypted(revealSecret)
+
+            // The second occurrence must not decrypt the plain text again.
+            #expect(decrypted.name == "John")
+            #expect(decrypted.encrypted.isEmpty)
+        }
+
+        @Test func keepsUnknownEncryptedFields() throws {
+            let user = User(
+                name: base64("secret:John"),
+                encrypted: ["name", "unknown-field"]
+            )
+
+            let decrypted = try user.decrypted(revealSecret)
+
+            #expect(decrypted.name == "John")
+            #expect(decrypted.encrypted == ["unknown-field"])
+        }
+
+        @Test func rethrowsDecryptionErrors() {
+            let user = User(
+                name: base64("secret:John"),
+                encrypted: ["name"]
+            )
+
+            #expect(throws: DummyError.self) {
+                try user.decrypted { _ in throw DummyError() }
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+/// Fake decryption: the "encrypted" value is the plain text prefixed with
+/// `secret:`, then Base64-encoded.
+private func revealSecret(_ data: Data) -> Data? {
+    let string = String(data: data, encoding: .utf8)!
+    guard string.hasPrefix("secret:") else {
+        return nil
+    }
+    return Data(string.dropFirst("secret:".count).utf8)
+}
+
+private func base64(_ string: String) -> String {
+    Data(string.utf8).base64EncodedString()
+}
+
+private struct DummyError: Error {}

--- a/docs/Guides/Readium LCP.md
+++ b/docs/Guides/Readium LCP.md
@@ -223,6 +223,14 @@ class LCPClientAdapter: ReadiumLCP.LCPClient {
     func findOneValidPassphrase(jsonLicense: String, hashedPassphrases: [LCPPassphraseHash]) -> LCPPassphraseHash? {
         R2LCPClient.findOneValidPassphrase(jsonLicense: jsonLicense, hashedPassphrases: hashedPassphrases)
     }
+
+    func decryptField(field: Data, using context: LCPClientContext) -> Data? {
+        R2LCPClient.decryptField(field: field, using: context as! DRMContext)
+    }
+
+    func getSupportedLCPProfileURIs() -> [String] {
+        R2LCPClient.getSupportedLCPProfileURIs() ?? []
+    }
 }
 ```
 
@@ -414,6 +422,18 @@ case .failure(let error):
     // Display the error.
 }
 ```
+
+Some user fields may be encrypted with the user key in the License Document, as listed in `license.user.encrypted`. Use `lcpLicense.decipheredUser()` to get the user information with these fields deciphered.
+
+```swift
+let user = try lcpLicense.decipheredUser()
+if let name = user.name, !user.encrypted.contains("name") {
+    print("The publication was acquired by \(name)")
+}
+```
+
+> [!NOTE]
+> Deciphering the user fields requires an `R2LCPClient` version providing `decryptField()` (starting from 4.3.0), forwarded in your `LCPClient` facade. Fields that cannot be deciphered are left untouched and still listed in `user.encrypted`.
 
 If you have already opened a `Publication` with the `PublicationOpener`, you can directly obtain the `LCPLicense` using `publication.lcpLicense`.
 

--- a/docs/Migration Guide.md
+++ b/docs/Migration Guide.md
@@ -114,6 +114,29 @@ Then drop the `sender` argument from your calls:
  )
 ```
 
+#### New requirements in the `LCPClient` facade
+
+The `LCPClient` facade to `R2LCPClient` (liblcp) has two new required members, previously covered by backward-compatible default implementations which have been removed:
+
+* `getSupportedLCPProfileURIs()`, used to report `LCPError.licenseProfileNotSupported` based on the profiles the embedded liblcp actually supports.
+* `decryptField(field:using:)`, used to decipher the user fields encrypted in a License Document (e.g. the user name or email) with `LCPLicense.decipheredUser()`. It requires an `R2LCPClient` version providing `decryptField()`, such as 4.3.0.
+
+Add them to your facade:
+
+```swift
+func decryptField(field: Data, using context: LCPClientContext) -> Data? {
+    R2LCPClient.decryptField(field: field, using: context as! DRMContext)
+}
+
+func getSupportedLCPProfileURIs() -> [String] {
+    R2LCPClient.getSupportedLCPProfileURIs() ?? []
+}
+```
+
+#### New `decipherUserField` requirement in `LCPLicense`
+
+`LCPLicense` has a new `decipherUserField(_:)` requirement, used to decipher the user fields encrypted in a License Document (e.g. the user name or email) with `decipheredUser()`. This only impacts you if you implement a custom `LCPLicense` – for example a test mock – in which case you can return `nil`.
+
 #### New `updateUserRights` signature in `LCPLicenseRepository`
 
 If you implement a custom `LCPLicenseRepository`, `updateUserRights` changed shape. It is now `async` and `throws`, and it is generic so it can return a value computed while the rights are locked – for example, whether a copy or print request fit within the remaining budget. Update your implementation to match:


### PR DESCRIPTION
Fixes #147.

Exposes liblcp's `decryptField()` (available since R2LCPClient 4.3.0) through the toolkit:

- New hard requirement `decryptField(field:using:)` on the `LCPClient` facade, forwarding raw (Base64-decoded) ciphertext to `R2LCPClient.decryptField`. For consistency on the breaking 4.0 release, `getSupportedLCPProfileURIs()` also becomes a hard requirement and both backward-compatible defaults are removed.
- New `decipherUserField(_:)` requirement and a best-effort `decipheredUser()` convenience on `LCPLicense`: it returns the `User` with the fields listed in `encrypted` (e.g. `name`, `email`) decrypted with the user key. Fields that cannot be deciphered are left untouched and remain listed in `encrypted`; the call throws when the license is restricted.

Includes TestApp facade forwarding, 9 unit tests for the field decryption, and CHANGELOG, Migration Guide and LCP guide updates.

Note: the `decryptField` input format (raw ciphertext, no internal Base64 decode) was verified against the disassembled 4.3.0 framework; a quick runtime check with a real license containing encrypted user fields would be a definitive confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)