### PR TITLE
Fix horizontal swipes over page margins skipping resources in paginated EPUBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ All notable changes to this project will be documented in this file. Take a look
 * The deprecated `ReadiumAdapterGCDWebServer` and `ReadiumAdapterLCPSQLite` adapter packages have been removed.
 * The `ReadiumInternal` package has been removed. Its utilities were internal helpers and are now folded into `ReadiumShared` with `package` visibility. If you imported `ReadiumInternal` directly, remove the import.
 
+### Fixed
+
+#### Navigator
+
+* [#112](https://github.com/readium/swift-toolkit/issues/112) In the paginated EPUB navigator, horizontal swipes over the top and bottom margins of a reflowable resource now turn the page, instead of skipping to the previous or next resource.
+
 
 <!-- ## [Unreleased] -->
 

--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -110,6 +110,35 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
         }
     }
 
+    /// In paginated mode, the top and bottom content insets are applied
+    /// outside the web view, which therefore does not span the full height of
+    /// the spread view. Horizontal swipes over these margins would be picked
+    /// up by the parent `PaginationView` and jump to the previous or next
+    /// resource, instead of turning the page.
+    ///
+    /// To fix this, touches falling through to the spread view (i.e. over the
+    /// margins) are rerouted to the web view's scroll view, so they behave
+    /// exactly like swipes over the content. Taps on the margins are still
+    /// expected to reach this view's `touchesBegan`/`touchesEnded` (and
+    /// therefore the app chrome activation) through the responder chain, as
+    /// the web view's scroll view forwards the touches it does not consume up
+    /// the chain.
+    ///
+    /// See https://github.com/readium/swift-toolkit/issues/112
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let view = super.hitTest(point, with: event)
+        guard
+            !viewModel.scroll,
+            view == self,
+            // Returning the scroll view manually would bypass the
+            // `isUserInteractionEnabled` check of the regular hit-testing.
+            scrollView.isUserInteractionEnabled
+        else {
+            return view
+        }
+        return scrollView
+    }
+
     override func convertPointToNavigatorSpace(_ point: CGPoint) -> CGPoint {
         var point = point
         if viewModel.scroll {


### PR DESCRIPTION
Fixes #112.

In paginated mode, the top/bottom content insets sit outside the web view, so horizontal swipes over these margins were caught by the outer `PaginationView` and jumped to the previous/next resource instead of turning the page.

`EPUBReflowableSpreadView` now overrides `hitTest(_:with:)` to reroute margin touches (those that would fall through to the spread view itself) to the web view's internal scroll view, so margin swipes take exactly the same path as swipes over content: the inner paginated scroll view turns the page, and UIKit's nested-scroll behavior still hands over to `PaginationView` at resource boundaries. Scroll mode and fixed layouts are unaffected, and a defensive `isUserInteractionEnabled` guard preserves the pre-fix fallback.

Needs manual verification on a device/simulator:
- Margin swipes turn the page (paginated LTR and RTL); at the first/last page they move between resources.
- Taps on the top/bottom margins still toggle the app chrome (relies on WebKit forwarding unhandled touches up the responder chain).
- Scroll mode unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)