### PR TITLE
Replace DifferenceKit and CryptoSwift with native Swift code

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
         .library(name: "ReadiumLCP", targets: ["ReadiumLCP"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.10.0"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.2"),
         .package(url: "https://github.com/readium/Fuzi.git", from: "4.0.0"),
         .package(url: "https://github.com/readium/ZIPFoundation.git", from: "3.0.1"),
@@ -59,7 +58,6 @@ let package = Package(
         .target(
             name: "ReadiumStreamer",
             dependencies: [
-                "CryptoSwift",
                 "ReadiumShared",
                 .product(name: "ReadiumFuzi", package: "Fuzi"),
             ],
@@ -121,7 +119,6 @@ let package = Package(
         .target(
             name: "ReadiumLCP",
             dependencies: [
-                "CryptoSwift",
                 "ReadiumShared",
                 .product(name: "ReadiumZIPFoundation", package: "ZIPFoundation"),
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.10.0"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.2"),
-        .package(url: "https://github.com/ra1028/DifferenceKit.git", from: "1.3.0"),
         .package(url: "https://github.com/readium/Fuzi.git", from: "4.0.0"),
         .package(url: "https://github.com/readium/ZIPFoundation.git", from: "3.0.1"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.13.5"),
@@ -82,7 +81,6 @@ let package = Package(
             name: "ReadiumNavigator",
             dependencies: [
                 "ReadiumShared",
-                "DifferenceKit",
                 "SwiftSoup",
             ],
             path: "Sources/Navigator",

--- a/Playground/Playground.xcodeproj/project.pbxproj
+++ b/Playground/Playground.xcodeproj/project.pbxproj
@@ -30,8 +30,8 @@
 /* Begin PBXFileReference section */
 		21B9812F732ED2F093918E79 /* Logger+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+Ext.swift"; sourceTree = "<group>"; };
 		2C1CFC0B9AEB966345163620 /* PublicationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationView.swift; sourceTree = "<group>"; };
-		2E399BE85546465BB3B37527 /* swift-toolkit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = swift-toolkit; path = ..; sourceTree = SOURCE_ROOT; };
 		3A9F2917BE7D720CB89EBC9C /* UserError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserError.swift; sourceTree = "<group>"; };
+		4168CCA0CF528F54A6DD0681 /* swift-toolkit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = swift-toolkit; path = ..; sourceTree = SOURCE_ROOT; };
 		4DC581D9DDE636037C5FAB4A /* HTMLText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLText.swift; sourceTree = "<group>"; };
 		59844953100C517348EF23D0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5BD99839EEEAFBFAF8A2264F /* PublicationMetadataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationMetadataView.swift; sourceTree = "<group>"; };
@@ -129,7 +129,7 @@
 		75054112A41CDCE58ADACF92 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
-				2E399BE85546465BB3B37527 /* swift-toolkit */,
+				4168CCA0CF528F54A6DD0681 /* swift-toolkit */,
 			);
 			name = Packages;
 			sourceTree = "<group>";

--- a/Sources/LCP/Services/PassphrasesService.swift
+++ b/Sources/LCP/Services/PassphrasesService.swift
@@ -4,7 +4,7 @@
 //  available in the top-level LICENSE file of the project.
 //
 
-import CryptoSwift
+import CryptoKit
 import Foundation
 import ReadiumShared
 
@@ -184,5 +184,12 @@ final class PassphrasesService: Loggable, Sendable {
     /// passphrase, and not just a clear passphrase.
     private func isValidHashedPassphrase(_ passphrase: String) -> Bool {
         passphrase.count == 64 && passphrase.allSatisfy { $0.isASCII && $0.isHexDigit }
+    }
+}
+
+private extension String {
+    func sha256() -> String {
+        let digest = SHA256.hash(data: Data(utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sources/LCP/Services/PassphrasesService.swift
+++ b/Sources/LCP/Services/PassphrasesService.swift
@@ -4,7 +4,6 @@
 //  available in the top-level LICENSE file of the project.
 //
 
-import CryptoKit
 import Foundation
 import ReadiumShared
 
@@ -184,12 +183,5 @@ final class PassphrasesService: Loggable, Sendable {
     /// passphrase, and not just a clear passphrase.
     private func isValidHashedPassphrase(_ passphrase: String) -> Bool {
         passphrase.count == 64 && passphrase.allSatisfy { $0.isASCII && $0.isHexDigit }
-    }
-}
-
-private extension String {
-    func sha256() -> String {
-        let digest = SHA256.hash(data: Data(utf8))
-        return digest.map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sources/LCP/Toolkit/String+SHA256.swift
+++ b/Sources/LCP/Toolkit/String+SHA256.swift
@@ -1,0 +1,15 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import CryptoKit
+import Foundation
+
+extension String {
+    func sha256() -> String {
+        let digest = SHA256.hash(data: Data(utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/Navigator/Decorator/DiffableDecoration.swift
+++ b/Sources/Navigator/Decorator/DiffableDecoration.swift
@@ -25,8 +25,8 @@ extension Array where Element == DiffableDecoration {
             changes[locator.href, default: []].append(change)
         }
 
-        let sourceById = Dictionary(grouping: source, by: \.decoration.id).compactMapValues(\.first)
-        let targetById = Dictionary(grouping: self, by: \.decoration.id).compactMapValues(\.first)
+        let sourceById = Dictionary(source.map { ($0.decoration.id, $0) }, uniquingKeysWith: { first, _ in first })
+        let targetById = Dictionary(map { ($0.decoration.id, $0) }, uniquingKeysWith: { first, _ in first })
 
         for sourceElement in source {
             let id = sourceElement.decoration.id

--- a/Sources/Navigator/Decorator/DiffableDecoration.swift
+++ b/Sources/Navigator/Decorator/DiffableDecoration.swift
@@ -4,15 +4,11 @@
 //  available in the top-level LICENSE file of the project.
 //
 
-import DifferenceKit
 import Foundation
 import ReadiumShared
 
-struct DiffableDecoration: Hashable, Differentiable {
+struct DiffableDecoration: Hashable {
     let decoration: Decoration
-    var differenceIdentifier: Decoration.Id {
-        decoration.id
-    }
 }
 
 enum DecorationChange {
@@ -23,28 +19,29 @@ enum DecorationChange {
 
 extension Array where Element == DiffableDecoration {
     func changesByHREF(from source: [DiffableDecoration]) -> [AnyURL: [DecorationChange]] {
-        let changeset = StagedChangeset(source: source, target: self)
-
         var changes: [AnyURL: [DecorationChange]] = [:]
 
         func register(_ change: DecorationChange, at locator: Locator) {
-            var resourceChanges: [DecorationChange] = changes[locator.href] ?? []
-            resourceChanges.append(change)
-            changes[locator.href] = resourceChanges
+            changes[locator.href, default: []].append(change)
         }
 
-        for change in changeset {
-            for deleted in change.elementDeleted {
-                let decoration = source[deleted.element].decoration
-                register(.remove(decoration.id), at: decoration.locator)
+        let sourceById = Dictionary(grouping: source, by: \.decoration.id).compactMapValues(\.first)
+        let targetById = Dictionary(grouping: self, by: \.decoration.id).compactMapValues(\.first)
+
+        for sourceElement in source {
+            let id = sourceElement.decoration.id
+            if let targetElement = targetById[id] {
+                if sourceElement != targetElement {
+                    register(.update(targetElement.decoration), at: targetElement.decoration.locator)
+                }
+            } else {
+                register(.remove(id), at: sourceElement.decoration.locator)
             }
-            for inserted in change.elementInserted {
-                let decoration = self[inserted.element].decoration
-                register(.add(decoration), at: decoration.locator)
-            }
-            for updated in change.elementUpdated {
-                let decoration = self[updated.element].decoration
-                register(.update(decoration), at: decoration.locator)
+        }
+
+        for targetElement in self {
+            if sourceById[targetElement.decoration.id] == nil {
+                register(.add(targetElement.decoration), at: targetElement.decoration.locator)
             }
         }
 

--- a/Sources/Navigator/Preferences/Configurable.swift
+++ b/Sources/Navigator/Preferences/Configurable.swift
@@ -5,7 +5,6 @@
 //
 
 import Foundation
-import ReadiumShared
 
 /// A `Configurable` is a component with a set of `ConfigurableSettings`.
 @MainActor

--- a/Sources/Streamer/Parser/EPUB/EPUBManifestParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBManifestParser.swift
@@ -4,7 +4,6 @@
 //  available in the top-level LICENSE file of the project.
 //
 
-import ReadiumFuzi
 import ReadiumShared
 
 final class EPUBManifestParser {

--- a/Sources/Streamer/Parser/EPUB/EPUBParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBParser.swift
@@ -5,7 +5,6 @@
 //
 
 import Foundation
-import ReadiumFuzi
 import ReadiumShared
 
 /// Errors thrown during the parsing of the EPUB

--- a/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
+++ b/Sources/Streamer/Parser/EPUB/Resource Transformers/EPUBDeobfuscator.swift
@@ -4,7 +4,7 @@
 //  available in the top-level LICENSE file of the project.
 //
 
-import CryptoSwift
+import CryptoKit
 import Foundation
 import ReadiumShared
 
@@ -122,7 +122,7 @@ private final class IDPFAlgorithm: ObfuscationAlgorithm {
     let obfuscatedLength = 1040
 
     func key(for publicationId: String) -> [UInt8] {
-        publicationId.sha1().hexaToBytes
+        Array(Insecure.SHA1.hash(data: Data(publicationId.utf8)))
     }
 }
 

--- a/Support/CocoaPods/ReadiumLCP.podspec
+++ b/Support/CocoaPods/ReadiumLCP.podspec
@@ -26,6 +26,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'ReadiumShared', '~> 3.11.0'
   s.dependency 'ReadiumZIPFoundation', '~> 3.0.1'
-  s.dependency 'CryptoSwift', '~> 1.10.0'
 
 end

--- a/Support/CocoaPods/ReadiumNavigator.podspec
+++ b/Support/CocoaPods/ReadiumNavigator.podspec
@@ -24,7 +24,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name Readium' }
 
   s.dependency 'ReadiumShared', '~> 3.11.0'
-  s.dependency 'DifferenceKit', '~> 1.0'
   s.dependency 'SwiftSoup', '~> 2.11.0'
 
 end

--- a/Support/CocoaPods/ReadiumStreamer.podspec
+++ b/Support/CocoaPods/ReadiumStreamer.podspec
@@ -27,6 +27,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'ReadiumShared', '~> 3.11.0'
   s.dependency 'ReadiumFuzi', '~> 4.0.0'
-  s.dependency 'CryptoSwift', '~> 1.10.0'
 
 end

--- a/Support/CocoaPods/Specs.swift
+++ b/Support/CocoaPods/Specs.swift
@@ -84,7 +84,6 @@ let modules: [ModuleSpec] = [
         ]],
         dependencies: [
             .readium("ReadiumShared"),
-            .pod("DifferenceKit", "~> 1.0"),
             // SwiftSoup's podspec is stuck at 2.11.
             .pod("SwiftSoup", "~> 2.11.0"),
         ]

--- a/Support/CocoaPods/Specs.swift
+++ b/Support/CocoaPods/Specs.swift
@@ -71,7 +71,6 @@ let modules: [ModuleSpec] = [
         dependencies: [
             .readium("ReadiumShared"),
             .pod("ReadiumFuzi", "~> 4.0.0"),
-            .pod("CryptoSwift", "~> 1.10.0"),
         ]
     ),
     ModuleSpec(
@@ -110,7 +109,6 @@ let modules: [ModuleSpec] = [
         dependencies: [
             .readium("ReadiumShared"),
             .pod("ReadiumZIPFoundation", "~> 3.0.1"),
-            .pod("CryptoSwift", "~> 1.10.0"),
         ]
     ),
 ]

--- a/Tests/LCPTests/KeychainTests.swift
+++ b/Tests/LCPTests/KeychainTests.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-@testable import ReadiumInternal
+@testable import ReadiumShared
 import Testing
 
 struct KeychainTests {

--- a/Tests/LCPTests/Services/DeviceServiceTests.swift
+++ b/Tests/LCPTests/Services/DeviceServiceTests.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 @testable import ReadiumLCP
-import ReadiumShared
+@testable import ReadiumShared
 import Testing
 
 /// Serialized because the legacy migration path reads a process-global

--- a/Tests/LCPTests/Services/PassphrasesServiceTest.swift
+++ b/Tests/LCPTests/Services/PassphrasesServiceTest.swift
@@ -1,0 +1,159 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import CryptoKit
+import Foundation
+@testable import ReadiumLCP
+@testable import ReadiumShared
+import Testing
+
+final class MockLCPClient: LCPClient, @unchecked Sendable {
+    var validPassphrase: LCPPassphraseHash?
+
+    func createContext(jsonLicense: String, hashedPassphrase: ReadiumLCP.LCPPassphraseHash, pemCrl: String) throws -> ReadiumLCP.LCPClientContext {
+        ""
+    }
+
+    func decrypt(data: Data, using context: ReadiumLCP.LCPClientContext) -> Data? {
+        data
+    }
+
+    func findOneValidPassphrase(jsonLicense: String, hashedPassphrases: [ReadiumLCP.LCPPassphraseHash]) -> ReadiumLCP.LCPPassphraseHash? {
+        if let valid = validPassphrase, hashedPassphrases.contains(valid) {
+            return valid
+        }
+        return nil
+    }
+
+    func getSupportedLCPProfileURIs() -> [String] {
+        []
+    }
+}
+
+final class MockLCPAuthenticating: LCPAuthenticating, @unchecked Sendable {
+    var passphraseToReturn: String?
+
+    @MainActor
+    func retrievePassphrase(
+        for license: ReadiumLCP.LCPAuthenticatedLicense,
+        reason: ReadiumLCP.LCPAuthenticationReason,
+        allowUserInteraction: Bool
+    ) async -> String? {
+        passphraseToReturn
+    }
+}
+
+struct PassphrasesServiceTest {
+    let client: MockLCPClient
+    let repository: InMemoryLCPPassphraseRepository
+    let service: PassphrasesService
+
+    init() {
+        client = MockLCPClient()
+        repository = InMemoryLCPPassphraseRepository()
+        service = PassphrasesService(client: client, repository: repository)
+    }
+
+    private func createTestLicenseDocument(id: String = UUID().uuidString) throws -> LicenseDocument {
+        let licenseJSON = """
+        {
+            "provider": "https://test.provider.com",
+            "id": "\(id)",
+            "issued": "2024-01-01T00:00:00Z",
+            "updated": "2024-01-01T00:00:00Z",
+            "encryption": {
+                "profile": "http://readium.org/lcp/basic-profile",
+                "content_key": {
+                    "algorithm": "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
+                    "encrypted_value": "dGVzdA=="
+                },
+                "user_key": {
+                    "algorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
+                    "text_hint": "Enter your passphrase",
+                    "key_check": "dGVzdA=="
+                }
+            },
+            "links": [
+                {
+                    "rel": "publication",
+                    "href": "https://test.com/publication",
+                    "type": "application/epub+zip"
+                }
+            ],
+            "user": {
+                "id": "user123",
+                "email": "test@example.com",
+                "name": "Test User"
+            },
+            "rights": {
+                "start": "2024-01-01T00:00:00Z"
+            },
+            "signature": {
+                "algorithm": "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256",
+                "certificate": "dGVzdA==",
+                "value": "dGVzdA=="
+            }
+        }
+        """
+        let data = licenseJSON.data(using: .utf8)!
+        return try LicenseDocument(data: data)
+    }
+
+    @Test func addPassphraseHashesAndStores() async throws {
+        try await service.addPassphrase("my_passphrase", isHashed: false, userID: "user123", provider: "https://test.provider.com")
+
+        let stored = try await repository.passphrases()
+        #expect(stored.count == 1)
+        #expect(stored.contains("my_passphrase".sha256()))
+    }
+
+    @Test func addHashedPassphraseStoresDirectly() async throws {
+        let hash = "a".padding(toLength: 64, withPad: "0", startingAt: 0) // 64 hex characters
+        try await service.addPassphrase(hash, isHashed: true, userID: "user123", provider: "https://test.provider.com")
+
+        let stored = try await repository.passphrases()
+        #expect(stored.count == 1)
+        #expect(stored.contains(hash.lowercased()))
+    }
+
+    @Test func requestReturnsValidPassphraseFromRepository() async throws {
+        let license = try createTestLicenseDocument()
+        let validHash = "my_passphrase".sha256()
+
+        client.validPassphrase = validHash
+
+        try await service.addPassphrase("my_passphrase", isHashed: false, userID: "user123", provider: "https://test.provider.com")
+
+        let auth = MockLCPAuthenticating()
+
+        let result = try await service.request(for: license, authentication: auth, allowUserInteraction: true)
+        #expect(result == validHash)
+    }
+
+    @Test func requestFallsBackToAuthentication() async throws {
+        let license = try createTestLicenseDocument()
+        let clearPassphrase = "my_passphrase"
+        let validHash = clearPassphrase.sha256()
+
+        client.validPassphrase = validHash
+
+        let auth = MockLCPAuthenticating()
+        auth.passphraseToReturn = clearPassphrase
+
+        let result = try await service.request(for: license, authentication: auth, allowUserInteraction: true)
+        #expect(result == validHash)
+
+        let stored = try await repository.passphrases()
+        #expect(stored.contains(validHash))
+    }
+}
+
+private extension String {
+    func sha256() -> String {
+        let digest = SHA256.hash(data: Data(utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Tests/LCPTests/Services/PassphrasesServiceTests.swift
+++ b/Tests/LCPTests/Services/PassphrasesServiceTests.swift
@@ -4,7 +4,6 @@
 //  available in the top-level LICENSE file of the project.
 //
 
-import CryptoKit
 import Foundation
 @testable import ReadiumLCP
 @testable import ReadiumShared
@@ -46,7 +45,7 @@ final class MockLCPAuthenticating: LCPAuthenticating, @unchecked Sendable {
     }
 }
 
-struct PassphrasesServiceTest {
+struct PassphrasesServiceTests {
     let client: MockLCPClient
     let repository: InMemoryLCPPassphraseRepository
     let service: PassphrasesService
@@ -148,12 +147,5 @@ struct PassphrasesServiceTest {
 
         let stored = try await repository.passphrases()
         #expect(stored.contains(validHash))
-    }
-}
-
-private extension String {
-    func sha256() -> String {
-        let digest = SHA256.hash(data: Data(utf8))
-        return digest.map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Tests/NavigatorTests/Decorator/DiffableDecorationTests.swift
+++ b/Tests/NavigatorTests/Decorator/DiffableDecorationTests.swift
@@ -1,0 +1,84 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+@testable import ReadiumNavigator
+@testable import ReadiumShared
+import Testing
+
+struct DiffableDecorationTests {
+    private func makeLocator(href: String) -> Locator {
+        Locator(href: AnyURL(string: href)!, mediaType: .html)
+    }
+
+    private func makeDecoration(id: String, href: String, style: Decoration.Style) -> Decoration {
+        Decoration(id: id, locator: makeLocator(href: href), style: style)
+    }
+
+    @Test func changesByHREF() {
+        let dec1 = makeDecoration(id: "1", href: "/chapter1.html", style: .highlight(isActive: false))
+        let dec2 = makeDecoration(id: "2", href: "/chapter1.html", style: .highlight(isActive: false))
+        let dec3 = makeDecoration(id: "3", href: "/chapter2.html", style: .highlight(isActive: false))
+
+        let source = [
+            DiffableDecoration(decoration: dec1),
+            DiffableDecoration(decoration: dec2),
+            DiffableDecoration(decoration: dec3),
+        ]
+
+        // Modify dec1 (update), remove dec2, keep dec3, add dec4
+        var updatedDec1 = dec1
+        updatedDec1.style = .highlight(isActive: true)
+
+        let dec4 = makeDecoration(id: "4", href: "/chapter1.html", style: .underline(isActive: false))
+        let dec5 = makeDecoration(id: "5", href: "/chapter3.html", style: .highlight(isActive: false))
+
+        let target = [
+            DiffableDecoration(decoration: updatedDec1),
+            DiffableDecoration(decoration: dec3),
+            DiffableDecoration(decoration: dec4),
+            DiffableDecoration(decoration: dec5),
+        ]
+
+        let changes = target.changesByHREF(from: source)
+
+        // Verify /chapter1.html
+        let ch1 = changes[AnyURL(string: "/chapter1.html")!] ?? []
+        #expect(ch1.count == 3)
+
+        var hasUpdate1 = false
+        var hasRemove2 = false
+        var hasAdd4 = false
+
+        for change in ch1 {
+            switch change {
+            case let .update(dec):
+                if dec.id == "1" { hasUpdate1 = true }
+            case let .remove(id):
+                if id == "2" { hasRemove2 = true }
+            case let .add(dec):
+                if dec.id == "4" { hasAdd4 = true }
+            }
+        }
+
+        #expect(hasUpdate1)
+        #expect(hasRemove2)
+        #expect(hasAdd4)
+
+        // Verify /chapter2.html has no changes
+        #expect(changes[AnyURL(string: "/chapter2.html")!] == nil)
+
+        // Verify /chapter3.html
+        let ch3 = changes[AnyURL(string: "/chapter3.html")!] ?? []
+        #expect(ch3.count == 1)
+
+        if case let .add(dec) = ch3.first, dec.id == "5" {
+            // success
+        } else {
+            Issue.record("Expected add change for decoration 5")
+        }
+    }
+}


### PR DESCRIPTION
This PR removes the need for DifferenceKit and CryptoSwift, as both have native Swift solutions. Two tests (DiffableDecorationTests.swift and PassphrasesServiceTest.swift) were created first and all tests in the toolkit ran successfully. Then code changes were made, and tests ran again successfully.

No public APIs are changed.