### PR TITLE
Fixed a crash in `ContentSearchService` with combining grapheme clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ All notable changes to this project will be documented in this file. Take a look
 * The deprecated `ReadiumAdapterGCDWebServer` and `ReadiumAdapterLCPSQLite` adapter packages have been removed.
 * The `ReadiumInternal` package has been removed. Its utilities were internal helpers and are now folded into `ReadiumShared` with `package` visibility. If you imported `ReadiumInternal` directly, remove the import.
 
+### Fixed
+
+#### Shared
+
+* [#876](https://github.com/readium/swift-toolkit/issues/876) Fixed a crash (`String index is out of bounds`) in `ContentSearchService` when searching a publication containing characters merging with the surrounding text, such as combining diacritical marks.
+
 
 <!-- ## [Unreleased] -->
 

--- a/Sources/Shared/Publication/Services/Search/ContentSearchService.swift
+++ b/Sources/Shared/Publication/Services/Search/ContentSearchService.swift
@@ -314,24 +314,43 @@ private actor Iterator: SearchIterator, Loggable {
 
         guard !entryText.isEmpty else { return }
 
+        // `windowTextCount` is recomputed from `windowText` after each append
+        // instead of adding the appended text's count: Swift regroups grapheme
+        // clusters across the junction (e.g. a leading combining mark merges
+        // with the preceding separator space), so the sum can exceed the real
+        // character count and offset arithmetic would later fall out of the
+        // window's bounds (see `windowIndex(at:)`).
         let startOffset: Int
         if windowText.isEmpty {
             startOffset = 0
         } else {
-            // Space separator owned by this (following) entry.
+            // The space separator is owned by this (following) entry and adds
+            // exactly one character, barring degenerate regroupings which
+            // `windowIndex(at:)` clamps.
             windowText.append(" ")
-            windowTextCount += 1
-            startOffset = windowTextCount
+            startOffset = windowTextCount + 1
         }
 
         windowText.append(contentsOf: entryText)
-        windowTextCount += entryText.count
+        windowTextCount = windowText.count
 
         entries.append(ElementEntry(
             text: entryText,
             segments: segments,
             startOffset: startOffset
         ))
+    }
+
+    /// Returns the index in `windowText` at the given character offset, or
+    /// `nil` if the offset falls out of the window's bounds.
+    ///
+    /// Offsets are clamped instead of trapping: window offsets are derived
+    /// from cached character counts, which can briefly overstate the real
+    /// window length when Swift regroups grapheme clusters across an append
+    /// junction (see `appendToWindow`). Callers degrade gracefully (skip the
+    /// trim, drop the match or return no snippet) instead of crashing.
+    private func windowIndex(at offset: Int) -> String.Index? {
+        windowText.index(windowText.startIndex, offsetBy: offset, limitedBy: windowText.endIndex)
     }
 
     /// Resets the window for a new resource.
@@ -421,7 +440,11 @@ private actor Iterator: SearchIterator, Loggable {
             trimAmount = 0
         }
 
-        guard trimAmount > 0 else { return }
+        guard
+            trimAmount > 0,
+            let trimIdx = windowIndex(at: trimAmount),
+            trimIdx < windowText.endIndex
+        else { return }
 
         // Drop leading entries.
         entries.removeFirst(dropCount)
@@ -434,7 +457,6 @@ private actor Iterator: SearchIterator, Loggable {
         searchCeiling -= trimAmount
 
         // Drop prefix from windowText.
-        let trimIdx = windowText.index(windowText.startIndex, offsetBy: trimAmount)
         windowText = String(windowText[trimIdx...])
         windowTextCount -= trimAmount
         isAtResourceStart = false
@@ -462,8 +484,10 @@ private actor Iterator: SearchIterator, Loggable {
     private func search(dangerZoneCapacity: Int) async -> [Locator] {
         guard searchCeiling > searchFloor else { return [] }
 
-        let sliceStart = windowText.index(windowText.startIndex, offsetBy: searchFloor)
-        let sliceEnd = windowText.index(windowText.startIndex, offsetBy: searchCeiling)
+        guard let sliceStart = windowIndex(at: searchFloor) else {
+            return []
+        }
+        let sliceEnd = windowIndex(at: searchCeiling) ?? windowText.endIndex
         let searchSlice = String(windowText[sliceStart ..< sliceEnd])
 
         let ranges = await searchAlgorithm.findRanges(
@@ -507,8 +531,14 @@ private actor Iterator: SearchIterator, Loggable {
             return nil
         }
 
-        let highlightStart = windowText.index(windowText.startIndex, offsetBy: matchStart)
-        let highlightEnd = windowText.index(windowText.startIndex, offsetBy: matchEnd)
+        guard
+            let highlightStart = windowIndex(at: matchStart),
+            let highlightEnd = windowIndex(at: matchEnd)
+        else {
+            log(.error, "Match range (\(matchStart), \(matchEnd)) is out of the window's bounds")
+            return nil
+        }
+
         let highlight = String(
             windowText[highlightStart ..< highlightEnd]
         )
@@ -563,11 +593,14 @@ private actor Iterator: SearchIterator, Loggable {
     /// Returns `nil` if the match is at the very beginning of a resource and
     /// the resulting text is empty after trimming.
     private func extractSnippetBefore(matchStart: Int) -> String? {
-        guard matchStart > 0 else {
+        guard
+            matchStart > 0,
+            let matchStartIndex = windowIndex(at: matchStart)
+        else {
             return nil
         }
 
-        let available = windowText[windowText.startIndex ..< windowText.index(windowText.startIndex, offsetBy: matchStart)]
+        let available = windowText[windowText.startIndex ..< matchStartIndex]
 
         var chars: [Character] = []
         var count = snippetLength
@@ -600,11 +633,13 @@ private actor Iterator: SearchIterator, Loggable {
     /// Returns `nil` if the match is at the very end of a resource and the
     /// resulting text is empty after trimming.
     private func extractSnippetAfter(matchEnd: Int) -> String? {
-        guard matchEnd < windowTextCount else {
+        guard
+            matchEnd < windowTextCount,
+            let afterStart = windowIndex(at: matchEnd)
+        else {
             return nil
         }
 
-        let afterStart = windowText.index(windowText.startIndex, offsetBy: matchEnd)
         let available = windowText[afterStart...]
 
         var result = ""

--- a/Tests/SharedTests/Publication/Services/Search/ContentSearchServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Search/ContentSearchServiceTests.swift
@@ -1,0 +1,136 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumShared
+import Testing
+
+enum ContentSearchServiceTests {
+    /// Regression tests for https://github.com/readium/swift-toolkit/issues/876
+    ///
+    /// When an element's text begins with a character that merges with the
+    /// preceding grapheme cluster (e.g. a combining mark merging with the
+    /// window's space separator), the sliding window's cached character count
+    /// used to run ahead of the real `windowText.count`, and offset arithmetic
+    /// trapped with "String index is out of bounds".
+    struct GraphemeClusterBoundaries {
+        @Test func elementStartingWithCombiningMark() async throws {
+            let results = try await search(query: "夜灯", elements: [
+                ["夜灯亮着，街角安静。"],
+                ["\u{0301}猫在窗台上打盹，夜灯映出影子。"],
+            ])
+
+            #expect(results.count == 2)
+            #expect(results.allSatisfy { $0.text.highlight == "夜灯" })
+        }
+
+        @Test func elementStartingWithVariationSelector() async throws {
+            let results = try await search(query: "夜灯", elements: [
+                ["夜灯亮着，街角安静。"],
+                ["\u{FE0F}猫在窗台上打盹，夜灯映出影子。"],
+            ])
+
+            #expect(results.count == 2)
+            #expect(results.allSatisfy { $0.text.highlight == "夜灯" })
+        }
+
+        /// A segment starting with a combining mark merges with the last
+        /// character of the previous segment inside the same element.
+        @Test func segmentStartingWithCombiningMark() async throws {
+            let results = try await search(query: "夜灯", elements: [
+                ["夜灯亮着，街角安静", "\u{0301}，猫在窗台上打盹，夜灯映出影子。"],
+            ])
+
+            #expect(results.count == 2)
+            #expect(results.allSatisfy { $0.text.highlight == "夜灯" })
+        }
+
+        /// Control: the same content without any cluster-merging character.
+        @Test func plainContent() async throws {
+            let results = try await search(query: "夜灯", elements: [
+                ["夜灯亮着，街角安静。"],
+                ["猫在窗台上打盹，夜灯映出影子。"],
+            ])
+
+            #expect(results.count == 2)
+            #expect(results.allSatisfy { $0.text.highlight == "夜灯" })
+        }
+    }
+}
+
+// MARK: - Helpers
+
+/// Runs a search over a publication whose content is made of one
+/// `TextContentElement` per array of segment texts.
+private func search(query: String, elements segmentTexts: [[String]]) async throws -> [Locator] {
+    let locator = Locator(href: "chap1", mediaType: .html)
+    let elements: [ContentElement] = segmentTexts.map { texts in
+        TextContentElement(
+            locator: locator,
+            role: .body,
+            segments: texts.map { TextContentElement.Segment(locator: locator, text: $0) }
+        )
+    }
+
+    let publication = Publication(
+        manifest: Manifest(
+            metadata: Metadata(title: ""),
+            readingOrder: [Link(href: "chap1", mediaType: .html)]
+        ),
+        servicesBuilder: PublicationServicesBuilder(
+            content: { _ in StubContentService(elements: elements) },
+            search: ContentSearchService.makeFactory()
+        )
+    )
+
+    let iterator = try await publication.search(query: query).get()
+
+    var locators: [Locator] = []
+    while let batch = try await iterator.next().get() {
+        locators.append(contentsOf: batch.locators)
+    }
+    return locators
+}
+
+private final class StubContentService: ContentService {
+    private let elements: [ContentElement]
+
+    init(elements: [ContentElement]) {
+        self.elements = elements
+    }
+
+    func content(from start: Locator?) -> Content? {
+        StubContent(elements: elements)
+    }
+
+    private struct StubContent: Content {
+        let elements: [ContentElement]
+
+        func iterator() -> ContentIterator {
+            StubContentIterator(elements: elements)
+        }
+    }
+
+    private actor StubContentIterator: ContentIterator {
+        private let elements: [ContentElement]
+        private var index = 0
+
+        init(elements: [ContentElement]) {
+            self.elements = elements
+        }
+
+        func next() async throws -> ContentElement? {
+            guard index < elements.count else {
+                return nil
+            }
+            defer { index += 1 }
+            return elements[index]
+        }
+
+        func previous() async throws -> ContentElement? {
+            nil
+        }
+    }
+}


### PR DESCRIPTION
### Fixed

#### Shared

* [#876](https://github.com/readium/swift-toolkit/issues/876) Fixed a crash (`String index is out of bounds`) in `ContentSearchService` when searching a publication containing characters merging with the surrounding text, such as combining diacritical marks.