### PR TITLE
Recycle spread web views to avoid per-navigation WebContent process launches

### DIFF
--- a/Sources/Navigator/EPUB/EPUBFixedSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBFixedSpreadView.swift
@@ -16,18 +16,28 @@ final class EPUBFixedSpreadView: EPUBSpreadView {
     /// URL to load in the iframe once the wrapper page is loaded.
     private var urlToLoad: URL?
 
+    /// Value of `spreadEnabled` the wrapper page was built for. The one- and
+    /// two-page wrappers are different documents, so a view loaded with one of
+    /// them cannot be reused once the setting changed.
+    private var wrapperSpreadEnabled = false
+
+    override var canBeRecycled: Bool {
+        isWrapperLoaded && wrapperSpreadEnabled == viewModel.spreadEnabled
+    }
+
     private static let fixedScript = loadScript(named: "readium-fixed")
 
     required init(
         viewModel: EPUBNavigatorViewModel,
         spread: EPUBSpread,
         scripts: [WKUserScript],
-        animatedLoad: Bool
+        animatedLoad: Bool,
+        webView: WebView? = nil
     ) {
         var scripts = scripts
         scripts.append(WKUserScript(source: Self.fixedScript, injectionTime: .atDocumentStart, forMainFrameOnly: false))
 
-        super.init(viewModel: viewModel, spread: spread, scripts: scripts, animatedLoad: animatedLoad)
+        super.init(viewModel: viewModel, spread: spread, scripts: scripts, animatedLoad: animatedLoad, webView: webView)
     }
 
     override func setupWebView() {
@@ -47,6 +57,7 @@ final class EPUBFixedSpreadView: EPUBSpreadView {
         scrollView.backgroundColor = UIColor.clear
 
         // Loads the wrapper page into the web view.
+        wrapperSpreadEnabled = viewModel.spreadEnabled
         let spreadFile = "fxl-spread-\(viewModel.spreadEnabled ? "two" : "one")"
         if
             let wrapperPageURL = Bundle.module.url(forResource: spreadFile, withExtension: "html", subdirectory: "Assets"),
@@ -113,6 +124,22 @@ final class EPUBFixedSpreadView: EPUBSpreadView {
     }
 
     override func spreadDidLoad() async {
+        resumeGoToContinuations()
+    }
+
+    override var pendingNavigationCount: Int { goToContinuations.count }
+
+    override func resetForReuse() {
+        super.resetForReuse()
+
+        // `isWrapperLoaded` is deliberately left alone: the wrapper page hosts
+        // the iframe and is reused as-is, only the resource it displays
+        // changes.
+        urlToLoad = nil
+        resumeGoToContinuations()
+    }
+
+    private func resumeGoToContinuations() {
         for continuation in goToContinuations {
             continuation.resume()
         }

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -595,10 +595,10 @@ open class EPUBNavigatorViewController: InputObservableViewController,
     private var borrowedWebViews: [WebView] = []
 
     /// Borrows a web view for a new spread view, if a pool is configured.
-    private func checkoutWebView() -> WebView? {
+    private func checkoutWebView() async -> WebView? {
         guard
             let pool = config.webViewPool,
-            let webView = pool.checkout(editingActions: viewModel.editingActions)
+            let webView = await pool.checkout(editingActions: viewModel.editingActions)
         else {
             return nil
         }
@@ -1327,7 +1327,7 @@ extension EPUBNavigatorViewController: EditingActionsControllerDelegate {
 }
 
 extension EPUBNavigatorViewController: PaginationViewDelegate {
-    func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) -> (UIView & PageView)? {
+    func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) async -> (UIView & PageView)? {
         let spread = spreads[index]
 
         // Recycling avoids spawning a web content process, which costs
@@ -1347,7 +1347,7 @@ extension EPUBNavigatorViewController: PaginationViewDelegate {
             animatedLoad: false,
             // A pooled web view has already paid for its process launch and
             // for its first navigation on the Readium scheme.
-            webView: checkoutWebView()
+            webView: await checkoutWebView()
         )
         spreadView.delegate = self
 

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewController.swift
@@ -96,6 +96,15 @@ open class EPUBNavigatorViewController: InputObservableViewController,
         /// Logs the state changes when true.
         public var debugState: Bool
 
+        /// Pool of web views shared with the other navigators of the
+        /// application.
+        ///
+        /// Supplying one lets a navigator reuse web views created — and warmed
+        /// up — before it existed, which is the bulk of the time it takes to
+        /// display a first spread. The pool must outlive the navigators using
+        /// it; hold it at the application level.
+        public var webViewPool: EPUBWebViewPool?
+
         public init(
             preferences: EPUBPreferences = .empty,
             defaults: EPUBDefaults = EPUBDefaults(),
@@ -110,7 +119,8 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             decorationTemplates: [Decoration.Style.Id: HTMLDecorationTemplate] = HTMLDecorationTemplate.defaultTemplates(),
             fontFamilyDeclarations: [AnyHTMLFontFamilyDeclaration] = [],
             readiumCSSRSProperties: CSSRSProperties = CSSRSProperties(),
-            debugState: Bool = false
+            debugState: Bool = false,
+            webViewPool: EPUBWebViewPool? = nil
         ) {
             self.preferences = preferences
             self.defaults = defaults
@@ -123,6 +133,7 @@ open class EPUBNavigatorViewController: InputObservableViewController,
             self.fontFamilyDeclarations = fontFamilyDeclarations
             self.readiumCSSRSProperties = readiumCSSRSProperties
             self.debugState = debugState
+            self.webViewPool = webViewPool
         }
 
         func contentInset(for sizeClass: UIUserInterfaceSizeClass) -> EPUBContentInsets {
@@ -377,6 +388,21 @@ open class EPUBNavigatorViewController: InputObservableViewController,
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+
+        // Hand the borrowed web views back so they outlive this navigator and
+        // spare the next publication their process launch and warm-up.
+        //
+        // `deinit` is not actor-isolated, so the work hops onto the main actor.
+        // Only locals are captured; the pool retains the web views, which is
+        // what keeps them alive once the spread views holding them are gone.
+        if let webViewPool, !borrowedWebViews.isEmpty {
+            let webViews = borrowedWebViews
+            Task { @MainActor in
+                for webView in webViews {
+                    webViewPool.giveBack(webView)
+                }
+            }
+        }
     }
 
     override open func viewDidLoad() {
@@ -546,6 +572,57 @@ open class EPUBNavigatorViewController: InputObservableViewController,
     // MARK: - Pagination and spreads
 
     private var paginationView: PaginationView?
+
+    /// Spread views the pagination view stopped displaying, kept aside to be
+    /// re-targeted instead of rebuilt.
+    ///
+    /// Sized after the pre-load window plus the incoming spread. That is a
+    /// best-effort bound rather than an invariant: the window is expressed in
+    /// positions, and resources reporting no position let the pagination view
+    /// walk further than this. Views handed back beyond the bound are dropped.
+    private lazy var recycledSpreadViews = RecyclingPool<EPUBSpreadView>(
+        capacity: config.preloadPreviousPositionCount + config.preloadNextPositionCount + 1
+    )
+
+    /// The application-wide pool this navigator borrowed web views from.
+    ///
+    /// Captured on the first checkout rather than read from `config`, so that
+    /// `deinit` — which is not actor-isolated — reaches it without going
+    /// through the view model.
+    private var webViewPool: EPUBWebViewPool?
+
+    /// Web views borrowed from ``webViewPool``, handed back on teardown.
+    private var borrowedWebViews: [WebView] = []
+
+    /// Borrows a web view for a new spread view, if a pool is configured.
+    private func checkoutWebView() -> WebView? {
+        guard
+            let pool = config.webViewPool,
+            let webView = pool.checkout(editingActions: viewModel.editingActions)
+        else {
+            return nil
+        }
+
+        webViewPool = pool
+        borrowedWebViews.append(webView)
+        return webView
+    }
+
+    /// Hands a discarded spread view's web view back to the pool, if it came
+    /// from there.
+    ///
+    /// Web views this navigator built itself are deliberately not offered: the
+    /// pool's are created with a non-persistent data store, and mixing the two
+    /// would quietly break that guarantee.
+    private func returnBorrowedWebView(of spreadView: EPUBSpreadView) {
+        let webView = spreadView.webView
+        guard let index = borrowedWebViews.firstIndex(where: { $0 === webView }) else {
+            return
+        }
+
+        borrowedWebViews.remove(at: index)
+        webViewPool?.giveBack(webView)
+    }
 
     private func makePaginationView(hasPositions: Bool) -> PaginationView {
         let view = PaginationView(
@@ -1252,12 +1329,25 @@ extension EPUBNavigatorViewController: EditingActionsControllerDelegate {
 extension EPUBNavigatorViewController: PaginationViewDelegate {
     func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) -> (UIView & PageView)? {
         let spread = spreads[index]
+
+        // Recycling avoids spawning a web content process, which costs
+        // seconds. The user scripts already installed on the pooled view stay
+        // valid, so they are not set up again.
+        //
+        if let spreadView = recycledSpreadViews.pop() {
+            spreadView.retarget(to: spread)
+            return spreadView
+        }
+
         let spreadViewType = (publication.metadata.layout == .fixed) ? EPUBFixedSpreadView.self : EPUBReflowableSpreadView.self
         let spreadView = spreadViewType.init(
             viewModel: viewModel,
             spread: spread,
             scripts: [],
-            animatedLoad: false
+            animatedLoad: false,
+            // A pooled web view has already paid for its process launch and
+            // for its first navigation on the Readium scheme.
+            webView: checkoutWebView()
         )
         spreadView.delegate = self
 
@@ -1265,6 +1355,19 @@ extension EPUBNavigatorViewController: PaginationViewDelegate {
         delegate?.navigator(self, setupUserScripts: userContentController)
 
         return spreadView
+    }
+
+    func paginationView(_ paginationView: PaginationView, didEndDisplayingView view: UIView & PageView, atIndex index: Int) {
+        guard let spreadView = view as? EPUBSpreadView else {
+            return
+        }
+
+        if !recycledSpreadViews.push(spreadView) {
+            // The spread view is about to be released. Anything it borrowed
+            // goes back now: held until this navigator is torn down, it would
+            // sit idle while other navigators build web views from scratch.
+            returnBorrowedWebView(of: spreadView)
+        }
     }
 
     func paginationViewDidUpdateViews(_ paginationView: PaginationView) {

--- a/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
+++ b/Sources/Navigator/EPUB/EPUBNavigatorViewModel.swift
@@ -28,6 +28,13 @@ enum EPUBScriptScope {
     /// The base URL for the publication resources.
     private(set) var publicationBaseURL: AbsoluteURL!
 
+    /// Route the publication resources are registered at on the `server`, when
+    /// this view model registered them itself.
+    ///
+    /// `nil` when the publication is already reachable at its own base URL, in
+    /// which case the server only serves the static assets.
+    private(set) var publicationRoute: String?
+
     /// The base URL for Readium assets (CSS, scripts, etc.) and fonts.
     let assetsBaseURL: any AbsoluteURL
 
@@ -51,10 +58,15 @@ enum EPUBScriptScope {
         let assetsDirectory = Bundle.module.resourceURL!.fileURL!
             .appendingPath("Assets/Static", isDirectory: true)
 
-        let formatSniffer = DefaultFormatSniffer()
-        let server = WebViewServer(scheme: "readium", formatSniffer: formatSniffer)
+        // Shared by every navigator: a web view's URL scheme handler is fixed
+        // when its configuration is built, so web views can only be reused
+        // across navigators that the same server serves.
+        let server = WebViewServer.shared
+        let formatSniffer = server.formatSniffer
 
-        // Serve static assets directory.
+        // Serve the static assets directory. Registering a route twice
+        // replaces the previous entry, so this stays correct once several
+        // navigators share the server.
         let assetsBaseURL = server.serve(directory: assetsDirectory, at: "assets")
 
         self.init(
@@ -73,7 +85,9 @@ enum EPUBScriptScope {
             publicationBaseURL = url
         } else {
             // Serve publication resources.
-            publicationBaseURL = server.serve(at: UUID().uuidString) { [weak self] in
+            let route = UUID().uuidString
+            publicationRoute = route
+            publicationBaseURL = server.serve(at: route) { [weak self] in
                 await self?.serve(href: $0)
             }
         }
@@ -148,6 +162,20 @@ enum EPUBScriptScope {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+
+        // Give the publication's route back, otherwise a server outliving this
+        // view model would keep both the route and everything it cached for as
+        // long as it lives.
+        //
+        // `deinit` is not actor-isolated, so the work is hopped onto the main
+        // actor the server is bound to. Capturing `server` keeps it alive until
+        // the hop runs.
+        if let publicationRoute {
+            let server = server
+            Task { @MainActor in
+                server.remove(at: publicationRoute)
+            }
+        }
     }
 
     func url(to link: Link) -> AnyURL {
@@ -354,7 +382,12 @@ enum EPUBScriptScope {
         // (e.g. after a screen rotation) reflects the updated CSS instead of
         // the stale cached version. Non-HTML resources (images, audio, etc.)
         // are not affected by CSS changes and can remain cached.
-        server.clearResourceCache { _, mediaType in mediaType.isHTML }
+        //
+        // Scoped to this publication's route: the server may be serving others,
+        // whose resources this settings change does not affect.
+        if let publicationRoute {
+            server.clearResourceCache(atRoute: publicationRoute) { _, mediaType in mediaType.isHTML }
+        }
 
         if commitNow {
             commitCSSChange(from: previous, to: css)

--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -21,7 +21,8 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
         viewModel: EPUBNavigatorViewModel,
         spread: EPUBSpread,
         scripts: [WKUserScript],
-        animatedLoad: Bool
+        animatedLoad: Bool,
+        webView: WebView? = nil
     ) {
         super.init(
             viewModel: viewModel,
@@ -29,8 +30,23 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
             scripts: [
                 WKUserScript(source: Self.reflowableScript, injectionTime: .atDocumentStart, forMainFrameOnly: false),
             ],
-            animatedLoad: animatedLoad
+            animatedLoad: animatedLoad,
+            webView: webView
         )
+    }
+
+    override var pendingNavigationCount: Int { goToContinuations.count }
+
+    override func resetForReuse() {
+        super.resetForReuse()
+
+        // A page-change notification scheduled for the previous spread would
+        // otherwise fire against the new one.
+        NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(notifyPagesDidChange), object: nil)
+
+        pendingLocation = PendingLocation(location: .start, animated: false)
+        progression = nil
+        previousProgression = nil
     }
 
     override func clear() {

--- a/Sources/Navigator/EPUB/EPUBSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBSpreadView.swift
@@ -42,10 +42,13 @@ protocol EPUBSpreadViewDelegate: AnyObject {
     func spreadViewDidTerminate()
 }
 
-class EPUBSpreadView: UIView, Loggable, PageView {
+class EPUBSpreadView: UIView, Loggable, PageView, Recyclable {
     weak var delegate: EPUBSpreadViewDelegate?
     let viewModel: EPUBNavigatorViewModel
-    let spread: EPUBSpread
+
+    /// The spread currently rendered by this view. Changed by
+    /// ``retarget(to:)`` when the view is recycled.
+    private(set) var spread: EPUBSpread
     private(set) var focusedResource: ReadingOrder.Index?
 
     let webView: WebView
@@ -65,23 +68,30 @@ class EPUBSpreadView: UIView, Loggable, PageView {
         viewModel: EPUBNavigatorViewModel,
         spread: EPUBSpread,
         scripts: [WKUserScript],
-        animatedLoad: Bool
+        animatedLoad: Bool,
+        webView pooledWebView: WebView? = nil
     ) {
         self.viewModel = viewModel
         self.spread = spread
         self.animatedLoad = animatedLoad
 
-        let config = WKWebViewConfiguration()
-        config.setURLSchemeHandler(viewModel.server, forURLScheme: viewModel.server.scheme)
-        config.mediaTypesRequiringUserActionForPlayback = .all
+        if let pooledWebView {
+            // Built against the shared server and already rebound to this
+            // publication's editing rights by the pool.
+            webView = pooledWebView
+        } else {
+            let config = WKWebViewConfiguration()
+            config.setURLSchemeHandler(viewModel.server, forURLScheme: viewModel.server.scheme)
+            config.mediaTypesRequiringUserActionForPlayback = .all
 
-        // Disable the Apple Intelligence Writing tools in the web views.
-        // See https://github.com/readium/swift-toolkit/issues/509#issuecomment-2577780749
-        if #available(iOS 18.0, *) {
-            config.writingToolsBehavior = .none
+            // Disable the Apple Intelligence Writing tools in the web views.
+            // See https://github.com/readium/swift-toolkit/issues/509#issuecomment-2577780749
+            if #available(iOS 18.0, *) {
+                config.writingToolsBehavior = .none
+            }
+
+            webView = WebView(editingActions: viewModel.editingActions, configuration: config)
         }
-
-        webView = WebView(editingActions: viewModel.editingActions, configuration: config)
 
         super.init(frame: .zero)
 
@@ -116,6 +126,8 @@ class EPUBSpreadView: UIView, Loggable, PageView {
 
         spreadLoadTask?.cancel()
         spreadLoadTask = nil
+
+        cancelActivityIndicatorStop()
 
         // Disable JS messages to break WKUserContentController reference.
         disableJSMessages()
@@ -168,6 +180,73 @@ class EPUBSpreadView: UIView, Loggable, PageView {
 
     func loadSpread() {
         fatalError("loadSpread() must be implemented in subclasses")
+    }
+
+    /// Whether this view can be re-targeted to another spread, or has to be
+    /// thrown away.
+    ///
+    /// Overridden by subclasses baking settings into the web view that
+    /// ``retarget(to:)`` cannot undo.
+    var canBeRecycled: Bool { true }
+
+    /// Points this view at another spread and reloads it, instead of building
+    /// a brand new view.
+    ///
+    /// Creating an `EPUBSpreadView` spawns a web content process, which costs
+    /// orders of magnitude more than navigating an existing web view to
+    /// another resource. Recycling views keeps that cost to the first spreads
+    /// only.
+    ///
+    /// The view behaves like a freshly built one afterwards: it is not loaded,
+    /// and the location to display is applied through the usual
+    /// `go(to:animated:)` call once the document is ready.
+    ///
+    /// - Precondition: No navigation towards the previous spread may still be
+    ///   in flight. Recycling resumes such callers without having moved
+    ///   anywhere, so the caller has to be one that no longer acts on the
+    ///   result. `PaginationView` satisfies this by cancelling its loading
+    ///   task in the same synchronous turn that flushes the view.
+    func retarget(to spread: EPUBSpread) {
+        if pendingNavigationCount > 0 {
+            // Routine whenever a pre-load was interrupted: the reader swiped
+            // quickly, or jumped through the table of contents past a
+            // neighbour that had not finished loading yet. Logged only to make
+            // the hand-off visible when tracing a navigation.
+            log(.debug, "Recycling a spread view away from \(self.spread.first.link.href) with \(pendingNavigationCount) navigation(s) still awaiting it; they are resumed without having moved.")
+        }
+
+        self.spread = spread
+
+        resetForReuse()
+        updateActivityIndicator()
+        loadSpread()
+    }
+
+    /// Navigations suspended until the spread finishes loading.
+    ///
+    /// Subclasses letting `go(to:animated:)` suspend must report them, so that
+    /// recycling can flag the ones abandoned half-way.
+    var pendingNavigationCount: Int { 0 }
+
+    /// Discards the state tied to the spread this view was previously
+    /// rendering.
+    ///
+    /// Subclasses holding per-spread state must override this and call
+    /// `super`.
+    func resetForReuse() {
+        // Cancels pending operations and resumes anything awaiting the
+        // previous spread.
+        clear()
+
+        isSpreadLoaded = false
+        focusedResource = nil
+        lastClick = nil
+
+        // `clear()` disabled the JS messages to break the retain cycle while
+        // the view was off screen. They must be back on before the reloaded
+        // document starts emitting, in particular `spreadLoaded`, rather than
+        // waiting for `didMoveToSuperview`.
+        enableJSMessages()
     }
 
     /// Evaluates the given JavaScript into the resource's HTML page.
@@ -391,7 +470,8 @@ class EPUBSpreadView: UIView, Loggable, PageView {
         }
     }
 
-    private func spreadLoadDidStart(_ body: Any) {}
+    private func spreadLoadDidStart(_ body: Any) {
+    }
 
     /// Called by the javascript code when the spread contents is fully loaded.
     /// The JS message `spreadLoaded` needs to be emitted by a subclass script, EPUBSpreadView's scripts don't.
@@ -435,7 +515,7 @@ class EPUBSpreadView: UIView, Loggable, PageView {
 
     func showSpread() {
         activityIndicatorView?.stopAnimating()
-        activityIndicatorStopWorkItem?.cancel()
+        cancelActivityIndicatorStop()
         UIView.animate(withDuration: animatedLoad ? 0.3 : 0, animations: {
             self.scrollView.alpha = 1
         })
@@ -640,6 +720,12 @@ extension EPUBSpreadView: WKScriptMessageHandler {
 }
 
 extension EPUBSpreadView: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+    }
+
+    func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+    }
+
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         log(.error, error)
     }
@@ -713,6 +799,17 @@ private extension EPUBSpreadView {
 
         activityIndicatorView?.removeFromSuperview()
         activityIndicatorView = addCenteredActivityIndicator(color: color)
+    }
+
+    /// Cancels the pending activity indicator timeout, if any.
+    ///
+    /// Clearing the reference matters: a cancelled `DispatchWorkItem` never
+    /// runs its body, so it cannot nil itself out, and
+    /// ``setNeedsStopActivityIndicator()`` would then refuse to ever schedule
+    /// another one.
+    private func cancelActivityIndicatorStop() {
+        activityIndicatorStopWorkItem?.cancel()
+        activityIndicatorStopWorkItem = nil
     }
 
     private func setNeedsStopActivityIndicator() {

--- a/Sources/Navigator/EPUB/EPUBWebViewPool.swift
+++ b/Sources/Navigator/EPUB/EPUBWebViewPool.swift
@@ -1,0 +1,300 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+import WebKit
+
+/// A pool of web views shared by the EPUB navigators of an application.
+///
+/// Creating a `WKWebView` spawns a web content process, and the first
+/// navigation on a custom URL scheme costs seconds more, once per web view.
+/// Together they dominate the time it takes to display the first spread of a
+/// publication.
+///
+/// Hold a pool for the lifetime of the application, ``prewarm(count:)`` it
+/// while the reader is still browsing, and pass it to
+/// ``EPUBNavigatorViewController/Configuration/webViewPool``. Web views
+/// outlive the navigators using them and are handed back when a navigator goes
+/// away, so opening a second publication reuses the first one's web views.
+///
+/// The pool is safe to share across publications: every web view is stripped
+/// of the previous navigator's scripts, message handlers and editing rights
+/// before being handed out.
+@MainActor
+public final class EPUBWebViewPool {
+    /// Maximum number of web views kept alive.
+    public let capacity: Int
+
+    private var available: [WebView] = []
+
+    /// How many web views the pool has been asked to keep ready.
+    private var prewarmTarget = 0
+
+    /// Web views handed out and not given back yet.
+    ///
+    /// While any is outstanding a reader is on screen, and the pool stays out
+    /// of its way.
+    private var borrowedCount = 0
+
+    /// Web views being warmed up right now, kept so the work can be abandoned
+    /// when a reader needs the device.
+    private var warmingUp: [WebView] = []
+
+    /// Whether the warm-up in progress was interrupted by a reader.
+    private var didAbortWarmup = false
+
+    /// Creates a pool holding at most `capacity` web views.
+    ///
+    /// The default covers the first spread and its immediate neighbours, which
+    /// is what the reader waits on. A navigator's full pre-load window is
+    /// larger, so the spreads beyond those fall back to building web views
+    /// from scratch — off the critical path, while the reader is already
+    /// reading. Worth revisiting once the trade-off has been measured.
+    public init(capacity: Int = 4) {
+        precondition(capacity >= 0)
+        self.capacity = capacity
+    }
+
+    /// Number of web views ready to be handed out.
+    public var count: Int { available.count }
+
+    /// Creates web views ahead of time and pays their one-off costs, so that
+    /// opening a publication does not have to.
+    ///
+    /// Call this once the application's window is up and the reader is doing
+    /// something else. Each web view spawns its web content process and
+    /// performs a real navigation on the Readium URL scheme, which is what
+    /// discharges the expensive first navigation. The warm-ups run together
+    /// rather than one after another.
+    ///
+    /// ### Yielding to the reader
+    ///
+    /// Warming up competes with a publication being opened, to the point of
+    /// making the open slower than having no pool at all. The pool therefore
+    /// never works while a reader does:
+    ///
+    /// - a checkout abandons whatever is still warming up, and web views whose
+    ///   navigation was cut short are discarded rather than pooled, since they
+    ///   may not have paid the first-navigation cost;
+    /// - nothing is built again while web views are still out on loan. A
+    ///   reading session needs no new stock: the web views come back when the
+    ///   navigator goes away, which restocks the pool for free;
+    /// - returning the last borrowed web view tops the pool back up if it
+    ///   ended up below the target.
+    ///
+    /// A pool emptied by a reader that borrowed nothing back stays empty, as
+    /// there is no return to trigger a refill. Call this method again to
+    /// restock; it is safe at any point and does nothing while a reader holds
+    /// web views.
+    public func prewarm(count: Int) async {
+        prewarmTarget = min(max(prewarmTarget, count), capacity)
+        await refill()
+    }
+
+    /// Brings the pool up to its prewarm target, unless a reader is using it.
+    private func refill() async {
+        guard borrowedCount == 0, warmingUp.isEmpty else {
+            return
+        }
+
+        let missing = min(prewarmTarget, capacity) - available.count
+        guard missing > 0 else {
+            return
+        }
+
+        didAbortWarmup = false
+        warmingUp = (0 ..< missing).map { _ in Self.makeWebView() }
+
+        // The navigations are independent, so they run together. WebKit may
+        // still serialize process spawns internally, but that is its call to
+        // make, not ours.
+        await withTaskGroup(of: WebView?.self) { group in
+            for webView in warmingUp {
+                group.addTask { @MainActor in
+                    await Self.warmUp(webView)
+                    // A navigation that was stopped part-way may not have paid
+                    // the first-navigation cost. Pooling such a web view would
+                    // hand that cost to the reader later, unpredictably.
+                    return self.didAbortWarmup ? nil : webView
+                }
+            }
+
+            for await webView in group {
+                if let webView, available.count < capacity {
+                    available.append(webView)
+                }
+            }
+        }
+
+        warmingUp = []
+    }
+
+    /// Abandons any warm-up in flight so it stops competing with a reader.
+    ///
+    /// Stopping the navigation is what actually frees the device: cancelling
+    /// the task alone would not, since a warm-up sits waiting on its
+    /// navigation delegate.
+    private func abortWarmup() {
+        guard !warmingUp.isEmpty else {
+            return
+        }
+
+        didAbortWarmup = true
+        for webView in warmingUp {
+            webView.stopLoading()
+        }
+    }
+
+    // MARK: - Checkout
+
+    /// Hands out a web view bound to the given publication's editing rights,
+    /// or `nil` if the pool is empty.
+    ///
+    /// This is the only way to obtain a web view from the pool, so that one
+    /// cannot reach a navigator while still carrying the previous
+    /// publication's scripts, message handlers or rights.
+    func checkout(editingActions: EditingActionsController) -> WebView? {
+        // A reader is opening a publication, whether or not the pool can serve
+        // it. Warming up alongside would slow that open down more than the
+        // pool speeds it up.
+        abortWarmup()
+
+        guard !available.isEmpty else {
+            return nil
+        }
+
+        borrowedCount += 1
+        let webView = available.removeLast()
+
+        // Stripped again on the way out, even though `giveBack` already did:
+        // the cost is negligible and it keeps the guarantee local to the one
+        // function that hands web views to navigators.
+        strip(webView)
+        webView.rebind(editingActions: editingActions)
+        return webView
+    }
+
+    /// Takes a web view back once its navigator is gone.
+    ///
+    /// The web view is stripped right away rather than on its way out again:
+    /// an idling pooled web view must not keep the previous publication's
+    /// scripts installed, nor keep its editing rights controller — and through
+    /// it the publication's `UserRights` — alive.
+    ///
+    /// Ignored when the pool is already full, letting the web view be
+    /// released.
+    func giveBack(_ webView: WebView) {
+        borrowedCount = max(0, borrowedCount - 1)
+
+        guard available.count < capacity else {
+            return
+        }
+
+        strip(webView)
+        available.append(webView)
+
+        // The reading session is over. Returns usually restock the pool on
+        // their own; build the difference only if they did not.
+        if borrowedCount == 0, available.count < prewarmTarget {
+            Task { await refill() }
+        }
+    }
+
+    /// Removes everything a navigator installed on a web view, leaving it
+    /// bound to no publication.
+    private func strip(_ webView: WebView) {
+        webView.stopLoading()
+        webView.removeFromSuperview()
+
+        // Scripts and handlers are installed per navigator, in
+        // `EPUBSpreadView.init` and through the `setupUserScripts` delegate.
+        // Removing them does not re-arm the first-navigation cost.
+        let contentController = webView.configuration.userContentController
+        contentController.removeAllUserScripts()
+        contentController.removeAllScriptMessageHandlers()
+
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
+        webView.scrollView.delegate = nil
+
+        webView.unbindFromPublication()
+    }
+
+    // MARK: - Web view creation
+
+    /// Builds a web view bound to the shared server.
+    ///
+    /// The URL scheme handler is registered on the configuration before the
+    /// web view is created, because it cannot be changed afterwards. This is
+    /// why pooled web views only work with navigators served by
+    /// ``WebViewServer/shared``.
+    static func makeWebView() -> WebView {
+        let server = WebViewServer.shared
+
+        let config = WKWebViewConfiguration()
+        config.setURLSchemeHandler(server, forURLScheme: server.scheme)
+        config.mediaTypesRequiringUserActionForPlayback = .all
+
+        // Publication documents have no use for persistent storage, and their
+        // origin embeds a per-navigator identifier: anything written would be
+        // unreachable on the next open and would only accumulate on disk.
+        config.websiteDataStore = .nonPersistent()
+
+        // Disable the Apple Intelligence Writing tools in the web views.
+        // See https://github.com/readium/swift-toolkit/issues/509#issuecomment-2577780749
+        if #available(iOS 18.0, *) {
+            config.writingToolsBehavior = .none
+        }
+
+        // No publication is bound yet: the web view denies every editing
+        // action until `checkout(editingActions:)` rebinds it.
+        return WebView(configuration: config)
+    }
+
+    /// Performs the first navigation on the Readium scheme, which every web
+    /// view pays once.
+    private static func warmUp(_ webView: WebView) async {
+        let delegate = WarmupNavigationDelegate()
+        webView.navigationDelegate = delegate
+        defer { webView.navigationDelegate = nil }
+
+        webView.load(URLRequest(url: WebViewServer.shared.warmupURL.url))
+        await delegate.wait()
+    }
+}
+
+/// Awaits the end of the warm-up navigation.
+private final class WarmupNavigationDelegate: NSObject, WKNavigationDelegate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isDone = false
+
+    func wait() async {
+        guard !isDone else {
+            return
+        }
+
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    private func finish() {
+        isDone = true
+        let continuation = continuation
+        self.continuation = nil
+        continuation?.resume()
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        finish()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {
+        finish()
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: any Error) {
+        finish()
+    }
+}

--- a/Sources/Navigator/EPUB/EPUBWebViewPool.swift
+++ b/Sources/Navigator/EPUB/EPUBWebViewPool.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import ReadiumInternal
 import WebKit
 
 /// A pool of web views shared by the EPUB navigators of an application.
@@ -39,12 +40,26 @@ public final class EPUBWebViewPool {
     /// of its way.
     private var borrowedCount = 0
 
-    /// Web views being warmed up right now, kept so the work can be abandoned
-    /// when a reader needs the device.
-    private var warmingUp: [WebView] = []
+    /// Warm-ups started and not finished yet.
+    private var pendingWarmups = 0
 
-    /// Whether the warm-up in progress was interrupted by a reader.
-    private var didAbortWarmup = false
+    /// Checkouts waiting for one of those warm-ups, oldest first.
+    ///
+    /// Each is promised the next warm-up to finish, or `nil` if that one
+    /// failed, so no caller is left hanging.
+    private var waiters: [CheckoutWaiter] = []
+
+    /// How long a single warm-up is given before the pool stops counting on
+    /// it. Generous on purpose: a warm-up this slow is broken, not busy.
+    static let defaultWarmupTimeout: TimeInterval = 15
+
+    private let warmupTimeout: TimeInterval
+
+    /// Builds a web view and pays its one-off costs, or returns `nil` if that
+    /// failed.
+    typealias WarmupFactory = @MainActor () async -> WebView?
+
+    private let warmup: WarmupFactory
 
     /// Creates a pool holding at most `capacity` web views.
     ///
@@ -53,13 +68,34 @@ public final class EPUBWebViewPool {
     /// larger, so the spreads beyond those fall back to building web views
     /// from scratch — off the critical path, while the reader is already
     /// reading. Worth revisiting once the trade-off has been measured.
-    public init(capacity: Int = 4) {
+    public convenience init(capacity: Int = 4) {
+        self.init(capacity: capacity, warmup: { await Self.makeWarmedWebView() })
+    }
+
+    /// Creates a pool that builds its web views with the given factory.
+    ///
+    /// Exists so tests can drive warm-ups deterministically; a real warm-up
+    /// finishes whenever WebKit says so, which makes the timing of a checkout
+    /// racing one impossible to pin down.
+    init(
+        capacity: Int,
+        warmupTimeout: TimeInterval = EPUBWebViewPool.defaultWarmupTimeout,
+        warmup: @escaping WarmupFactory
+    ) {
         precondition(capacity >= 0)
         self.capacity = capacity
+        self.warmupTimeout = warmupTimeout
+        self.warmup = warmup
     }
 
     /// Number of web views ready to be handed out.
     public var count: Int { available.count }
+
+    /// Whether a warm-up is in flight that a checkout could wait for.
+    var isWarmingUp: Bool { pendingWarmups > 0 }
+
+    /// Whether a checkout is currently waiting for a warm-up to finish.
+    var hasWaitingCheckouts: Bool { !waiters.isEmpty }
 
     /// Creates web views ahead of time and pays their one-off costs, so that
     /// opening a publication does not have to.
@@ -70,17 +106,19 @@ public final class EPUBWebViewPool {
     /// discharges the expensive first navigation. The warm-ups run together
     /// rather than one after another.
     ///
-    /// ### Yielding to the reader
+    /// ### Sharing the device with the reader
     ///
-    /// Warming up competes with a publication being opened, to the point of
-    /// making the open slower than having no pool at all. The pool therefore
-    /// never works while a reader does:
+    /// A publication opened while the pool is still warming up must not have
+    /// to compete with it:
     ///
-    /// - a checkout abandons whatever is still warming up, and web views whose
-    ///   navigation was cut short are discarded rather than pooled, since they
-    ///   may not have paid the first-navigation cost;
-    /// - nothing is built again while web views are still out on loan. A
-    ///   reading session needs no new stock: the web views come back when the
+    /// - a checkout that finds the pool empty but a warm-up in flight waits
+    ///   for it instead of building its own. The warm-up started earlier, so
+    ///   its remainder is always less than a fresh build, and waiting keeps
+    ///   the two from fighting over the device. Abandoning it and starting
+    ///   over — which is what this used to do — measured worse than having no
+    ///   pool at all;
+    /// - nothing new is built while web views are out on loan. A reading
+    ///   session needs no fresh stock: the web views come back when the
     ///   navigator goes away, which restocks the pool for free;
     /// - returning the last borrowed web view tops the pool back up if it
     ///   ended up below the target.
@@ -96,7 +134,7 @@ public final class EPUBWebViewPool {
 
     /// Brings the pool up to its prewarm target, unless a reader is using it.
     private func refill() async {
-        guard borrowedCount == 0, warmingUp.isEmpty else {
+        guard borrowedCount == 0, pendingWarmups == 0 else {
             return
         }
 
@@ -105,69 +143,108 @@ public final class EPUBWebViewPool {
             return
         }
 
-        didAbortWarmup = false
-        warmingUp = (0 ..< missing).map { _ in Self.makeWebView() }
+        pendingWarmups = missing
 
         // The navigations are independent, so they run together. WebKit may
         // still serialize process spawns internally, but that is its call to
         // make, not ours.
         await withTaskGroup(of: WebView?.self) { group in
-            for webView in warmingUp {
+            for _ in 0 ..< missing {
                 group.addTask { @MainActor in
-                    await Self.warmUp(webView)
-                    // A navigation that was stopped part-way may not have paid
-                    // the first-navigation cost. Pooling such a web view would
-                    // hand that cost to the reader later, unpredictably.
-                    return self.didAbortWarmup ? nil : webView
+                    await self.boundedWarmup()
                 }
             }
 
+            // Handed over one at a time, as each finishes, so a checkout
+            // waiting for one is served the moment it is ready instead of
+            // when the whole batch is.
             for await webView in group {
-                if let webView, available.count < capacity {
-                    available.append(webView)
-                }
+                pendingWarmups -= 1
+                deliver(webView)
             }
         }
-
-        warmingUp = []
     }
 
-    /// Abandons any warm-up in flight so it stops competing with a reader.
+    /// Runs one warm-up, giving up on it after ``warmupTimeout``.
     ///
-    /// Stopping the navigation is what actually frees the device: cancelling
-    /// the task alone would not, since a warm-up sits waiting on its
-    /// navigation delegate.
-    private func abortWarmup() {
-        guard !warmingUp.isEmpty else {
-            return
+    /// A warm-up that never comes back would leave `pendingWarmups` above zero
+    /// for the rest of the process: every later refill would decline to run
+    /// and every waiter would wait forever. The web content process dying is
+    /// the realistic way that happens, and it is handled directly, but this
+    /// backstop means no unforeseen stall can wedge the pool either.
+    ///
+    /// The warm-up itself cannot be forced to return, so it is left running.
+    /// Should it finish late, its web view is still perfectly good and goes
+    /// back into circulation.
+    private func boundedWarmup() async -> WebView? {
+        await withCheckedContinuation { continuation in
+            let slot = WarmupSlot(continuation)
+
+            let timeout = Task { @MainActor in
+                try? await Task.sleep(seconds: warmupTimeout)
+                slot.resolve(nil)
+            }
+
+            Task { @MainActor in
+                let webView = await warmup()
+                timeout.cancel()
+
+                if !slot.resolve(webView), let webView {
+                    // Timed out before this landed. The web view is fine, so
+                    // it is offered rather than thrown away.
+                    deliver(webView)
+                }
+            }
+        }
+    }
+
+    /// Passes a finished warm-up to whoever is waiting for one, or shelves it.
+    ///
+    /// `nil` means the warm-up failed; the waiter is resumed with it anyway so
+    /// that it falls back to building its own rather than hanging.
+    private func deliver(_ webView: WebView?) {
+        while !waiters.isEmpty {
+            let waiter = waiters.removeFirst()
+            if waiter.resolve(webView) {
+                return
+            }
+            // That one was cancelled between being queued and now; try the
+            // next in line.
         }
 
-        didAbortWarmup = true
-        for webView in warmingUp {
-            webView.stopLoading()
+        if let webView, available.count < capacity {
+            available.append(webView)
         }
+    }
+
+    /// Drops a waiter whose checkout was cancelled, releasing it with nothing.
+    private func cancelWaiter(_ waiter: CheckoutWaiter) {
+        waiters.removeAll { $0 === waiter }
+        waiter.resolve(nil)
     }
 
     // MARK: - Checkout
 
-    /// Hands out a web view bound to the given publication's editing rights,
-    /// or `nil` if the pool is empty.
+    /// Hands out a web view bound to the given publication's editing rights.
+    ///
+    /// Returns one straight away when the pool has stock. When it does not but
+    /// a warm-up is in flight, it waits for that warm-up rather than letting
+    /// the caller build a web view alongside it: the warm-up is already part
+    /// way through, so its remainder costs less than a fresh build, and the
+    /// two would otherwise compete.
+    ///
+    /// Returns `nil` only when there is nothing to wait for, or when the
+    /// warm-up it waited for failed. The caller then builds its own.
     ///
     /// This is the only way to obtain a web view from the pool, so that one
     /// cannot reach a navigator while still carrying the previous
     /// publication's scripts, message handlers or rights.
-    func checkout(editingActions: EditingActionsController) -> WebView? {
-        // A reader is opening a publication, whether or not the pool can serve
-        // it. Warming up alongside would slow that open down more than the
-        // pool speeds it up.
-        abortWarmup()
-
-        guard !available.isEmpty else {
+    func checkout(editingActions: EditingActionsController) async -> WebView? {
+        guard let webView = await claimWebView() else {
             return nil
         }
 
         borrowedCount += 1
-        let webView = available.removeLast()
 
         // Stripped again on the way out, even though `giveBack` already did:
         // the cost is negligible and it keeps the guarantee local to the one
@@ -175,6 +252,35 @@ public final class EPUBWebViewPool {
         strip(webView)
         webView.rebind(editingActions: editingActions)
         return webView
+    }
+
+    /// Takes a web view off the shelf, or waits for one being warmed up.
+    private func claimWebView() async -> WebView? {
+        if let webView = available.popLast() {
+            return webView
+        }
+
+        // Only wait when a warm-up is in flight that nobody ahead in the queue
+        // has already been promised — otherwise this would wait for something
+        // that is never coming.
+        guard pendingWarmups > waiters.count else {
+            return nil
+        }
+
+        let waiter = CheckoutWaiter()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                waiter.attach(continuation)
+                waiters.append(waiter)
+            }
+        } onCancel: {
+            // A cancelled load chain has no use for a web view any more, and
+            // should not sit through the rest of a warm-up to find that out.
+            // The warm-up carries on; whatever it produces is shelved.
+            Task { @MainActor in
+                cancelWaiter(waiter)
+            }
+        }
     }
 
     /// Takes a web view back once its navigator is gone.
@@ -188,13 +294,13 @@ public final class EPUBWebViewPool {
     /// released.
     func giveBack(_ webView: WebView) {
         borrowedCount = max(0, borrowedCount - 1)
-
-        guard available.count < capacity else {
-            return
-        }
-
         strip(webView)
-        available.append(webView)
+
+        // Through the same funnel as a finished warm-up: a checkout already
+        // waiting should be handed this one rather than sit through a warm-up
+        // that has not landed yet. Shelved instead when nobody is waiting, and
+        // dropped when there is no room.
+        deliver(webView)
 
         // The reading session is over. Returns usually restock the pool on
         // their own; build the difference only if they did not.
@@ -254,47 +360,130 @@ public final class EPUBWebViewPool {
         return WebView(configuration: config)
     }
 
+    /// Builds a web view and performs its first navigation on the Readium
+    /// scheme, the cost every web view pays once.
+    private static func makeWarmedWebView() async -> WebView? {
+        let webView = makeWebView()
+        return await warmUp(webView) ? webView : nil
+    }
+
     /// Performs the first navigation on the Readium scheme, which every web
     /// view pays once.
-    private static func warmUp(_ webView: WebView) async {
+    ///
+    /// - Returns: Whether the navigation succeeded. A web view whose warm-up
+    ///   failed has not paid that cost and is not worth pooling.
+    private static func warmUp(_ webView: WebView) async -> Bool {
         let delegate = WarmupNavigationDelegate()
         webView.navigationDelegate = delegate
         defer { webView.navigationDelegate = nil }
 
         webView.load(URLRequest(url: WebViewServer.shared.warmupURL.url))
-        await delegate.wait()
+        return await delegate.wait()
+    }
+}
+
+/// One pending warm-up, resolved by whichever of the warm-up itself or the
+/// timeout gets there first.
+@MainActor
+private final class WarmupSlot {
+    private var continuation: CheckedContinuation<WebView?, Never>?
+    private var isResolved = false
+
+    init(_ continuation: CheckedContinuation<WebView?, Never>) {
+        self.continuation = continuation
+    }
+
+    /// - Returns: Whether this call is the one that resolved the slot.
+    @discardableResult
+    func resolve(_ webView: WebView?) -> Bool {
+        guard !isResolved else {
+            return false
+        }
+
+        isResolved = true
+        let continuation = self.continuation
+        self.continuation = nil
+        continuation?.resume(returning: webView)
+        return true
+    }
+}
+
+/// A checkout waiting for a warm-up, resolved by whichever of the warm-up or
+/// its own cancellation gets there first.
+@MainActor
+final class CheckoutWaiter {
+    private var continuation: CheckedContinuation<WebView?, Never>?
+    private var isResolved = false
+
+    /// Hands the waiter the continuation to resume.
+    ///
+    /// Resolves straight away if the checkout was cancelled before it got this
+    /// far, which is possible for a task cancelled the moment it started.
+    func attach(_ continuation: CheckedContinuation<WebView?, Never>) {
+        guard !isResolved else {
+            continuation.resume(returning: nil)
+            return
+        }
+
+        self.continuation = continuation
+    }
+
+    /// - Returns: Whether this call is the one that resolved the waiter.
+    @discardableResult
+    func resolve(_ webView: WebView?) -> Bool {
+        guard !isResolved else {
+            return false
+        }
+
+        isResolved = true
+        let continuation = self.continuation
+        self.continuation = nil
+        continuation?.resume(returning: webView)
+        return true
     }
 }
 
 /// Awaits the end of the warm-up navigation.
 private final class WarmupNavigationDelegate: NSObject, WKNavigationDelegate {
-    private var continuation: CheckedContinuation<Void, Never>?
-    private var isDone = false
+    private var continuation: CheckedContinuation<Bool, Never>?
+    private var result: Bool?
 
-    func wait() async {
-        guard !isDone else {
+    /// - Returns: Whether the navigation succeeded.
+    func wait() async -> Bool {
+        if let result {
+            return result
+        }
+
+        return await withCheckedContinuation { continuation = $0 }
+    }
+
+    private func finish(succeeded: Bool) {
+        guard result == nil else {
             return
         }
 
-        await withCheckedContinuation { continuation = $0 }
-    }
-
-    private func finish() {
-        isDone = true
+        result = succeeded
         let continuation = continuation
         self.continuation = nil
-        continuation?.resume()
+        continuation?.resume(returning: succeeded)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        finish()
+        finish(succeeded: true)
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {
-        finish()
+        finish(succeeded: false)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: any Error) {
-        finish()
+        finish(succeeded: false)
+    }
+
+    /// The web content process died, most likely to memory pressure during
+    /// launch. No navigation callback is coming, so the warm-up is resolved
+    /// here or it would never return at all.
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        finish(succeeded: false)
     }
 }

--- a/Sources/Navigator/EPUB/WebViewServer.swift
+++ b/Sources/Navigator/EPUB/WebViewServer.swift
@@ -19,10 +19,57 @@ import WebKit
     /// Format sniffer used to infer the media type of served resources.
     let formatSniffer: FormatSniffer
 
+    /// The server shared by every EPUB navigator in the process.
+    ///
+    /// A web view's URL scheme handler is bound when its configuration is
+    /// created and cannot be swapped afterwards, so a web view can only ever
+    /// be reused by navigators served by the same instance. Sharing one server
+    /// is what makes web views outlive the navigator that first used them.
+    ///
+    /// Isolation between publications open at the same time rests on the
+    /// secrecy of their route rather than on separate objects: through this
+    /// one server, every publication is reachable at `readium://{uuid}/`, so a
+    /// document that learned another publication's UUID could request its
+    /// resources. The UUID is generated per navigator and never leaves the
+    /// app, and ``publicationContentSecurityPolicy`` stops documents from
+    /// being embedded across origins, but this is a weaker boundary than one
+    /// server per publication.
+    ///
+    /// No publication is ever served another's bytes: the resource cache is
+    /// keyed by route, and routes are unregistered when their navigator goes
+    /// away.
+    static let shared = WebViewServer(scheme: "readium", formatSniffer: DefaultFormatSniffer())
+
+    /// Policy sent with publication resources.
+    ///
+    /// `frame-ancestors 'self'` keeps a publication's documents from being
+    /// embedded by a document of another origin. Same-origin framing has to
+    /// stay allowed: fixed-layout publications load their spine resources into
+    /// iframes of a wrapper page, and wrapper and resources share the
+    /// publication's origin.
+    static let publicationContentSecurityPolicy = "frame-ancestors 'self'"
+
+    /// Route serving the document used to warm web views up.
+    private static let warmupRoute = "readium-warmup"
+
+    /// URL of a minimal document served by this server.
+    ///
+    /// Navigating a web view to it pays, once per web view, the one-off cost
+    /// of the first navigation on a custom URL scheme. Warming up requires a
+    /// real navigation on the scheme: loading an HTML string does not
+    /// discharge it.
+    let warmupURL: AbsoluteURL
+
     init(scheme: String, formatSniffer: FormatSniffer) {
         self.scheme = scheme
         self.formatSniffer = formatSniffer
+        warmupURL = AnyURL(string: "\(scheme)://\(Self.warmupRoute)/index.html")!.absoluteURL!
+
         super.init()
+
+        serve(at: Self.warmupRoute) { _ in
+            (DataResource(string: "<!doctype html><html></html>"), .html)
+        }
     }
 
     // MARK: - Route registration
@@ -78,10 +125,24 @@ import WebKit
         return baseURL
     }
 
-    /// Removes the handler at the given route.
+    /// Removes the handler at the given route, along with anything it had
+    /// cached.
     func remove(at route: String) {
         let route = normalizedRoute(route)
-        routes.removeAll { $0.path.hasPrefix(route) }
+        routes.removeAll { isPath($0.path, atOrUnder: route) }
+
+        // Resources cached for a route that is gone would never be served
+        // again, and would keep the publication's data alive for as long as
+        // the server lives.
+        resourceCache.remove { key, _ in isPath(key.route, atOrUnder: route) }
+    }
+
+    /// Whether `path` is the route `route` itself, or nested under it.
+    ///
+    /// Compared on segment boundaries: a plain prefix test would make removing
+    /// `book1` take `book10/` down with it.
+    private func isPath(_ path: String, atOrUnder route: String) -> Bool {
+        path == route || path.hasPrefix(route.addingSuffix("/"))
     }
 
     private func normalizedRoute(_ route: String, isDirectory: Bool = false) -> String {
@@ -115,23 +176,43 @@ import WebKit
     /// Oldest entries are evicted when the cache exceeds its capacity.
     private var resourceCache = BoundedResourceCache()
 
-    /// Removes cached resources matching the given predicate, forcing them to
-    /// be re-served on the next request.
-    func clearResourceCache(where predicate: (RelativeURL, MediaType) -> Bool) {
-        resourceCache.remove(where: predicate)
+    /// Removes the resources cached for the given route and matching the given
+    /// predicate, forcing them to be re-served on the next request.
+    ///
+    /// Other routes are left untouched: the server may be serving several
+    /// publications, and what invalidates one does not invalidate the others.
+    func clearResourceCache(atRoute route: String, where predicate: (RelativeURL, MediaType) -> Bool) {
+        let route = normalizedRoute(route, isDirectory: true)
+        resourceCache.remove { key, mediaType in
+            key.route == route && predicate(key.relativeURL, mediaType)
+        }
     }
 
     // MARK: - WKURLSchemeHandler
 
     func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
+        start(urlSchemeTask)
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {
+        stop(urlSchemeTask)
+    }
+
+    /// Starts serving the given task.
+    ///
+    /// Split out of ``webView(_:start:)``, which does not use its web view, so
+    /// that serving can be exercised without one.
+    func start(_ urlSchemeTask: any WKURLSchemeTask) {
         let taskID = ObjectIdentifier(urlSchemeTask)
+
         activeTasks[taskID] = Task {
             await serve(urlSchemeTask)
             _ = activeTasks.removeValue(forKey: taskID)
         }
     }
 
-    func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {
+    /// Stops serving the given task.
+    func stop(_ urlSchemeTask: any WKURLSchemeTask) {
         let taskID = ObjectIdentifier(urlSchemeTask)
         activeTasks.removeValue(forKey: taskID)?.cancel()
     }
@@ -171,9 +252,10 @@ import WebKit
                 }
                 await serveResource(
                     urlSchemeTask,
+                    cacheKey: BoundedResourceCache.Key(route: route.path, relativeURL: relativeURL),
                     relativeURL: relativeURL,
                     handler: handler,
-                    requestURL: requestURL
+                    requestURL: requestURL,
                 )
                 return
             }
@@ -185,6 +267,7 @@ import WebKit
     /// Serves a resource from a handler callback, with caching.
     private func serveResource(
         _ urlSchemeTask: WKURLSchemeTask,
+        cacheKey: BoundedResourceCache.Key,
         relativeURL: RelativeURL,
         handler: @MainActor (RelativeURL) async -> (Resource, MediaType)?,
         requestURL: URL
@@ -194,7 +277,7 @@ import WebKit
         // one.
         let resource: Resource
         let mediaType: MediaType
-        if let (cachedResource, cachedMediaType) = resourceCache[relativeURL] {
+        if let (cachedResource, cachedMediaType) = resourceCache[cacheKey] {
             resource = cachedResource
             mediaType = cachedMediaType
         } else {
@@ -204,14 +287,15 @@ import WebKit
             }
             resource = newResource.buffered(size: 256 * 1024)
             mediaType = newMediaType
-            resourceCache.set(relativeURL, resource: resource, mediaType: mediaType)
+            resourceCache.set(cacheKey, resource: resource, mediaType: mediaType)
         }
 
         await serveResource(
             resource,
             with: urlSchemeTask,
             mediaType: mediaType,
-            requestURL: requestURL
+            requestURL: requestURL,
+            contentSecurityPolicy: Self.publicationContentSecurityPolicy,
         )
     }
 
@@ -231,7 +315,7 @@ import WebKit
             with: urlSchemeTask,
             mediaType: mediaTypeFromURL(file),
             requestURL: requestURL,
-            allowCrossOrigin: allowCrossOrigin
+            allowCrossOrigin: allowCrossOrigin,
         )
     }
 
@@ -240,7 +324,8 @@ import WebKit
         with urlSchemeTask: WKURLSchemeTask,
         mediaType: MediaType?,
         requestURL: URL,
-        allowCrossOrigin: Bool = false
+        allowCrossOrigin: Bool = false,
+        contentSecurityPolicy: String? = nil
     ) async {
         // Try to serve a byte range if the client requested one and the
         // resource length is known.
@@ -251,7 +336,7 @@ import WebKit
             let result = await resource.read(range: range)
             switch result {
             case let .success(data):
-                await respond(urlSchemeTask, with: data, range: range, totalLength: totalLength, mediaType: mediaType, url: requestURL, allowCrossOrigin: allowCrossOrigin)
+                await respond(urlSchemeTask, with: data, range: range, totalLength: totalLength, mediaType: mediaType, url: requestURL, allowCrossOrigin: allowCrossOrigin, contentSecurityPolicy: contentSecurityPolicy)
             case let .failure(error):
                 log(.error, "Failed to read resource \(requestURL.path) range \(range): \(error)")
                 await fail(urlSchemeTask, with: URLError(.resourceUnavailable))
@@ -263,7 +348,7 @@ import WebKit
         let result = await resource.read()
         switch result {
         case let .success(data):
-            await respond(urlSchemeTask, with: data, range: nil, totalLength: UInt64(data.count), mediaType: mediaType, url: requestURL, allowCrossOrigin: allowCrossOrigin)
+            await respond(urlSchemeTask, with: data, range: nil, totalLength: UInt64(data.count), mediaType: mediaType, url: requestURL, allowCrossOrigin: allowCrossOrigin, contentSecurityPolicy: contentSecurityPolicy)
         case let .failure(error):
             log(.error, "Failed to read resource \(requestURL.path): \(error)")
             await fail(urlSchemeTask, with: URLError(.resourceUnavailable))
@@ -294,7 +379,8 @@ import WebKit
         totalLength: UInt64,
         mediaType: MediaType?,
         url: URL,
-        allowCrossOrigin: Bool
+        allowCrossOrigin: Bool,
+        contentSecurityPolicy: String? = nil
     ) async {
         var headers: [String: String] = [
             "Content-Length": "\(data.count)",
@@ -310,6 +396,10 @@ import WebKit
             // load without this header. Mirrors `allowCors()` in the Kotlin
             // toolkit's WebViewServer. See issue #802.
             headers["Access-Control-Allow-Origin"] = "*"
+        }
+
+        if let contentSecurityPolicy {
+            headers["Content-Security-Policy"] = contentSecurityPolicy
         }
 
         if let mediaType {
@@ -361,15 +451,26 @@ private extension URLRequest {
 /// ``capacity``, preventing unbounded memory growth as the user navigates
 /// through chapters.
 private struct BoundedResourceCache {
-    private let capacity = 8
-    private var entries: [RelativeURL: (Resource, MediaType)] = [:]
-    private var order: [RelativeURL] = []
+    /// Identifies a cached resource.
+    ///
+    /// The route is part of the key: a relative URL is only meaningful within
+    /// the route it was resolved against, and two publications routinely serve
+    /// different resources under the same publication-relative path (say
+    /// `chapter1.xhtml`).
+    struct Key: Hashable {
+        let route: String
+        let relativeURL: RelativeURL
+    }
 
-    subscript(key: RelativeURL) -> (Resource, MediaType)? {
+    private let capacity = 8
+    private var entries: [Key: (Resource, MediaType)] = [:]
+    private var order: [Key] = []
+
+    subscript(key: Key) -> (Resource, MediaType)? {
         entries[key]
     }
 
-    mutating func set(_ key: RelativeURL, resource: Resource, mediaType: MediaType) {
+    mutating func set(_ key: Key, resource: Resource, mediaType: MediaType) {
         if entries[key] == nil {
             order.append(key)
         }
@@ -381,12 +482,12 @@ private struct BoundedResourceCache {
         }
     }
 
-    mutating func remove(where predicate: (RelativeURL, MediaType) -> Bool) {
-        let toRemove = order.filter { url in
-            entries[url].map { predicate(url, $0.1) } ?? false
+    mutating func remove(where predicate: (Key, MediaType) -> Bool) {
+        let toRemove = order.filter { key in
+            entries[key].map { predicate(key, $0.1) } ?? false
         }
-        for url in toRemove {
-            entries.removeValue(forKey: url)
+        for key in toRemove {
+            entries.removeValue(forKey: key)
         }
         order = order.filter { entries[$0] != nil }
     }

--- a/Sources/Navigator/Toolkit/PaginationView.swift
+++ b/Sources/Navigator/Toolkit/PaginationView.swift
@@ -41,6 +41,14 @@ protocol PaginationViewDelegate: AnyObject {
     /// Called when the page views were updated.
     func paginationViewDidUpdateViews(_ paginationView: PaginationView)
 
+    /// Called when the page view at the given index is no longer displayed,
+    /// because it fell outside of the pre-loaded range or the pagination was
+    /// reloaded.
+    ///
+    /// The delegate takes ownership of the view again and may recycle it for a
+    /// later `paginationView(_:pageViewAtIndex:)` call.
+    func paginationView(_ paginationView: PaginationView, didEndDisplayingView view: UIView & PageView, atIndex index: Int)
+
     /// Returns the number of positions (as in `Publication.positionList`) in the page view at given index.
     func paginationView(_ paginationView: PaginationView, positionCountAtIndex index: Int) -> Int
 }
@@ -161,7 +169,11 @@ final class PaginationView: UIView, Loggable {
         super.willMove(toSuperview: newSuperview)
 
         if newSuperview == nil {
-            // Remove all spread views to break retain cycles
+            // Remove all spread views to break retain cycles.
+            //
+            // Deliberately not routed through `stopDisplaying(_:at:)`: this is
+            // teardown rather than a flush, so there is nothing left for the
+            // delegate to recycle the views into.
             for (_, view) in loadedViews {
                 view.removeFromSuperview()
             }
@@ -200,11 +212,10 @@ final class PaginationView: UIView, Loggable {
         self.pageCount = pageCount
         self.readingProgression = readingProgression
 
-        for (_, view) in loadedViews {
-            view.removeFromSuperview()
+        for (i, view) in loadedViews {
+            stopDisplaying(view, at: i)
         }
         loadedViews.removeAll()
-        loadingIndexQueue.removeAll()
 
         setCurrentIndex(index, location: location)
     }
@@ -223,6 +234,11 @@ final class PaginationView: UIView, Loggable {
 
         currentIndex = index
 
+        // Pages queued for the previous position are obsolete: loading them
+        // first would delay the page the reader is actually looking at. The
+        // ones still relevant are re-scheduled right below.
+        loadingIndexQueue.removeAll()
+
         // To make sure that the views the most likely to be visible are loaded first, we first load
         // the current one, then the next ones and to finish the previous ones.
         scheduleLoadPage(at: index, location: location)
@@ -232,8 +248,8 @@ final class PaginationView: UIView, Loggable {
         for (i, view) in loadedViews {
             // Flushes the views that are not needed anymore.
             guard firstIndex ... lastIndex ~= i else {
-                view.removeFromSuperview()
                 loadedViews.removeValue(forKey: i)
+                stopDisplaying(view, at: i)
                 continue
             }
         }
@@ -241,18 +257,42 @@ final class PaginationView: UIView, Loggable {
         loadPages()
     }
 
+    /// Detaches a page view and gives it back to the delegate, which may
+    /// recycle it for a later index.
+    private func stopDisplaying(_ view: UIView & PageView, at index: Int) {
+        view.removeFromSuperview()
+        delegate?.paginationView(self, didEndDisplayingView: view, atIndex: index)
+    }
+
     private func loadPages() {
         loadPagesTask.replace { @MainActor in
-            await loadNextPage()
-            delegate?.paginationViewDidUpdateViews(self)
+            // The current page is always scheduled first. Notifying per page,
+            // instead of once the whole queue is drained, lets the current
+            // spread be displayed immediately while its neighbours keep
+            // pre-loading in the background.
+            while await loadNextPage() {
+                // A reload happened while the page above was loading: the new
+                // task owns the queue now, and this one must not report its
+                // stale progress. Doing so would publish a location for a page
+                // that is no longer the current one, and which may still be
+                // blank.
+                guard !Task.isCancelled else {
+                    return
+                }
+
+                delegate?.paginationViewDidUpdateViews(self)
+            }
         }
     }
 
     private var loadPagesTask: Task<Void, Never>?
 
-    private func loadNextPage() async {
-        guard let (index, location) = loadingIndexQueue.popFirst() else {
-            return
+    /// Loads the next page in the queue, if any.
+    ///
+    /// - Returns: Whether a page was dequeued.
+    private func loadNextPage() async -> Bool {
+        guard !Task.isCancelled, let (index, location) = loadingIndexQueue.popFirst() else {
+            return false
         }
 
         if
@@ -265,11 +305,14 @@ final class PaginationView: UIView, Loggable {
         }
 
         guard let view = loadedViews[index] else {
-            return
+            return true
         }
 
+        // Deliberately not cancellable: interrupting a page mid-navigation
+        // would leave it on a half-applied location. Cancellation is observed
+        // between pages instead.
         await view.go(to: location, animated: false)
-        await loadNextPage()
+        return true
     }
 
     /// Queue views to be loaded until reaching the given number of pre-loaded positions.

--- a/Sources/Navigator/Toolkit/PaginationView.swift
+++ b/Sources/Navigator/Toolkit/PaginationView.swift
@@ -36,7 +36,13 @@ protocol PageView {
 
 protocol PaginationViewDelegate: AnyObject {
     /// Creates the page view for the page at given index.
-    func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) -> (UIView & PageView)?
+    ///
+    /// May suspend: building a page view can mean waiting on a shared and
+    /// expensive resource. The pagination view re-checks its own state once
+    /// this returns, and hands the view straight back through
+    /// ``paginationView(_:didEndDisplayingView:atIndex:)`` if it turns out it
+    /// no longer needs it.
+    func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) async -> (UIView & PageView)?
 
     /// Called when the page views were updated.
     func paginationViewDidUpdateViews(_ paginationView: PaginationView)
@@ -295,10 +301,30 @@ final class PaginationView: UIView, Loggable {
             return false
         }
 
-        if
-            loadedViews[index] == nil,
-            let view = delegate?.paginationView(self, pageViewAtIndex: index)
-        {
+        if loadedViews[index] == nil {
+            guard let view = await delegate?.paginationView(self, pageViewAtIndex: index) else {
+                return true
+            }
+
+            // Building the view suspended, so this chain's assumptions may no
+            // longer hold. In either case below the view is handed straight
+            // back: the delegate owns whatever it holds, and dropping it here
+            // would strand those resources until the navigator is torn down.
+
+            // A reload cancelled this chain while it waited. It must not put a
+            // page belonging to the previous position on screen.
+            guard !Task.isCancelled else {
+                delegate?.paginationView(self, didEndDisplayingView: view, atIndex: index)
+                return false
+            }
+
+            // Another chain filled this index in the meantime. The one already
+            // installed wins; two views at one index would leak the loser.
+            guard loadedViews[index] == nil else {
+                delegate?.paginationView(self, didEndDisplayingView: view, atIndex: index)
+                return true
+            }
+
             loadedViews[index] = view
             scrollView.addSubview(view)
             setNeedsLayout()

--- a/Sources/Navigator/Toolkit/RecyclingPool.swift
+++ b/Sources/Navigator/Toolkit/RecyclingPool.swift
@@ -1,0 +1,80 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+
+/// An object that can be set aside after use and handed out again later.
+protocol Recyclable: AnyObject {
+    /// Whether this instance is still fit for reuse.
+    ///
+    /// It is queried both when the instance is pooled and when it is handed
+    /// out again, because an instance may stop being eligible while it sits in
+    /// the pool.
+    var canBeRecycled: Bool { get }
+}
+
+/// A bounded pool of reusable instances.
+struct RecyclingPool<Element: Recyclable> {
+    /// Maximum number of instances kept around.
+    ///
+    /// This is a best-effort bound rather than an invariant of the caller:
+    /// instances offered beyond it are simply dropped.
+    let capacity: Int
+
+    private var elements: [Element] = []
+
+    init(capacity: Int) {
+        precondition(capacity >= 0)
+        self.capacity = capacity
+    }
+
+    var count: Int { elements.count }
+
+    var isEmpty: Bool { elements.isEmpty }
+
+    /// Takes an instance back for later reuse.
+    ///
+    /// - Returns: Whether the instance was kept. It is rejected when it is not
+    ///   reusable, or when the pool is full. A caller holding resources on the
+    ///   rejected instance's behalf has to dispose of them itself rather than
+    ///   let them go with it.
+    @discardableResult
+    mutating func push(_ element: Element) -> Bool {
+        guard element.canBeRecycled else {
+            return false
+        }
+
+        // Instances that went stale while pooled are dropped first: they will
+        // never be handed out, so letting them take up room would evict usable
+        // ones for nothing.
+        elements.removeAll { !$0.canBeRecycled }
+
+        guard elements.count < capacity else {
+            return false
+        }
+
+        elements.append(element)
+        return true
+    }
+
+    /// Hands out a reusable instance, if there is one.
+    ///
+    /// Instances that stopped being eligible while pooled are discarded.
+    mutating func pop() -> Element? {
+        while let element = elements.popLast() {
+            if element.canBeRecycled {
+                return element
+            }
+        }
+
+        return nil
+    }
+
+    /// Drops every pooled instance.
+    mutating func removeAll() {
+        elements.removeAll()
+    }
+}

--- a/Sources/Navigator/Toolkit/WebView.swift
+++ b/Sources/Navigator/Toolkit/WebView.swift
@@ -10,10 +10,36 @@ import WebKit
 /// A custom web view which:
 ///  - Forwards copy: menu action to an EditingActionsController.
 final class WebView: WKWebView {
-    private let editingActions: EditingActionsController
+    /// Gates copy, drag and the edit menu according to the rights of the
+    /// publication being displayed.
+    ///
+    /// Mutable because a web view outlives the navigator that created it: once
+    /// recycled for another publication it must stop enforcing the previous
+    /// one's rights. Rebinding goes through ``rebind(editingActions:)``.
+    ///
+    /// `nil` on a pooled web view that no publication has claimed yet, in
+    /// which case every editing action is denied.
+    private var editingActions: EditingActionsController?
 
     convenience init(editingActions: EditingActionsController) {
         self.init(editingActions: editingActions, configuration: WKWebViewConfiguration())
+    }
+
+    /// Creates a web view that no publication is bound to yet.
+    ///
+    /// Until ``rebind(editingActions:)`` is called it denies every editing
+    /// action, so a pooled web view cannot leak the rights of whichever
+    /// publication reaches it first.
+    init(configuration: WKWebViewConfiguration) {
+        editingActions = nil
+
+        super.init(frame: .zero, configuration: configuration)
+
+        #if DEBUG && swift(>=5.8)
+            if #available(macOS 13.3, iOS 16.4, *) {
+                isInspectable = true
+            }
+        #endif
     }
 
     init(editingActions: EditingActionsController, configuration: WKWebViewConfiguration) {
@@ -33,12 +59,46 @@ final class WebView: WKWebView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    /// Whether a publication's editing rights are bound to this web view. One
+    /// idling in a pool must not be bound to any.
+    var isBoundToPublication: Bool { editingActions != nil }
+
+    /// Drops the editing rights of the publication this web view was
+    /// displaying, denying every editing action until it is rebound.
+    ///
+    /// Called when a web view goes back to a pool, so that it stops keeping
+    /// the publication's rights alive while it idles.
+    func unbindFromPublication() {
+        editingActions = nil
+
+        // Leave the view in the state a freshly built one is in, rather than
+        // with a drag interaction still torn out for a publication it no
+        // longer displays.
+        restoreDragAndDropIfNeeded()
+    }
+
+    /// Points this web view at another publication's editing rights.
+    ///
+    /// Must be called before a recycled web view is shown again: until it is,
+    /// the view denies every editing action.
+    func rebind(editingActions: EditingActionsController) {
+        self.editingActions = editingActions
+
+        // The drag interaction is *removed* for publications that disallow
+        // copying, and removal is not undone by simply swapping the
+        // controller. Restore it before re-applying the new rights, otherwise
+        // a no-copy publication would leave drag broken for every publication
+        // that reuses this web view.
+        restoreDragAndDropIfNeeded()
+        setupDragAndDrop()
+    }
+
     func clearSelection() {
         evaluateJavaScript("window.getSelection().removeAllRanges()")
     }
 
     override func buildMenu(with builder: any UIMenuBuilder) {
-        editingActions.buildMenu(with: builder)
+        editingActions?.buildMenu(with: builder)
 
         // Don't call super as it is the only way to remove the
         // "Copy Link with Highlight" menu item.
@@ -48,10 +108,14 @@ final class WebView: WKWebView {
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         super.canPerformAction(action, withSender: sender)
-            && editingActions.canPerformAction(action)
+            && (editingActions?.canPerformAction(action) ?? false)
     }
 
     override func copy(_ sender: Any?) {
+        guard let editingActions else {
+            return
+        }
+
         Task {
             await editingActions.copy()
         }
@@ -62,9 +126,15 @@ final class WebView: WKWebView {
         setupDragAndDrop()
     }
 
+    /// The drag interaction removed for a publication that disallows copying,
+    /// kept so that it can be restored if this web view is recycled for a
+    /// publication that allows it.
+    private var removedDragInteraction: (interaction: any UIInteraction, view: UIView)?
+
     private func setupDragAndDrop() {
-        if !editingActions.canCopy {
+        if !(editingActions?.canCopy ?? false) {
             guard
+                removedDragInteraction == nil,
                 let webScrollView = subviews.first(where: { $0 is UIScrollView }),
                 let contentView = webScrollView.subviews.first(where: { $0.interactions.count > 1 }),
                 let dragInteraction = contentView.interactions.first(where: { $0 is UIDragInteraction })
@@ -72,6 +142,16 @@ final class WebView: WKWebView {
                 return
             }
             contentView.removeInteraction(dragInteraction)
+            removedDragInteraction = (dragInteraction, contentView)
         }
+    }
+
+    private func restoreDragAndDropIfNeeded() {
+        guard let removed = removedDragInteraction else {
+            return
+        }
+
+        removedDragInteraction = nil
+        removed.view.addInteraction(removed.interaction)
     }
 }

--- a/Tests/NavigatorTests/EPUB/EPUBWebViewPoolTests.swift
+++ b/Tests/NavigatorTests/EPUB/EPUBWebViewPoolTests.swift
@@ -1,0 +1,268 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumNavigator
+import ReadiumShared
+import WebKit
+import XCTest
+
+/// Creating a `WKWebView` spawns a web content process, so these tests keep
+/// the number of real web views to a minimum.
+@MainActor
+final class EPUBWebViewPoolTests: XCTestCase {
+    func testStartsEmpty() {
+        let sut = EPUBWebViewPool(capacity: 2)
+
+        XCTAssertEqual(sut.count, 0)
+        XCTAssertNil(sut.checkout(editingActions: makeEditingActions()))
+    }
+
+    func testPrewarmFillsThePool() async {
+        let sut = EPUBWebViewPool(capacity: 2)
+
+        await sut.prewarm(count: 1)
+
+        XCTAssertEqual(sut.count, 1)
+    }
+
+    func testPrewarmNeverExceedsCapacity() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+
+        await sut.prewarm(count: 3)
+
+        XCTAssertEqual(sut.count, 1)
+    }
+
+    func testCheckoutHandsOutAPrewarmedWebView() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+        await sut.prewarm(count: 1)
+
+        let webView = sut.checkout(editingActions: makeEditingActions())
+
+        XCTAssertNotNil(webView)
+        XCTAssertEqual(sut.count, 0, "The web view should no longer be available")
+        XCTAssertNil(sut.checkout(editingActions: makeEditingActions()))
+    }
+
+    /// The whole point of the pool: a web view handed back by one navigator is
+    /// served to the next one, instead of being torn down with its process.
+    func testWebViewsAreReusedAcrossCheckouts() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+        await sut.prewarm(count: 1)
+
+        guard let first = sut.checkout(editingActions: makeEditingActions()) else {
+            return XCTFail("Expected a prewarmed web view")
+        }
+        sut.giveBack(first)
+        let second = sut.checkout(editingActions: makeEditingActions())
+
+        XCTAssertTrue(second === first, "The returned web view was not handed out again")
+    }
+
+    func testGiveBackDropsWebViewsBeyondCapacity() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+        await sut.prewarm(count: 1)
+        guard let webView = sut.checkout(editingActions: makeEditingActions()) else {
+            return XCTFail("Expected a prewarmed web view")
+        }
+
+        sut.giveBack(webView)
+        sut.giveBack(webView)
+
+        XCTAssertEqual(sut.count, 1)
+    }
+
+    /// A recycled web view must not keep running the previous publication's
+    /// scripts, nor keep delivering messages to its spread view.
+    func testCheckoutClearsTheScriptsInstalledByThePreviousNavigator() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+        await sut.prewarm(count: 1)
+        guard let webView = sut.checkout(editingActions: makeEditingActions()) else {
+            return XCTFail("Expected a prewarmed web view")
+        }
+        webView.configuration.userContentController.addUserScript(
+            WKUserScript(source: "window.leaked = true;", injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        )
+        XCTAssertEqual(webView.configuration.userContentController.userScripts.count, 1)
+
+        sut.giveBack(webView)
+        _ = sut.checkout(editingActions: makeEditingActions())
+
+        XCTAssertEqual(
+            webView.configuration.userContentController.userScripts.count, 0,
+            "The previous publication's user scripts survived the checkout"
+        )
+    }
+
+    func testCheckoutDetachesTheWebViewFromThePreviousSpreadView() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+        await sut.prewarm(count: 1)
+        guard let webView = sut.checkout(editingActions: makeEditingActions()) else {
+            return XCTFail("Expected a prewarmed web view")
+        }
+        let container = UIView()
+        container.addSubview(webView)
+
+        sut.giveBack(webView)
+        _ = sut.checkout(editingActions: makeEditingActions())
+
+        XCTAssertNil(webView.superview, "The web view is still attached to the previous spread view")
+        XCTAssertNil(webView.navigationDelegate)
+        XCTAssertNil(webView.uiDelegate)
+    }
+
+    /// A web view idling in the pool must not still carry the previous
+    /// publication's scripts, delegates or rights: stripping only on the way
+    /// out would keep them — and through them the publication's `UserRights` —
+    /// alive for as long as the web view sits there.
+    func testGiveBackStripsTheWebViewImmediately() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+        await sut.prewarm(count: 1)
+        guard let webView = sut.checkout(editingActions: makeEditingActions()) else {
+            return XCTFail("Expected a prewarmed web view")
+        }
+        let container = UIView()
+        container.addSubview(webView)
+        webView.configuration.userContentController.addUserScript(
+            WKUserScript(source: "window.leaked = true;", injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        )
+        XCTAssertTrue(webView.isBoundToPublication)
+
+        sut.giveBack(webView)
+
+        XCTAssertFalse(webView.isBoundToPublication, "The publication's editing rights are still bound")
+        XCTAssertEqual(webView.configuration.userContentController.userScripts.count, 0)
+        XCTAssertNil(webView.superview)
+        XCTAssertNil(webView.navigationDelegate)
+        XCTAssertNil(webView.uiDelegate)
+    }
+
+    func testCheckoutBindsThePublicationsEditingRights() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+        await sut.prewarm(count: 1)
+
+        let webView = sut.checkout(editingActions: makeEditingActions())
+
+        XCTAssertEqual(webView?.isBoundToPublication, true)
+    }
+
+    /// Pooled web views are bound to the shared server, and their storage is
+    /// kept out of the persistent store.
+    func testPooledWebViewsUseANonPersistentDataStore() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+        await sut.prewarm(count: 1)
+
+        let webView = sut.checkout(editingActions: makeEditingActions())
+
+        XCTAssertEqual(webView?.configuration.websiteDataStore.isPersistent, false)
+    }
+
+    // MARK: - Yielding to the reader
+
+    /// Warming up competes with the publication the reader is opening, badly
+    /// enough to make the open slower than having no pool at all. Once a web
+    /// view is on loan the pool must stop building any.
+    func testPrewarmDoesNothingWhileWebViewsAreBorrowed() async {
+        let sut = EPUBWebViewPool(capacity: 2)
+        await sut.prewarm(count: 1)
+        _ = sut.checkout(editingActions: makeEditingActions())
+        XCTAssertEqual(sut.count, 0)
+
+        await sut.prewarm(count: 2)
+
+        XCTAssertEqual(sut.count, 0, "The pool built web views while a reader was using them")
+    }
+
+    /// A reading session needs no new stock: the web views come back at
+    /// teardown, which restocks the pool for free.
+    func testReturnsRestockThePoolWithoutBuildingAnything() async {
+        let sut = EPUBWebViewPool(capacity: 2)
+        await sut.prewarm(count: 2)
+        guard
+            let first = sut.checkout(editingActions: makeEditingActions()),
+            let second = sut.checkout(editingActions: makeEditingActions())
+        else {
+            return XCTFail("Expected two prewarmed web views")
+        }
+        XCTAssertEqual(sut.count, 0)
+
+        sut.giveBack(first)
+        sut.giveBack(second)
+
+        XCTAssertEqual(sut.count, 2)
+        let restocked = [
+            sut.checkout(editingActions: makeEditingActions()),
+            sut.checkout(editingActions: makeEditingActions()),
+        ]
+        XCTAssertEqual(
+            Set(restocked.compactMap { $0.map(ObjectIdentifier.init) }),
+            Set([first, second].map(ObjectIdentifier.init)),
+            "The pool built replacements instead of reusing the returned web views"
+        )
+    }
+
+    /// Returning only some of the borrowed web views means the reader is still
+    /// on screen, so the pool keeps out of the way.
+    func testPoolStaysIdleWhileSomeWebViewsAreStillBorrowed() async {
+        let sut = EPUBWebViewPool(capacity: 2)
+        await sut.prewarm(count: 2)
+        guard
+            let first = sut.checkout(editingActions: makeEditingActions()),
+            sut.checkout(editingActions: makeEditingActions()) != nil
+        else {
+            return XCTFail("Expected two prewarmed web views")
+        }
+
+        sut.giveBack(first)
+        await sut.prewarm(count: 2)
+
+        XCTAssertEqual(sut.count, 1, "The pool built a web view while one was still on loan")
+    }
+
+    /// Closing the reader both returns web views and asks for a top-up. The
+    /// two together must not take the pool past its capacity.
+    func testReturnsAndAnExplicitPrewarmDoNotOverfillThePool() async {
+        let sut = EPUBWebViewPool(capacity: 2)
+        await sut.prewarm(count: 2)
+        guard
+            let first = sut.checkout(editingActions: makeEditingActions()),
+            let second = sut.checkout(editingActions: makeEditingActions())
+        else {
+            return XCTFail("Expected two prewarmed web views")
+        }
+
+        // The order a reader dismissal produces: the top-up is asked for while
+        // teardown is still handing web views back.
+        async let topUp: Void = sut.prewarm(count: 2)
+        sut.giveBack(first)
+        sut.giveBack(second)
+        await topUp
+
+        XCTAssertEqual(sut.count, 2, "The pool grew past its capacity")
+    }
+
+    func testPrewarmRestocksOnceEverythingIsBack() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+        await sut.prewarm(count: 1)
+        guard let webView = sut.checkout(editingActions: makeEditingActions()) else {
+            return XCTFail("Expected a prewarmed web view")
+        }
+        sut.giveBack(webView)
+
+        await sut.prewarm(count: 1)
+
+        XCTAssertEqual(sut.count, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeEditingActions() -> EditingActionsController {
+        EditingActionsController(
+            actions: EditingAction.defaultActions,
+            publication: Publication(manifest: Manifest(metadata: Metadata(title: "Test")))
+        )
+    }
+}

--- a/Tests/NavigatorTests/EPUB/EPUBWebViewPoolTests.swift
+++ b/Tests/NavigatorTests/EPUB/EPUBWebViewPoolTests.swift
@@ -11,13 +11,71 @@ import XCTest
 
 /// Creating a `WKWebView` spawns a web content process, so these tests keep
 /// the number of real web views to a minimum.
+// MARK: - Deterministic warm-ups
+
+/// A warm-up the test drives itself.
+///
+/// Real warm-ups finish whenever WebKit says so, which makes the timing of a
+/// checkout racing one impossible to pin down — and a test that waits on the
+/// wrong side of that race hangs rather than fails.
+@MainActor
+private final class WarmupStub {
+    private(set) var startedCount = 0
+    private var pending: [CheckedContinuation<WebView?, Never>] = []
+
+    /// Web views handed out, so a test can compare identities.
+    private(set) var producedViews: [WebView] = []
+
+    var isWaiting: Bool { !pending.isEmpty }
+
+    /// When set, later warm-ups finish straight away instead of waiting to be
+    /// driven, so a test can check the pool still works after a stall.
+    var autoCompletes = false
+
+    /// The factory to hand to `EPUBWebViewPool(capacity:warmup:)`.
+    func factory() -> EPUBWebViewPool.WarmupFactory {
+        { [self] in
+            startedCount += 1
+
+            if autoCompletes {
+                let webView = WebView(configuration: WKWebViewConfiguration())
+                producedViews.append(webView)
+                return webView
+            }
+
+            return await withCheckedContinuation { pending.append($0) }
+        }
+    }
+
+    /// Completes one warm-up successfully.
+    func finishOne() {
+        guard !pending.isEmpty else { return }
+        let webView = WebView(configuration: WKWebViewConfiguration())
+        producedViews.append(webView)
+        pending.removeFirst().resume(returning: webView)
+    }
+
+    /// Completes one warm-up as a failure.
+    func failOne() {
+        guard !pending.isEmpty else { return }
+        pending.removeFirst().resume(returning: nil)
+    }
+
+    func finishAll() {
+        while !pending.isEmpty {
+            finishOne()
+        }
+    }
+}
+
 @MainActor
 final class EPUBWebViewPoolTests: XCTestCase {
-    func testStartsEmpty() {
+    func testStartsEmpty() async {
         let sut = EPUBWebViewPool(capacity: 2)
 
         XCTAssertEqual(sut.count, 0)
-        XCTAssertNil(sut.checkout(editingActions: makeEditingActions()))
+        let webView = await sut.checkout(editingActions: makeEditingActions())
+        XCTAssertNil(webView)
     }
 
     func testPrewarmFillsThePool() async {
@@ -40,11 +98,12 @@ final class EPUBWebViewPoolTests: XCTestCase {
         let sut = EPUBWebViewPool(capacity: 1)
         await sut.prewarm(count: 1)
 
-        let webView = sut.checkout(editingActions: makeEditingActions())
+        let webView = await sut.checkout(editingActions: makeEditingActions())
 
         XCTAssertNotNil(webView)
         XCTAssertEqual(sut.count, 0, "The web view should no longer be available")
-        XCTAssertNil(sut.checkout(editingActions: makeEditingActions()))
+        let second = await sut.checkout(editingActions: makeEditingActions())
+        XCTAssertNil(second)
     }
 
     /// The whole point of the pool: a web view handed back by one navigator is
@@ -53,11 +112,11 @@ final class EPUBWebViewPoolTests: XCTestCase {
         let sut = EPUBWebViewPool(capacity: 1)
         await sut.prewarm(count: 1)
 
-        guard let first = sut.checkout(editingActions: makeEditingActions()) else {
+        guard let first = await sut.checkout(editingActions: makeEditingActions()) else {
             return XCTFail("Expected a prewarmed web view")
         }
         sut.giveBack(first)
-        let second = sut.checkout(editingActions: makeEditingActions())
+        let second = await sut.checkout(editingActions: makeEditingActions())
 
         XCTAssertTrue(second === first, "The returned web view was not handed out again")
     }
@@ -65,7 +124,7 @@ final class EPUBWebViewPoolTests: XCTestCase {
     func testGiveBackDropsWebViewsBeyondCapacity() async {
         let sut = EPUBWebViewPool(capacity: 1)
         await sut.prewarm(count: 1)
-        guard let webView = sut.checkout(editingActions: makeEditingActions()) else {
+        guard let webView = await sut.checkout(editingActions: makeEditingActions()) else {
             return XCTFail("Expected a prewarmed web view")
         }
 
@@ -80,7 +139,7 @@ final class EPUBWebViewPoolTests: XCTestCase {
     func testCheckoutClearsTheScriptsInstalledByThePreviousNavigator() async {
         let sut = EPUBWebViewPool(capacity: 1)
         await sut.prewarm(count: 1)
-        guard let webView = sut.checkout(editingActions: makeEditingActions()) else {
+        guard let webView = await sut.checkout(editingActions: makeEditingActions()) else {
             return XCTFail("Expected a prewarmed web view")
         }
         webView.configuration.userContentController.addUserScript(
@@ -89,7 +148,7 @@ final class EPUBWebViewPoolTests: XCTestCase {
         XCTAssertEqual(webView.configuration.userContentController.userScripts.count, 1)
 
         sut.giveBack(webView)
-        _ = sut.checkout(editingActions: makeEditingActions())
+        _ = await sut.checkout(editingActions: makeEditingActions())
 
         XCTAssertEqual(
             webView.configuration.userContentController.userScripts.count, 0,
@@ -100,14 +159,14 @@ final class EPUBWebViewPoolTests: XCTestCase {
     func testCheckoutDetachesTheWebViewFromThePreviousSpreadView() async {
         let sut = EPUBWebViewPool(capacity: 1)
         await sut.prewarm(count: 1)
-        guard let webView = sut.checkout(editingActions: makeEditingActions()) else {
+        guard let webView = await sut.checkout(editingActions: makeEditingActions()) else {
             return XCTFail("Expected a prewarmed web view")
         }
         let container = UIView()
         container.addSubview(webView)
 
         sut.giveBack(webView)
-        _ = sut.checkout(editingActions: makeEditingActions())
+        _ = await sut.checkout(editingActions: makeEditingActions())
 
         XCTAssertNil(webView.superview, "The web view is still attached to the previous spread view")
         XCTAssertNil(webView.navigationDelegate)
@@ -121,7 +180,7 @@ final class EPUBWebViewPoolTests: XCTestCase {
     func testGiveBackStripsTheWebViewImmediately() async {
         let sut = EPUBWebViewPool(capacity: 1)
         await sut.prewarm(count: 1)
-        guard let webView = sut.checkout(editingActions: makeEditingActions()) else {
+        guard let webView = await sut.checkout(editingActions: makeEditingActions()) else {
             return XCTFail("Expected a prewarmed web view")
         }
         let container = UIView()
@@ -144,7 +203,7 @@ final class EPUBWebViewPoolTests: XCTestCase {
         let sut = EPUBWebViewPool(capacity: 1)
         await sut.prewarm(count: 1)
 
-        let webView = sut.checkout(editingActions: makeEditingActions())
+        let webView = await sut.checkout(editingActions: makeEditingActions())
 
         XCTAssertEqual(webView?.isBoundToPublication, true)
     }
@@ -155,9 +214,208 @@ final class EPUBWebViewPoolTests: XCTestCase {
         let sut = EPUBWebViewPool(capacity: 1)
         await sut.prewarm(count: 1)
 
-        let webView = sut.checkout(editingActions: makeEditingActions())
+        let webView = await sut.checkout(editingActions: makeEditingActions())
 
         XCTAssertEqual(webView?.configuration.websiteDataStore.isPersistent, false)
+    }
+
+    // MARK: - Checking out during a warm-up
+
+    /// A reader that opens a publication moments after launch finds the pool
+    /// still filling. Waiting for the warm-up already under way beats starting
+    /// a second one alongside it: it is part way through, and the two would
+    /// otherwise compete for the device.
+    func testCheckoutWaitsForAWarmupAlreadyInFlight() async {
+        let sut = EPUBWebViewPool(capacity: 1)
+        async let warming: Void = sut.prewarm(count: 1)
+        await pump { sut.isWarmingUp }
+        XCTAssertEqual(sut.count, 0, "The warm-up should not have finished yet")
+
+        let webView = await sut.checkout(editingActions: makeEditingActions())
+        await warming
+
+        XCTAssertNotNil(webView, "The checkout gave up instead of waiting for the warm-up")
+        XCTAssertEqual(webView?.isBoundToPublication, true)
+    }
+
+    /// Nothing to wait for means answering straight away, so the caller can
+    /// get on with building its own.
+    func testCheckoutReturnsNilWhenNothingIsWarmingUp() async {
+        let sut = EPUBWebViewPool(capacity: 2)
+
+        let webView = await sut.checkout(editingActions: makeEditingActions())
+
+        XCTAssertNil(webView)
+        XCTAssertFalse(sut.isWarmingUp)
+    }
+
+
+    // MARK: - Checking out against a driven warm-up
+
+    /// Only as many checkouts as there are warm-ups in flight may wait. One
+    /// more would be waiting for something that is never coming.
+    func testCheckoutBeyondTheWarmupsInFlightReturnsNilRatherThanHanging() async {
+        let stub = WarmupStub()
+        let sut = EPUBWebViewPool(capacity: 1, warmup: stub.factory())
+        async let warming: Void = sut.prewarm(count: 1)
+        await pump { stub.isWaiting }
+
+        async let firstCheckout = sut.checkout(editingActions: makeEditingActions())
+        await pump { sut.hasWaitingCheckouts }
+
+        // Nothing left in flight for this one to wait on.
+        let second = await sut.checkout(editingActions: makeEditingActions())
+        XCTAssertNil(second, "The second checkout had no warm-up left to wait for")
+
+        stub.finishOne()
+        let first = await firstCheckout
+        await warming
+
+        XCTAssertNotNil(first, "The first checkout should have been served by the warm-up")
+    }
+
+    /// A warm-up that fails must still release whoever was waiting on it, or
+    /// the reader hangs instead of falling back to building its own.
+    func testWaiterIsResumedWhenTheWarmupFails() async {
+        let stub = WarmupStub()
+        let sut = EPUBWebViewPool(capacity: 1, warmup: stub.factory())
+        async let warming: Void = sut.prewarm(count: 1)
+        await pump { stub.isWaiting }
+
+        async let checkout = sut.checkout(editingActions: makeEditingActions())
+        await pump { sut.hasWaitingCheckouts }
+
+        stub.failOne()
+        let webView = await checkout
+        await warming
+
+        XCTAssertNil(webView, "A failed warm-up should send the caller off to build its own")
+        XCTAssertEqual(sut.count, 0)
+    }
+
+    /// The waiting checkout is served the moment its warm-up lands, rather
+    /// than starting a second one alongside it.
+    func testCheckoutIsServedByTheWarmupItWaitedFor() async {
+        let stub = WarmupStub()
+        let sut = EPUBWebViewPool(capacity: 1, warmup: stub.factory())
+        async let warming: Void = sut.prewarm(count: 1)
+        await pump { stub.isWaiting }
+
+        async let checkout = sut.checkout(editingActions: makeEditingActions())
+        await pump { sut.hasWaitingCheckouts }
+        stub.finishOne()
+
+        let webView = await checkout
+        await warming
+
+        XCTAssertEqual(stub.startedCount, 1, "A second web view was built instead of waiting")
+        XCTAssertTrue(webView === stub.producedViews.first, "The waiter got a different web view")
+        XCTAssertEqual(webView?.isBoundToPublication, true)
+    }
+
+    /// Waiters are served in the order they arrived.
+    func testWaitersAreServedInOrder() async {
+        let stub = WarmupStub()
+        let sut = EPUBWebViewPool(capacity: 2, warmup: stub.factory())
+        async let warming: Void = sut.prewarm(count: 2)
+        await pump { stub.startedCount == 2 }
+
+        async let firstCheckout = sut.checkout(editingActions: makeEditingActions())
+        await pump { sut.hasWaitingCheckouts }
+        async let secondCheckout = sut.checkout(editingActions: makeEditingActions())
+        await pump { stub.startedCount == 2 && sut.hasWaitingCheckouts }
+
+        stub.finishAll()
+        let first = await firstCheckout
+        let second = await secondCheckout
+        await warming
+
+        XCTAssertEqual(first === stub.producedViews.first, true, "The oldest waiter was not served first")
+        XCTAssertNotNil(second)
+    }
+
+
+    // MARK: - Warm-ups that never come back
+
+    /// A web content process can die mid warm-up, taking its navigation
+    /// callbacks with it. Without a backstop the warm-up never returns, the
+    /// pool's in-flight count never drops, every later refill declines to run
+    /// and any waiter waits for the rest of the process's life.
+    func testAStalledWarmupReleasesItsWaiterAndLeavesThePoolUsable() async {
+        let stub = WarmupStub()
+        let sut = EPUBWebViewPool(capacity: 1, warmupTimeout: 0.2, warmup: stub.factory())
+
+        async let warming: Void = sut.prewarm(count: 1)
+        await pump { stub.isWaiting }
+        async let checkout = sut.checkout(editingActions: makeEditingActions())
+        await pump { sut.hasWaitingCheckouts }
+
+        // The stub is never driven: only the timeout can resolve this.
+        let webView = await checkout
+        await warming
+
+        XCTAssertNil(webView, "The waiter was never released")
+        XCTAssertFalse(sut.isWarmingUp, "The in-flight count never came back down")
+
+        // And the pool is not wedged for good.
+        stub.autoCompletes = true
+        await sut.prewarm(count: 1)
+        XCTAssertEqual(sut.count, 1, "No later warm-up could run after the stall")
+    }
+
+    // MARK: - Cancellation
+
+    /// A load chain that gets cancelled has no use for a web view any more and
+    /// must not sit through the rest of a warm-up to discover that.
+    func testCancellingAWaitingCheckoutReleasesItPromptly() async {
+        let stub = WarmupStub()
+        let sut = EPUBWebViewPool(capacity: 1, warmup: stub.factory())
+        async let warming: Void = sut.prewarm(count: 1)
+        await pump { stub.isWaiting }
+
+        let checkout = Task { await sut.checkout(editingActions: makeEditingActions()) }
+        await pump { sut.hasWaitingCheckouts }
+
+        checkout.cancel()
+        let webView = await checkout.value
+
+        XCTAssertNil(webView, "A cancelled checkout should not wait the warm-up out")
+        await pump { !sut.hasWaitingCheckouts }
+        XCTAssertFalse(sut.hasWaitingCheckouts, "The cancelled waiter was left in the queue")
+
+        // The warm-up carries on, and what it produces is shelved.
+        stub.finishOne()
+        await warming
+        XCTAssertEqual(sut.count, 1, "The warm-up was lost along with its cancelled waiter")
+    }
+
+    // MARK: - Returns and waiters
+
+    /// A web view coming back is ready now, whereas the warm-up a checkout is
+    /// waiting on may be seconds away. The waiter should get the ready one.
+    func testGiveBackServesAWaitingCheckoutBeforeShelving() async {
+        let stub = WarmupStub()
+        let sut = EPUBWebViewPool(capacity: 2, warmup: stub.factory())
+        async let warming: Void = sut.prewarm(count: 2)
+        await pump { stub.startedCount == 2 }
+
+        stub.finishOne()
+        await pump { sut.count == 1 }
+        guard let borrowed = await sut.checkout(editingActions: makeEditingActions()) else {
+            return XCTFail("Expected the finished warm-up to be available")
+        }
+
+        // Nothing on the shelf, so this one waits for the second warm-up.
+        async let waiting = sut.checkout(editingActions: makeEditingActions())
+        await pump { sut.hasWaitingCheckouts }
+
+        sut.giveBack(borrowed)
+        let served = await waiting
+
+        XCTAssertTrue(served === borrowed, "The returned web view was shelved while a checkout waited")
+
+        stub.finishAll()
+        await warming
     }
 
     // MARK: - Yielding to the reader
@@ -168,7 +426,7 @@ final class EPUBWebViewPoolTests: XCTestCase {
     func testPrewarmDoesNothingWhileWebViewsAreBorrowed() async {
         let sut = EPUBWebViewPool(capacity: 2)
         await sut.prewarm(count: 1)
-        _ = sut.checkout(editingActions: makeEditingActions())
+        _ = await sut.checkout(editingActions: makeEditingActions())
         XCTAssertEqual(sut.count, 0)
 
         await sut.prewarm(count: 2)
@@ -182,8 +440,8 @@ final class EPUBWebViewPoolTests: XCTestCase {
         let sut = EPUBWebViewPool(capacity: 2)
         await sut.prewarm(count: 2)
         guard
-            let first = sut.checkout(editingActions: makeEditingActions()),
-            let second = sut.checkout(editingActions: makeEditingActions())
+            let first = await sut.checkout(editingActions: makeEditingActions()),
+            let second = await sut.checkout(editingActions: makeEditingActions())
         else {
             return XCTFail("Expected two prewarmed web views")
         }
@@ -194,8 +452,8 @@ final class EPUBWebViewPoolTests: XCTestCase {
 
         XCTAssertEqual(sut.count, 2)
         let restocked = [
-            sut.checkout(editingActions: makeEditingActions()),
-            sut.checkout(editingActions: makeEditingActions()),
+            await sut.checkout(editingActions: makeEditingActions()),
+            await sut.checkout(editingActions: makeEditingActions()),
         ]
         XCTAssertEqual(
             Set(restocked.compactMap { $0.map(ObjectIdentifier.init) }),
@@ -210,8 +468,8 @@ final class EPUBWebViewPoolTests: XCTestCase {
         let sut = EPUBWebViewPool(capacity: 2)
         await sut.prewarm(count: 2)
         guard
-            let first = sut.checkout(editingActions: makeEditingActions()),
-            sut.checkout(editingActions: makeEditingActions()) != nil
+            let first = await sut.checkout(editingActions: makeEditingActions()),
+            await sut.checkout(editingActions: makeEditingActions()) != nil
         else {
             return XCTFail("Expected two prewarmed web views")
         }
@@ -228,8 +486,8 @@ final class EPUBWebViewPoolTests: XCTestCase {
         let sut = EPUBWebViewPool(capacity: 2)
         await sut.prewarm(count: 2)
         guard
-            let first = sut.checkout(editingActions: makeEditingActions()),
-            let second = sut.checkout(editingActions: makeEditingActions())
+            let first = await sut.checkout(editingActions: makeEditingActions()),
+            let second = await sut.checkout(editingActions: makeEditingActions())
         else {
             return XCTFail("Expected two prewarmed web views")
         }
@@ -247,7 +505,7 @@ final class EPUBWebViewPoolTests: XCTestCase {
     func testPrewarmRestocksOnceEverythingIsBack() async {
         let sut = EPUBWebViewPool(capacity: 1)
         await sut.prewarm(count: 1)
-        guard let webView = sut.checkout(editingActions: makeEditingActions()) else {
+        guard let webView = await sut.checkout(editingActions: makeEditingActions()) else {
             return XCTFail("Expected a prewarmed web view")
         }
         sut.giveBack(webView)
@@ -258,6 +516,18 @@ final class EPUBWebViewPoolTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// Yields to the main actor until `condition` holds, or the budget runs out.
+    @discardableResult
+    private func pump(iterations: Int = 200, until condition: () -> Bool) async -> Bool {
+        for _ in 0 ..< iterations {
+            if condition() {
+                return true
+            }
+            await Task.yield()
+        }
+        return condition()
+    }
 
     private func makeEditingActions() -> EditingActionsController {
         EditingActionsController(

--- a/Tests/NavigatorTests/EPUB/WebViewServerTests.swift
+++ b/Tests/NavigatorTests/EPUB/WebViewServerTests.swift
@@ -1,0 +1,306 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumNavigator
+import ReadiumShared
+import WebKit
+import XCTest
+
+/// A `WKURLSchemeTask` standing in for WebKit's, recording what the server
+/// responded and letting the test await completion.
+private final class URLSchemeTaskSpy: NSObject, WKURLSchemeTask, @unchecked Sendable {
+    let request: URLRequest
+
+    private(set) var receivedData = Data()
+    private(set) var response: URLResponse?
+    private(set) var error: Error?
+    private(set) var isFinished = false
+
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    init(url: String) {
+        request = URLRequest(url: URL(string: url)!)
+        super.init()
+    }
+
+    /// The body the server sent, decoded as UTF-8.
+    var receivedString: String? {
+        String(data: receivedData, encoding: .utf8)
+    }
+
+    var statusCode: Int? {
+        (response as? HTTPURLResponse)?.statusCode
+    }
+
+    func header(_ name: String) -> String? {
+        (response as? HTTPURLResponse)?.value(forHTTPHeaderField: name)
+    }
+
+    /// Waits until the server either finished or failed the task.
+    func complete() async {
+        guard !isFinished, error == nil else {
+            return
+        }
+
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func didReceive(_ response: URLResponse) {
+        self.response = response
+    }
+
+    func didReceive(_ data: Data) {
+        receivedData.append(data)
+    }
+
+    func didFinish() {
+        isFinished = true
+        resume()
+    }
+
+    func didFailWithError(_ error: any Error) {
+        self.error = error
+        resume()
+    }
+
+    private func resume() {
+        let continuation = continuation
+        self.continuation = nil
+        continuation?.resume()
+    }
+}
+
+@MainActor
+final class WebViewServerTests: XCTestCase {
+    private let scheme = "readium"
+
+    // MARK: - Resource caching
+
+    /// Two publications are served under different routes but use the same
+    /// internal file names. Caching on the publication-relative path alone
+    /// would serve one book's bytes for the other.
+    func testResourcesWithTheSameRelativePathAreNotSharedAcrossRoutes() async {
+        let sut = makeSUT()
+        sut.serve(at: "book-a", handler: resources(["chapter1.xhtml": "A"]))
+        sut.serve(at: "book-b", handler: resources(["chapter1.xhtml": "B"]))
+
+        let a = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+        let b = await sut.get("\(scheme)://book-b/chapter1.xhtml")
+
+        XCTAssertEqual(a.receivedString, "A")
+        XCTAssertEqual(b.receivedString, "B", "Book B was served book A's cached resource")
+    }
+
+    /// The cache still has to do its job within a single route: the same
+    /// resource instance is reused so buffered reads keep their benefit.
+    func testResourcesAreCachedWithinARoute() async {
+        let sut = makeSUT()
+        var handlerCallCount = 0
+        sut.serve(at: "book-a", handler: resources(["chapter1.xhtml": "A"]) { handlerCallCount += 1 })
+
+        _ = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+        _ = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+
+        XCTAssertEqual(handlerCallCount, 1, "The resource should have been served from the cache the second time")
+    }
+
+    /// Evicting HTML because one publication's settings changed must not
+    /// throw away every other publication's resources.
+    func testClearingTheCacheOfOneRouteLeavesTheOthersAlone() async {
+        let sut = makeSUT()
+        var callsA = 0
+        var callsB = 0
+        sut.serve(at: "book-a", handler: resources(["chapter1.xhtml": "A"]) { callsA += 1 })
+        sut.serve(at: "book-b", handler: resources(["chapter1.xhtml": "B"]) { callsB += 1 })
+
+        _ = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+        _ = await sut.get("\(scheme)://book-b/chapter1.xhtml")
+        XCTAssertEqual(callsA, 1)
+        XCTAssertEqual(callsB, 1)
+
+        sut.clearResourceCache(atRoute: "book-a") { _, mediaType in mediaType.isHTML }
+
+        _ = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+        _ = await sut.get("\(scheme)://book-b/chapter1.xhtml")
+
+        XCTAssertEqual(callsA, 2, "Book A's resource should have been evicted and re-served")
+        XCTAssertEqual(callsB, 1, "Book B's resource was evicted by a change to book A")
+    }
+
+    func testClearingTheCacheHonoursThePredicate() async {
+        let sut = makeSUT()
+        var htmlCalls = 0
+        var imageCalls = 0
+        sut.serve(at: "book-a", handler: { relativeURL in
+            switch relativeURL.string {
+            case "chapter1.xhtml":
+                htmlCalls += 1
+                return (DataResource(string: "html"), .xhtml)
+            case "cover.jpg":
+                imageCalls += 1
+                return (DataResource(string: "image"), .jpeg)
+            default:
+                return nil
+            }
+        })
+
+        _ = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+        _ = await sut.get("\(scheme)://book-a/cover.jpg")
+
+        sut.clearResourceCache(atRoute: "book-a") { _, mediaType in mediaType.isHTML }
+
+        _ = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+        _ = await sut.get("\(scheme)://book-a/cover.jpg")
+
+        XCTAssertEqual(htmlCalls, 2, "The HTML resource should have been evicted")
+        XCTAssertEqual(imageCalls, 1, "The image does not match the predicate and should have stayed cached")
+    }
+
+    // MARK: - Embedding
+
+    /// A publication's documents must not be embeddable by a document of
+    /// another origin, which on a shared server means another publication.
+    func testPublicationResourcesRestrictEmbedding() async {
+        let sut = makeSUT()
+        sut.serve(at: "book-a", handler: resources(["chapter1.xhtml": "A"]))
+
+        let response = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+
+        XCTAssertEqual(response.header("Content-Security-Policy"), "frame-ancestors 'self'")
+    }
+
+    /// Fixed-layout publications load their spine resources into iframes of a
+    /// wrapper page served from the same origin, so same-origin framing has to
+    /// stay allowed.
+    func testEmbeddingPolicyAllowsSameOriginFraming() {
+        XCTAssertTrue(
+            WebViewServer.publicationContentSecurityPolicy.contains("'self'"),
+            "Fixed-layout publications frame their own resources"
+        )
+        XCTAssertFalse(WebViewServer.publicationContentSecurityPolicy.contains("'none'"))
+    }
+
+    // MARK: - Route lifetime
+
+    func testRemovedRouteStopsBeingServed() async {
+        let sut = makeSUT()
+        sut.serve(at: "book-a", handler: resources(["chapter1.xhtml": "A"]))
+        sut.serve(at: "book-b", handler: resources(["chapter1.xhtml": "B"]))
+
+        sut.remove(at: "book-a")
+
+        let a = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+        XCTAssertNotNil(a.error, "The removed route is still being served")
+
+        let b = await sut.get("\(scheme)://book-b/chapter1.xhtml")
+        XCTAssertEqual(b.receivedString, "B", "Removing one route took another one down with it")
+    }
+
+    /// Closing a publication has to release the resources it had cached,
+    /// otherwise a shared server would hold on to them for the lifetime of the
+    /// app.
+    func testRemovingARouteDropsItsCachedResources() async {
+        let sut = makeSUT()
+        var callsA = 0
+        var callsB = 0
+        sut.serve(at: "book-a", handler: resources(["chapter1.xhtml": "A"]) { callsA += 1 })
+        sut.serve(at: "book-b", handler: resources(["chapter1.xhtml": "B"]) { callsB += 1 })
+
+        _ = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+        _ = await sut.get("\(scheme)://book-b/chapter1.xhtml")
+
+        sut.remove(at: "book-a")
+        // Serving the route again stands in for reopening the publication.
+        sut.serve(at: "book-a", handler: resources(["chapter1.xhtml": "A"]) { callsA += 1 })
+        _ = await sut.get("\(scheme)://book-a/chapter1.xhtml")
+
+        XCTAssertEqual(callsA, 2, "The cached resource outlived the route it was served from")
+        XCTAssertEqual(callsB, 1, "Book B's cache was dropped along with book A's route")
+    }
+
+    /// Route names are matched on segment boundaries: `book1` and `book10` are
+    /// unrelated routes even though one is a textual prefix of the other.
+    func testRemovingARouteLeavesRoutesWithACollidingNameAlone() async {
+        let sut = makeSUT()
+        sut.serve(at: "book1", handler: resources(["chapter1.xhtml": "one"]))
+        sut.serve(at: "book10", handler: resources(["chapter1.xhtml": "ten"]))
+
+        sut.remove(at: "book1")
+
+        let removed = await sut.get("\(scheme)://book1/chapter1.xhtml")
+        XCTAssertNotNil(removed.error, "The removed route is still being served")
+
+        let survivor = await sut.get("\(scheme)://book10/chapter1.xhtml")
+        XCTAssertEqual(survivor.receivedString, "ten", "Removing book1 also took down book10")
+    }
+
+    func testRemovingARouteKeepsTheCacheOfRoutesWithACollidingName() async {
+        let sut = makeSUT()
+        var calls = 0
+        sut.serve(at: "book1", handler: resources(["chapter1.xhtml": "one"]))
+        sut.serve(at: "book10", handler: resources(["chapter1.xhtml": "ten"]) { calls += 1 })
+
+        _ = await sut.get("\(scheme)://book10/chapter1.xhtml")
+        XCTAssertEqual(calls, 1)
+
+        sut.remove(at: "book1")
+        _ = await sut.get("\(scheme)://book10/chapter1.xhtml")
+
+        XCTAssertEqual(calls, 1, "Removing book1 evicted book10's cached resource")
+    }
+
+    func testClearingTheCacheLeavesRoutesWithACollidingNameAlone() async {
+        let sut = makeSUT()
+        var calls = 0
+        sut.serve(at: "book1", handler: resources(["chapter1.xhtml": "one"]))
+        sut.serve(at: "book10", handler: resources(["chapter1.xhtml": "ten"]) { calls += 1 })
+
+        _ = await sut.get("\(scheme)://book10/chapter1.xhtml")
+        sut.clearResourceCache(atRoute: "book1") { _, _ in true }
+        _ = await sut.get("\(scheme)://book10/chapter1.xhtml")
+
+        XCTAssertEqual(calls, 1, "Clearing book1's cache evicted book10's resource")
+    }
+
+    func testUnknownRouteFails() async {
+        let sut = makeSUT()
+        sut.serve(at: "book-a", handler: resources(["chapter1.xhtml": "A"]))
+
+        let response = await sut.get("\(scheme)://book-b/chapter1.xhtml")
+
+        XCTAssertNotNil(response.error)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT() -> WebViewServer {
+        WebViewServer(scheme: scheme, formatSniffer: DefaultFormatSniffer())
+    }
+
+    /// Builds a resource handler serving the given UTF-8 bodies by path.
+    private func resources(
+        _ bodies: [String: String],
+        onServe: @escaping () -> Void = {}
+    ) -> (RelativeURL) async -> (Resource, MediaType)? {
+        { relativeURL in
+            guard let body = bodies[relativeURL.string] else {
+                return nil
+            }
+            onServe()
+            return (DataResource(string: body), .xhtml)
+        }
+    }
+}
+
+private extension WebViewServer {
+    /// Serves the given URL and waits for the response.
+    func get(_ url: String) async -> URLSchemeTaskSpy {
+        let task = URLSchemeTaskSpy(url: url)
+        start(task)
+        await task.complete()
+        return task
+    }
+}

--- a/Tests/NavigatorTests/Toolkit/PaginationViewTests.swift
+++ b/Tests/NavigatorTests/Toolkit/PaginationViewTests.swift
@@ -1,0 +1,385 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumNavigator
+import ReadiumShared
+import UIKit
+import XCTest
+
+@MainActor
+final class PaginationViewTests: XCTestCase {
+    private let pageSize = CGRect(x: 0, y: 0, width: 320, height: 480)
+
+    /// The delegate must be notified as soon as the *current* page finished
+    /// loading, without waiting for the preloaded neighbours.
+    func testDelegateNotifiedWhenCurrentPageLoadsBeforePreloads() async {
+        let didUpdateViews = expectation(description: "paginationViewDidUpdateViews called")
+        didUpdateViews.assertForOverFulfill = false
+
+        let spy = PaginationViewDelegateSpy()
+        let sut = makeSUT(delegate: spy)
+        sut.reloadAtIndex(5, location: .start, pageCount: 100, readingProgression: .ltr)
+
+        // Wait for the current page to be created and to start loading.
+        let currentPageIsLoading = await pump { spy.pageViews[5]?.isLoading == true }
+        XCTAssertTrue(currentPageIsLoading, "The current page (5) never started loading")
+
+        // Arm the expectation only now, so it cannot be satisfied by a
+        // notification that happened before the current page finished loading.
+        let updateCountBeforeRelease = spy.didUpdateViewsCallCount
+        spy.onDidUpdateViews = { didUpdateViews.fulfill() }
+
+        // Let the current page finish loading. Every other page stays gated.
+        spy.pageViews[5]?.release()
+
+        await fulfillment(of: [didUpdateViews], timeout: 1.0)
+
+        XCTAssertGreaterThan(
+            spy.didUpdateViewsCallCount, updateCountBeforeRelease,
+            "The delegate was not notified as a result of the current page finishing"
+        )
+        XCTAssertEqual(spy.pageViews[5]?.didFinishLoading, true)
+
+        // What matters is the state captured *at the moment* the delegate
+        // fired: page 5 must be the only page that had finished loading. This
+        // pins the ordering whether the neighbours are preloaded serially or
+        // concurrently, and cannot pass vacuously — page 5 must be present.
+        let firstUpdateAfterRelease = spy.updates
+            .dropFirst(updateCountBeforeRelease)
+            .first
+        XCTAssertEqual(
+            firstUpdateAfterRelease?.finishedIndices, [5],
+            "The delegate should be notified once the current page is loaded, not once its neighbours are"
+        )
+
+        // Unblock the remaining pages so no continuation is left dangling.
+        spy.releaseAll()
+        await pump { !spy.hasLoadingPageViews }
+    }
+
+    /// A single reload must not request the same page index twice: re-requesting
+    /// indices makes the preloading cost grow superlinearly.
+    func testEachIndexRequestedAtMostOncePerReload() async {
+        let spy = PaginationViewDelegateSpy()
+        let sut = makeSUT(delegate: spy)
+
+        sut.reloadAtIndex(5, location: .start, pageCount: 100, readingProgression: .ltr)
+
+        // Drain the whole loading queue.
+        for _ in 0 ..< 20 {
+            await pump { spy.hasLoadingPageViews }
+            spy.releaseAll()
+        }
+
+        XCTAssertFalse(spy.requestedIndices.isEmpty, "No page was ever requested")
+        XCTAssertEqual(
+            spy.pageViews[5]?.goCallCount, 1,
+            "The current page was loaded more than once for a single reload"
+        )
+
+        let duplicates = spy.requestedIndices
+            .reduce(into: [Int: Int]()) { $0[$1, default: 0] += 1 }
+            .filter { $0.value > 1 }
+            .keys
+            .sorted()
+
+        XCTAssertEqual(
+            duplicates, [],
+            "Indices requested more than once: \(duplicates), full sequence: \(spy.requestedIndices)"
+        )
+    }
+
+    /// Navigating away leaves the pages queued for the *previous* position
+    /// still pending. They must not be loaded before the new current page:
+    /// the page the reader is looking at always comes first.
+    func testNavigatingDropsPagesQueuedForThePreviousPosition() async {
+        let spy = PaginationViewDelegateSpy()
+        let sut = makeSUT(delegate: spy)
+
+        // Queues [5, 6, 4] and gets stuck loading page 5, leaving 6 and 4
+        // pending in the queue.
+        sut.reloadAtIndex(5, location: .start, pageCount: 100, readingProgression: .ltr)
+        let firstPageIsLoading = await pump { spy.pageViews[5]?.isLoading == true }
+        XCTAssertTrue(firstPageIsLoading, "Page 5 never started loading")
+
+        // Jump far away, the way a table of contents entry does.
+        let requestsBeforeJump = spy.requestedIndices.count
+        let jump = Task { await sut.goToIndex(50, location: .start, options: NavigatorGoOptions(animated: false)) }
+        defer { jump.cancel() }
+
+        // Release the stale in-flight page so the loading chain can move on.
+        await pump { spy.requestedIndices.count > requestsBeforeJump }
+        spy.releaseAll()
+        await pump { spy.requestedIndices.count > requestsBeforeJump }
+
+        let indexLoadedAfterJump = spy.requestedIndices.dropFirst(requestsBeforeJump).first
+        XCTAssertEqual(
+            indexLoadedAfterJump, 50,
+            "Pages queued for the previous position were loaded before the new current page"
+        )
+    }
+
+    /// Reloading cancels the in-flight loading task. The cancelled chain must
+    /// stop: it may finish the page it already started, but it must not keep
+    /// draining the queue nor notify the delegate about the new, still blank,
+    /// current page.
+    func testReloadStopsTheCancelledLoadingChain() async {
+        let spy = PaginationViewDelegateSpy()
+        let sut = makeSUT(delegate: spy)
+
+        // First reload queues [5, 6, 4] and gets stuck loading page 5.
+        sut.reloadAtIndex(5, location: .start, pageCount: 100, readingProgression: .ltr)
+        let firstPageIsLoading = await pump { spy.pageViews[5]?.isLoading == true }
+        XCTAssertTrue(firstPageIsLoading, "Page 5 never started loading")
+
+        // Jump elsewhere while page 5 is still in flight. This cancels the
+        // loading task and queues [50, 51, 49] instead.
+        let requestsBeforeReload = spy.requestedIndices.count
+        let updatesBeforeReload = spy.updates.count
+        sut.reloadAtIndex(50, location: .start, pageCount: 100, readingProgression: .ltr)
+
+        let newCurrentPageIsLoading = await pump { spy.pageViews[50]?.isLoading == true }
+        XCTAssertTrue(newCurrentPageIsLoading, "Page 50 never started loading after the reload")
+
+        // Let the *stale* page finish. Its chain is cancelled, so it must not
+        // pick up any further work — page 51 belongs to the new chain, which is
+        // still busy with page 50.
+        spy.pageViews[5]?.release()
+        await pump { spy.pageViews[51] != nil }
+
+        XCTAssertEqual(spy.pageViews[5]?.didFinishLoading, true, "Page 5 was never released")
+        XCTAssertEqual(spy.pageViews[50]?.isLoading, true, "The new chain should still be loading page 50")
+        XCTAssertNil(
+            spy.pageViews[51],
+            "The cancelled chain kept draining the queue and started loading page 51"
+        )
+
+        // Drain everything that remains.
+        for _ in 0 ..< 20 {
+            await pump { spy.hasLoadingPageViews }
+            spy.releaseAll()
+        }
+
+        let indicesAfterReload = Set(spy.requestedIndices.dropFirst(requestsBeforeReload))
+        XCTAssertFalse(indicesAfterReload.isEmpty, "No page was requested after the reload")
+        XCTAssertTrue(
+            indicesAfterReload.isSubset(of: [49, 50, 51]),
+            "Stale indices were loaded after the reload: \(indicesAfterReload.sorted())"
+        )
+
+        let updatesAfterReload = Array(spy.updates.dropFirst(updatesBeforeReload))
+        XCTAssertFalse(updatesAfterReload.isEmpty, "The delegate was never notified after the reload")
+        let blankNotifications = updatesAfterReload.filter { !$0.currentPageDidFinishLoading }
+        XCTAssertEqual(
+            blankNotifications, [],
+            "The delegate was notified while the current page was still blank: \(blankNotifications)"
+        )
+    }
+
+    /// Page views that fall out of the pre-load window are handed back to the
+    /// delegate, so it can re-target them instead of paying for a brand new
+    /// web view.
+    func testFlushedPageViewsAreHandedBackAndCanBeRecycled() async {
+        let spy = PaginationViewDelegateSpy()
+        spy.recyclesViews = true
+        let sut = makeSUT(delegate: spy)
+
+        sut.reloadAtIndex(5, location: .start, pageCount: 100, readingProgression: .ltr)
+        await drain(spy)
+
+        XCTAssertEqual(spy.displayedViews.keys.sorted(), [4, 5, 6], "Expected the current page and its neighbours")
+        XCTAssertEqual(spy.createdViewCount, 3)
+        XCTAssertEqual(spy.returnedIndices, [], "Nothing should have been flushed yet")
+
+        // Jump far away: none of the loaded pages stay in the window.
+        let jump = Task { await sut.goToIndex(50, location: .start, options: NavigatorGoOptions(animated: false)) }
+        defer { jump.cancel() }
+        await drain(spy)
+
+        XCTAssertEqual(
+            spy.returnedIndices.sorted(), [4, 5, 6],
+            "The flushed page views were discarded instead of being handed back"
+        )
+        XCTAssertEqual(
+            spy.createdViewCount, 3,
+            "New page views were built even though \(spy.returnedIndices.count) were available for reuse"
+        )
+        XCTAssertEqual(spy.displayedViews.keys.sorted(), [49, 50, 51])
+
+        let reused = Set(spy.displayedViews.values.map(ObjectIdentifier.init))
+        let handedBack = Set(spy.returnedViews.map(ObjectIdentifier.init))
+        XCTAssertEqual(reused, handedBack, "The pages now on screen are not the recycled instances")
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT(delegate: PaginationViewDelegateSpy) -> PaginationView {
+        let sut = PaginationView(
+            frame: pageSize,
+            preloadPreviousPositionCount: 1,
+            preloadNextPositionCount: 1,
+            isScrollEnabled: true
+        )
+        sut.delegate = delegate
+        return sut
+    }
+
+    /// Releases every gated page view until nothing is loading anymore.
+    private func drain(_ spy: PaginationViewDelegateSpy, iterations: Int = 20) async {
+        for _ in 0 ..< iterations {
+            await pump { spy.hasLoadingPageViews }
+            spy.releaseAll()
+        }
+    }
+
+    /// Yields to the main actor until `condition` holds, or the iteration
+    /// budget is exhausted.
+    @discardableResult
+    private func pump(iterations: Int = 50, until condition: () -> Bool) async -> Bool {
+        for _ in 0 ..< iterations {
+            if condition() {
+                return true
+            }
+            await Task.yield()
+        }
+        return condition()
+    }
+}
+
+/// A `PageView` whose loading is gated by the test: `go(to:animated:)` suspends
+/// until `release()` is called.
+@MainActor
+private final class GatedPageView: UIView, PageView {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    private(set) var didFinishLoading = false
+    private(set) var goCallCount = 0
+
+    /// Whether `go(to:animated:)` is currently suspended, waiting for `release()`.
+    var isLoading: Bool { continuation != nil }
+
+    func go(to location: PageLocation, animated: Bool) async {
+        goCallCount += 1
+        // A `CheckedContinuation` must be resumed exactly once. If production
+        // code starts a second load before the first one finished, resume the
+        // pending one rather than dropping it on the floor.
+        resumePendingContinuation()
+        await withCheckedContinuation { continuation = $0 }
+        didFinishLoading = true
+    }
+
+    func release() {
+        resumePendingContinuation()
+    }
+
+    private func resumePendingContinuation() {
+        guard let pending = continuation else {
+            return
+        }
+        continuation = nil
+        pending.resume()
+    }
+}
+
+/// State of the pagination view captured at the moment the delegate was
+/// notified.
+private struct UpdateSnapshot: Equatable {
+    let currentIndex: Int
+    /// Whether the page the pagination view considers current had finished
+    /// loading. Notifying while this is false means publishing a blank page.
+    let currentPageDidFinishLoading: Bool
+    let finishedIndices: [Int]
+}
+
+@MainActor
+private final class PaginationViewDelegateSpy: PaginationViewDelegate {
+    /// Every index passed to `pageViewAtIndex`, in call order.
+    private(set) var requestedIndices: [Int] = []
+
+    /// Last page view served for each index. Never pruned, so a test can still
+    /// reach a view after the pagination view stopped displaying it.
+    private(set) var pageViews: [Int: GatedPageView] = [:]
+
+    /// Page views the pagination view is currently displaying.
+    private(set) var displayedViews: [Int: GatedPageView] = [:]
+
+    /// Every page view ever built, including those no longer displayed.
+    private(set) var createdViews: [GatedPageView] = []
+
+    var createdViewCount: Int { createdViews.count }
+
+    /// Page views handed back through `didEndDisplayingView`, in call order.
+    private(set) var returnedIndices: [Int] = []
+    private(set) var returnedViews: [GatedPageView] = []
+
+    /// When enabled, page views handed back are pooled and served again on the
+    /// next request, the way the EPUB navigator recycles its spread views.
+    var recyclesViews = false
+    private var pool: [GatedPageView] = []
+
+    /// State captured at each `paginationViewDidUpdateViews` call, in call order.
+    private(set) var updates: [UpdateSnapshot] = []
+
+    var didUpdateViewsCallCount: Int { updates.count }
+
+    var onDidUpdateViews: (() -> Void)?
+
+    var hasLoadingPageViews: Bool {
+        createdViews.contains { $0.isLoading }
+    }
+
+    func releaseAll() {
+        for view in createdViews {
+            view.release()
+        }
+    }
+
+    func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) -> (UIView & PageView)? {
+        requestedIndices.append(index)
+
+        let view: GatedPageView
+        if recyclesViews, !pool.isEmpty {
+            view = pool.removeFirst()
+        } else {
+            view = GatedPageView()
+            createdViews.append(view)
+        }
+
+        pageViews[index] = view
+        displayedViews[index] = view
+        return view
+    }
+
+    func paginationView(_ paginationView: PaginationView, didEndDisplayingView view: UIView & PageView, atIndex index: Int) {
+        guard let view = view as? GatedPageView else {
+            return
+        }
+        returnedIndices.append(index)
+        returnedViews.append(view)
+        displayedViews.removeValue(forKey: index)
+
+        if recyclesViews {
+            pool.append(view)
+        }
+    }
+
+    func paginationViewDidUpdateViews(_ paginationView: PaginationView) {
+        let currentPage = paginationView.loadedViews[paginationView.currentIndex] as? GatedPageView
+        updates.append(UpdateSnapshot(
+            currentIndex: paginationView.currentIndex,
+            currentPageDidFinishLoading: currentPage?.didFinishLoading == true,
+            finishedIndices: pageViews
+                .filter { $0.value.didFinishLoading }
+                .keys
+                .sorted()
+        ))
+        onDidUpdateViews?()
+    }
+
+    func paginationView(_ paginationView: PaginationView, positionCountAtIndex index: Int) -> Int {
+        1
+    }
+}

--- a/Tests/NavigatorTests/Toolkit/PaginationViewTests.swift
+++ b/Tests/NavigatorTests/Toolkit/PaginationViewTests.swift
@@ -214,6 +214,76 @@ final class PaginationViewTests: XCTestCase {
         XCTAssertEqual(reused, handedBack, "The pages now on screen are not the recycled instances")
     }
 
+    /// Building a page view suspends, so the pagination can be reloaded while
+    /// one is being made. The page that arrives late belongs to the position
+    /// the reader has left: it must neither be displayed nor dropped on the
+    /// floor — the delegate gets it back so it can recycle it.
+    func testPageViewArrivingAfterAReloadIsHandedBackInsteadOfDisplayed() async {
+        let spy = PaginationViewDelegateSpy()
+        spy.gatesPageViewCreation = true
+        let sut = makeSUT(delegate: spy)
+
+        sut.reloadAtIndex(5, location: .start, pageCount: 100, readingProgression: .ltr)
+        let isBuildingPage5 = await pump { spy.hasPendingPageViewCreation }
+        XCTAssertTrue(isBuildingPage5, "Page 5 was never requested")
+        XCTAssertEqual(spy.requestedIndices, [5])
+
+        // Jump elsewhere while page 5 is still being built. This cancels the
+        // loading chain that asked for it.
+        sut.reloadAtIndex(50, location: .start, pageCount: 100, readingProgression: .ltr)
+        let updatesBeforeRelease = spy.updates.count
+
+        spy.releasePageViewCreation()
+        await pump { spy.returnedIndices.contains(5) }
+
+        XCTAssertNil(sut.loadedViews[5], "A page from the abandoned position was put on screen")
+        XCTAssertTrue(
+            spy.returnedIndices.contains(5),
+            "The page built for the abandoned position was dropped instead of handed back"
+        )
+
+        let staleUpdates = spy.updates
+            .dropFirst(updatesBeforeRelease)
+            .filter { $0.currentIndex == 5 }
+        XCTAssertEqual(staleUpdates, [], "The cancelled chain reported progress after the reload")
+
+        spy.gatesPageViewCreation = false
+        spy.releasePageViewCreation()
+        await drain(spy)
+    }
+
+    /// Reloads that interrupt page creation must leave nothing behind: every
+    /// page view built is either on screen or has been given back, never
+    /// silently dropped along with whatever it holds.
+    func testNoPageViewIsStrandedWhenReloadsInterruptCreation() async {
+        let spy = PaginationViewDelegateSpy()
+        spy.gatesPageViewCreation = true
+        let sut = makeSUT(delegate: spy)
+
+        sut.reloadAtIndex(5, location: .start, pageCount: 100, readingProgression: .ltr)
+        await pump { spy.hasPendingPageViewCreation }
+        sut.reloadAtIndex(50, location: .start, pageCount: 100, readingProgression: .ltr)
+        await pump { spy.requestedIndices.contains(50) }
+        sut.reloadAtIndex(80, location: .start, pageCount: 100, readingProgression: .ltr)
+
+        spy.gatesPageViewCreation = false
+        for _ in 0 ..< 20 {
+            spy.releasePageViewCreation()
+            await pump { spy.hasLoadingPageViews }
+            spy.releaseAll()
+        }
+
+        let built = Set(spy.createdViews.map(ObjectIdentifier.init))
+        let onScreen = Set(sut.loadedViews.values.compactMap { ($0 as? GatedPageView).map(ObjectIdentifier.init) })
+        let handedBack = Set(spy.returnedViews.map(ObjectIdentifier.init))
+
+        XCTAssertFalse(built.isEmpty, "No page view was ever built")
+        XCTAssertEqual(
+            built.subtracting(onScreen).subtracting(handedBack), [],
+            "Page views were dropped instead of being displayed or handed back"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeSUT(delegate: PaginationViewDelegateSpy) -> PaginationView {
@@ -337,8 +407,27 @@ private final class PaginationViewDelegateSpy: PaginationViewDelegate {
         }
     }
 
-    func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) -> (UIView & PageView)? {
+    /// When enabled, `pageViewAtIndex` suspends until `releasePageViewCreation`
+    /// is called, so a test can act while the pagination view is mid-await.
+    var gatesPageViewCreation = false
+    private var creationGates: [CheckedContinuation<Void, Never>] = []
+
+    var hasPendingPageViewCreation: Bool { !creationGates.isEmpty }
+
+    func releasePageViewCreation() {
+        let gates = creationGates
+        creationGates = []
+        for gate in gates {
+            gate.resume()
+        }
+    }
+
+    func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) async -> (UIView & PageView)? {
         requestedIndices.append(index)
+
+        if gatesPageViewCreation {
+            await withCheckedContinuation { creationGates.append($0) }
+        }
 
         let view: GatedPageView
         if recyclesViews, !pool.isEmpty {

--- a/Tests/NavigatorTests/Toolkit/RecyclingPoolTests.swift
+++ b/Tests/NavigatorTests/Toolkit/RecyclingPoolTests.swift
@@ -1,0 +1,145 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+@testable import ReadiumNavigator
+import Testing
+
+private final class RecyclableSpy: Recyclable {
+    var canBeRecycled: Bool
+
+    init(canBeRecycled: Bool = true) {
+        self.canBeRecycled = canBeRecycled
+    }
+}
+
+@Suite("RecyclingPool")
+struct RecyclingPoolTests {
+    @Test("hands back a pooled instance")
+    func popsPushedElement() {
+        var pool = RecyclingPool<RecyclableSpy>(capacity: 2)
+        let element = RecyclableSpy()
+
+        pool.push(element)
+
+        #expect(pool.pop() === element)
+        #expect(pool.pop() == nil)
+    }
+
+    @Test("is empty until something is pooled")
+    func emptyPool() {
+        var pool = RecyclingPool<RecyclableSpy>(capacity: 2)
+
+        #expect(pool.isEmpty)
+        #expect(pool.pop() == nil)
+    }
+
+    @Test("refuses instances that are already ineligible")
+    func rejectsIneligibleOnPush() {
+        var pool = RecyclingPool<RecyclableSpy>(capacity: 2)
+
+        pool.push(RecyclableSpy(canBeRecycled: false))
+
+        #expect(pool.isEmpty)
+    }
+
+    /// An instance can stop being eligible after it was pooled, for example
+    /// because a setting baked into it changed in the meantime. Checking only
+    /// on the way in would hand it out anyway.
+    @Test("discards instances that became ineligible while pooled")
+    func rejectsIneligibleOnPop() {
+        var pool = RecyclingPool<RecyclableSpy>(capacity: 3)
+        let stale = RecyclableSpy()
+        let usable = RecyclableSpy()
+
+        pool.push(usable)
+        pool.push(stale)
+        stale.canBeRecycled = false
+
+        #expect(pool.pop() === usable)
+        #expect(pool.isEmpty)
+    }
+
+    @Test("hands out nothing when every pooled instance went stale")
+    func allPooledElementsBecameIneligible() {
+        var pool = RecyclingPool<RecyclableSpy>(capacity: 3)
+        let elements = [RecyclableSpy(), RecyclableSpy()]
+
+        for element in elements {
+            pool.push(element)
+        }
+        for element in elements {
+            element.canBeRecycled = false
+        }
+
+        #expect(pool.pop() == nil)
+        #expect(pool.isEmpty)
+    }
+
+    /// A settings toggle can invalidate everything sitting in a full pool.
+    /// Those entries will never be handed out, so they must not keep usable
+    /// ones from being pooled.
+    @Test("does not let stale instances take up capacity")
+    func staleElementsDoNotConsumeCapacity() {
+        var pool = RecyclingPool<RecyclableSpy>(capacity: 2)
+        let stale = RecyclableSpy()
+        let usable = RecyclableSpy()
+        pool.push(stale)
+        pool.push(usable)
+
+        stale.canBeRecycled = false
+        let fresh = RecyclableSpy()
+        pool.push(fresh)
+
+        #expect(pool.count == 2)
+        #expect(pool.pop() === fresh)
+        #expect(pool.pop() === usable)
+        #expect(pool.pop() == nil)
+    }
+
+    /// A caller holding resources on a rejected instance's behalf has to know
+    /// it was rejected, so it can release them instead of letting them go with
+    /// it.
+    @Test("reports whether the instance was kept")
+    func pushReportsAcceptance() {
+        var pool = RecyclingPool<RecyclableSpy>(capacity: 1)
+
+        #expect(pool.push(RecyclableSpy()) == true)
+        #expect(pool.push(RecyclableSpy()) == false, "The pool is full")
+        #expect(pool.push(RecyclableSpy(canBeRecycled: false)) == false, "The instance is not reusable")
+    }
+
+    @Test("drops instances offered beyond its capacity")
+    func honoursCapacity() {
+        var pool = RecyclingPool<RecyclableSpy>(capacity: 2)
+
+        for _ in 0 ..< 5 {
+            pool.push(RecyclableSpy())
+        }
+
+        #expect(pool.count == 2)
+    }
+
+    @Test("keeps nothing when built with no capacity")
+    func zeroCapacity() {
+        var pool = RecyclingPool<RecyclableSpy>(capacity: 0)
+
+        pool.push(RecyclableSpy())
+
+        #expect(pool.isEmpty)
+        #expect(pool.pop() == nil)
+    }
+
+    @Test("forgets everything on removeAll")
+    func removesAll() {
+        var pool = RecyclingPool<RecyclableSpy>(capacity: 2)
+        pool.push(RecyclableSpy())
+
+        pool.removeAll()
+
+        #expect(pool.isEmpty)
+        #expect(pool.pop() == nil)
+    }
+}


### PR DESCRIPTION
### Problem

On publications with thousands of small spine items (common for web-novel EPUBs), the EPUB navigator takes 5–7 seconds to show the first page, and the same again for every TOC jump. Instrumented diagnosis on an iOS 27 simulator (Debug) showed the cost is entirely WKWebView lifecycle, not parsing or resource serving:

- Opening/parsing a 2,114-spine publication, loading its TOC and computing positions: **~0.4s total**.
- Serving every resource of a whole book-open through `WebViewServer`: **0.30s combined** (max single request 71ms).
- Each **fresh `WKWebView`** pays ~1.7s before `didStartProvisionalNavigation` (WebContent process launch) plus ~2.7s before `didCommit` — the latter is a **once-per-web-view first-navigation cost of the custom URL scheme** (measured in isolation: a scheme-only load pays it in full, a 104KB user-script-only load pays nothing, and a second navigation on the same web view drops to ~0.27s).
- `PaginationView` destroys and recreates spread views on every jump, so one TOC tap tears down 3 web views and spawns 3 processes (~15s of churn).
- Sharing a `WKProcessPool` or a `WKWebViewConfiguration` does not help (measured: still one WebContent process per web view).

Absolute numbers are simulator-inflated, but the structure (per-web-view launch + handshake, zero amortization, destroy-and-recreate on jump) is platform-independent.

### Fix

Two layers, one commit:

**`PaginationView` correctness**
- The load chain is cancellation-safe: `loadPagesTask.replace` used to cancel the old task, but `loadNextPage()` never checked cancellation, so orphaned chains kept draining the shared queue concurrently and fired `paginationViewDidUpdateViews` spuriously.
- The delegate is notified per loaded page, so the current spread displays as soon as it is ready instead of after the whole preload window drains.
- `setCurrentIndex` clears queue entries left over from the previous position (previously only `reloadAtIndex` cleared them, so after a jump the old neighbours loaded before the new current page).
- Views that fall out of the kept range are handed back through a new `didEndDisplayingView` delegate method instead of being discarded.

**Web view recycling**
- Within a navigator, flushed spread views are kept in a `RecyclingPool` and re-targeted to new spreads (`EPUBSpreadView.retarget(to:)`), reusing web view and process. Eligibility is re-checked at pop time (an FXL view pooled before a spread-mode toggle is rejected rather than rendering the wrong wrapper).
- Across navigators, a new public `EPUBWebViewPool` keeps warmed web views alive so reopening a publication (or opening another) skips both the process launch and the scheme handshake. Hosts can call `prewarm(count:)` early (e.g. while the user browses their library); warm-ups run concurrently and abort as soon as a reader checks a view out.
- This requires a shared `WebViewServer` (the scheme handler binds at configuration creation, before any publication is known). To make that safe, the resource cache is now keyed per route (previously two publications containing the same relative href shared a cache slot — wrong bytes served cross-publication, a latent bug even without pooling), cache clears are route-scoped, routes are unregistered when the view model deinits, and route matching is segment-boundary safe (`book1` no longer matches `book10`).
- Rights safety: a pooled `WebView` holds no `EditingActionsController` until rebound at checkout and denies every editing action while unbound, so one publication's copy/share permissions cannot leak into another. Pooled views use a non-persistent website data store and are stripped of scripts, message handlers and delegates on both give-back and checkout.
- Publication resources are served with `Content-Security-Policy: frame-ancestors 'self'` as defense-in-depth, since simultaneously open publications now share one server and are isolated by route-UUID secrecy rather than separate handler objects. **Reviewers should weigh this trade-off explicitly** — it is inherent to cross-navigator pooling.

### Results (simulator, Debug, 1,537- and 2,114-spine publications)

| Scenario | Before | After |
|---|---|---|
| Open after prewarm → first page visible | ~5.9s | **1.25–1.45s** |
| Re-open a publication | ~5.9s | **1.34s** |
| Far TOC jump → visible | ~5.9s (+15s churn) | **0.83s** (churn ~2.5s) |
| Page turn across spine boundary | up to 4.6s stall | instant |
| WebContent process count | grows per jump | stable (pool size) |

### Tests

`PaginationViewTests`, `RecyclingPoolTests`, `EPUBWebViewPoolTests`, `WebViewServerTests` added (28 new tests); full `ReadiumNavigatorTests` green (138 XCTest + 111 Swift Testing).

### Open questions for review

1. The `frame-ancestors 'self'` header: FXL wrappers frame spine resources from the same origin, so `'self'` should hold — verified reflowable end-to-end, but I could not verify FXL rendering (no FXL publication in the test corpus). If `loadHTMLString`'s wrapper document gets an opaque origin, the header needs to be dropped or scoped.
2. `WebViewServer.shared` vs. injected server instances — happy to rework the sharing shape if you prefer explicit injection over a process-wide default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bwrXwAqjjL4Vrj6vV6UuW
