### PR TITLE
Explicitly define os and arch for xcodebuild

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,6 +17,8 @@ permissions:
 env:
   platform: iOS Simulator
   device: iPhone 17 Pro
+  os: latest
+  arch: arm64
   commit_sha: ${{ github.sha }}
   DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
 
@@ -40,11 +42,11 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          xcodebuild build-for-testing -scheme "$scheme" -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
+          xcodebuild build-for-testing -scheme "$scheme" -destination "platform=$platform,name=$device,OS=$os,arch=$arch" | xcbeautify --renderer github-actions
       - name: Test
         run: |
           set -eo pipefail
-          xcodebuild test-without-building -scheme "$scheme" -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
+          xcodebuild test-without-building -scheme "$scheme" -destination "platform=$platform,name=$device,OS=$os,arch=$arch" | xcbeautify --renderer github-actions
       - name: Print Swift package versions
         run: |
           jq -r '.pins[] | "\(.identity): \(.state.version)"' Package.resolved
@@ -70,7 +72,7 @@ jobs:
       - name: Test
         run: |
           set -eo pipefail
-          xcodebuild test -scheme "$scheme" -destination "platform=$platform,name=$device" -enableThreadSanitizer YES | xcbeautify --renderer github-actions
+          xcodebuild test -scheme "$scheme" -destination "platform=$platform,name=$device,OS=$os,arch=$arch" -enableThreadSanitizer YES | xcbeautify --renderer github-actions
 
   lint:
     name: Lint
@@ -144,12 +146,12 @@ jobs:
         if: env.LCP_URL_SPM == ''
         run: |
           set -eo pipefail
-          xcodebuild build -scheme Playground -project Playground/Playground.xcodeproj -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
+          xcodebuild build -scheme Playground -project Playground/Playground.xcodeproj -destination "platform=$platform,name=$device,OS=$os,arch=$arch" | xcbeautify --renderer github-actions
       - name: Test LCP
         if: env.LCP_URL_SPM != ''
         run: |
           set -eo pipefail
-          xcodebuild test -scheme Playground -project Playground/Playground.xcodeproj -destination "platform=$platform,name=$device" -only-testing:ReadiumLCPTests | xcbeautify --renderer github-actions
+          xcodebuild test -scheme Playground -project Playground/Playground.xcodeproj -destination "platform=$platform,name=$device,OS=$os,arch=$arch" -only-testing:ReadiumLCPTests | xcbeautify --renderer github-actions
       - name: Generate TestApp project
         working-directory: TestApp
         run: make dev lcp="$LCP_URL_SPM"
@@ -157,7 +159,7 @@ jobs:
         working-directory: TestApp
         run: |
           set -eo pipefail
-          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
+          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device,OS=$os,arch=$arch" | xcbeautify --renderer github-actions
 
   int-spm:
     name: Integration (Swift Package Manager)
@@ -195,4 +197,4 @@ jobs:
       - name: Build
         run: |
           set -eo pipefail
-          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device" | xcbeautify --renderer github-actions
+          xcodebuild build -scheme TestApp -destination "platform=$platform,name=$device,OS=$os,arch=$arch" | xcbeautify --renderer github-actions


### PR DESCRIPTION
I've noticed in CI that it finds two matching destinations:

```
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:iOS Simulator, arch:arm64, id:6EE862FE-93F2-4D55-946E-8745EE2B3A88, OS:26.5, name:iPhone 17 Pro }
{ platform:iOS Simulator, arch:x86_64, id:6EE862FE-93F2-4D55-946E-8745EE2B3A88, OS:26.5, name:iPhone 17 Pro }
```

This PR explicitly says to use arm64.