### PR TITLE
fix(navigator): report position while a page scrolls continuously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 All notable changes to this project will be documented in this file. Take a look at [the migration guide](docs/Migration%20Guide.md) to upgrade between two major versions.
 
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+#### Navigator
+
+* The EPUB navigator now reports the reading position while a reflowable page scrolls continuously. Its "scrolling ended" callback was re-scheduled on every progression change, so a page that never stops scrolling — a long momentum flick, or an app scrolling the document itself — emitted no location for as long as the motion lasted.
 
 ## [4.0.0-alpha.1] - 2026-08-14
 

--- a/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
+++ b/Sources/Navigator/EPUB/EPUBReflowableSpreadView.swift
@@ -408,14 +408,39 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
         setNeedsNotifyPagesDidChange()
     }
 
+    /// When the oldest un-notified progression change arrived.
+    private var pagesDidChangePendingSince: Date?
+
+    /// How long a page may scroll without reporting where it is.
+    ///
+    /// The debounce below waits for scrolling to *end*, which never happens
+    /// while a page scrolls continuously — a long momentum flick, or a reader
+    /// auto-scrolling. Each new progression cancels the pending callback, so
+    /// without a ceiling the position would not be reported for as long as the
+    /// motion lasted, and a reader who closed the book mid-scroll would reopen
+    /// where they last lifted their finger.
+    private static let maximumUnreportedScrollDuration: TimeInterval = 1
+
     private func setNeedsNotifyPagesDidChange() {
+        let now = Date()
+        let pendingSince = pagesDidChangePendingSince ?? now
+        pagesDidChangePendingSince = pendingSince
+
         // Makes sure we always receive the "ending scroll" event.
         // ie. https://stackoverflow.com/a/1857162/1474476
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(notifyPagesDidChange), object: nil)
+
+        // A page turn takes well under this, so it still reports once, at its
+        // end. Only a page that keeps scrolling reaches the ceiling.
+        guard now.timeIntervalSince(pendingSince) < Self.maximumUnreportedScrollDuration else {
+            notifyPagesDidChange()
+            return
+        }
         perform(#selector(notifyPagesDidChange), with: nil, afterDelay: 0.3)
     }
 
     @objc private func notifyPagesDidChange() {
+        pagesDidChangePendingSince = nil
         guard previousProgression != progression else {
             return
         }


### PR DESCRIPTION
## What

`EPUBReflowableSpreadView` debounces `progressionChanged` by scheduling `notifyPagesDidChange` 0.3s out and cancelling the pending call each time a new progression arrives. That assumes scrolling stops.

A page that scrolls *continuously* re-arms the cancel on every frame, so the callback never runs: no `locationDidChange`, and `currentLocation` stays where the reader last lifted their finger — for as long as the motion lasts.

This adds a ceiling. The first un-notified change starts a clock; once a second has passed, the next change is reported immediately instead of re-scheduled. A page turn finishes well inside that second and still reports once, at its end, so paginated reading is unchanged.

## Why it matters

The cost is not cosmetic. Anything reading `currentLocation` — a progress footer, a "time left" estimate, a bookmark, or the position saved when the book closes — is stale for the whole length of the scroll. A reader who closes the book mid-scroll reopens where they last touched it rather than where they had read to.

It bites momentum flicks on long resources too, but it is most visible when the host app scrolls the document itself.

## How it was found and verified

Measured in an app that auto-scrolls a reflowable EPUB by moving the document from JavaScript:

- **Before:** no `locationDidChange` at all for the length of a chapter; a probe showed `currentLocation` frozen at `progression=0.1654 position=962` while the text moved several screens.
- **After:** locations arrive about once a second with a moving progression (0.023 → 0.027 → 0.031 → 0.035 over four seconds), and the app's chapter estimate walks down instead of standing still.

Paginated reading was re-checked by hand: page turns still report once, when the turn ends.