### PR TITLE
Improve CRL retrieval and fix poisoned cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * [#121](https://github.com/readium/swift-toolkit/issues/121) HTML `<audio>` and `<video>` elements are now paused when the resource moves off-screen in the EPUB navigator, rather than continuing to play in the background.
 
+#### LCP
+
+* The CRL used to validate LCP licenses is now checked to be a genuine X.509 CRL before being cached. Networks with a captive portal (e.g. on a plane) could return their login page with a `200 OK` status, which was then cached for seven days and prevented opening LCP publications. An invalid CRL cached by a previous version is now ignored instead of waiting for its expiration.
+
 
 ## [4.0.0-alpha.1] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file. Take a look
 
 * Converting a `Link` to a `Locator` is now synchronous: `await publication.locate(link)` becomes `publication.locator(for: link)`. The logic moved to `Manifest`, so it is also available as `manifest.locator(for: link)` without a `Publication`.
 
+#### LCP
+
+* Opening an LCP publication is no longer delayed by the CRL used to validate its license. The CRL is now downloaded when creating the `LCPService`, and an expired one is refreshed in the background instead of making the user wait for the response.
+
 ### Fixed
 
 #### Navigator

--- a/Sources/LCP/LCPService.swift
+++ b/Sources/LCP/LCPService.swift
@@ -48,10 +48,18 @@ public final class LCPService: Loggable, Sendable {
             repository: passphraseRepository
         )
 
+        let crl = CRLService(httpClient: httpClient)
+
+        // Warms the CRL cache so that opening a publication does not have to
+        // wait on the network.
+        Task(priority: .utility) {
+            await crl.preload()
+        }
+
         licenses = LicensesService(
             client: client,
             licenses: licenseRepository,
-            crl: CRLService(httpClient: httpClient),
+            crl: crl,
             device: DeviceService(
                 deviceName: deviceName,
                 deviceId: deviceId,

--- a/Sources/LCP/Services/CRLService.swift
+++ b/Sources/LCP/Services/CRLService.swift
@@ -24,9 +24,13 @@ actor CRLService {
     /// Refresh currently in flight, if any.
     private var refreshTask: Task<String, Error>?
 
-    init(httpClient: HTTPClient, defaults: UserDefaults = .standard) {
+    /// - Parameter defaultsSuite: Name of the `UserDefaults` suite used to
+    ///   cache the CRL, or `nil` for the standard one. A suite name is taken
+    ///   rather than a `UserDefaults`, as the latter is not `Sendable` and
+    ///   cannot be handed over to an actor.
+    init(httpClient: HTTPClient, defaultsSuite: String? = nil) {
         self.httpClient = httpClient
-        self.defaults = defaults
+        defaults = defaultsSuite.flatMap { UserDefaults(suiteName: $0) } ?? .standard
     }
 
     /// Warms the cache so that opening a publication does not have to wait on
@@ -60,7 +64,7 @@ actor CRLService {
             return refreshTask
         }
 
-        let task = Task {
+        let task = Task(priority: .utility) {
             defer { refreshTask = nil }
 
             let crl = try await fetch()
@@ -75,12 +79,7 @@ actor CRLService {
     private func fetch() async throws -> String {
         let url = HTTPURL(string: "http://crl.edrlab.telesec.de/rl/EDRLab_CA.crl")!
 
-        // Timeout for a CRL fetch. Generous enough for a slow connection,
-        // where a failure means the publication cannot be opened at all, but
-        // bounded so that a captive portal cannot hang the open too long.
-        let timeout: TimeInterval = 20
-
-        let response = try await httpClient.fetch(HTTPRequest(url: url, timeoutInterval: timeout))
+        let response = try await httpClient.fetch(HTTPRequest(url: url))
             .mapError { _ in LCPError.crlFetching }
             .get()
 

--- a/Sources/LCP/Services/CRLService.swift
+++ b/Sources/LCP/Services/CRLService.swift
@@ -12,6 +12,9 @@ final class CRLService: Sendable {
     /// Number of days before the CRL cache expires.
     private static let expiration = 7
 
+    private static let pemHeader = "-----BEGIN X509 CRL-----"
+    private static let pemFooter = "-----END X509 CRL-----"
+
     private static let crlKey = "org.readium.r2-lcp-swift.CRL"
     private static let dateKey = "org.readium.r2-lcp-swift.CRLDate"
 
@@ -53,24 +56,84 @@ final class CRLService: Sendable {
             .mapError { _ in LCPError.crlFetching }
             .get()
 
-        guard !response.body.isEmpty else {
+        guard CRLService.isX509CRL(response.body) else {
             throw LCPError.crlFetching
         }
 
         let body = response.body.base64EncodedString()
-        return "-----BEGIN X509 CRL-----\(body)-----END X509 CRL-----"
+        return "\(CRLService.pemHeader)\(body)\(CRLService.pemFooter)"
     }
 
     /// Reads the local CRL.
     private func readLocal() -> (String, Date)? {
         let defaults = UserDefaults.standard
         guard let crl = defaults.string(forKey: CRLService.crlKey),
-              let date = defaults.value(forKey: CRLService.dateKey) as? Date
+              let date = defaults.value(forKey: CRLService.dateKey) as? Date,
+              let der = CRLService.decodePEM(crl),
+              CRLService.isX509CRL(der)
         else {
             return nil
         }
 
         return (crl, date)
+    }
+
+    /// Extracts the DER payload of a PEM-encoded CRL cached by ``saveLocal(_:)``.
+    private static func decodePEM(_ crl: String) -> Data? {
+        guard crl.hasPrefix(pemHeader), crl.hasSuffix(pemFooter) else {
+            return nil
+        }
+        let base64 = crl.dropFirst(pemHeader.count).dropLast(pemFooter.count)
+        return Data(base64Encoded: String(base64))
+    }
+
+    /// Checks that `data` looks like a DER-encoded X.509 CRL.
+    ///
+    /// `CertificateList` is a `SEQUENCE` whose first element is the
+    /// `tbsCertList` `SEQUENCE`. We don't parse the whole structure: this is
+    /// only meant to reject payloads which are not DER at all, such as the HTML
+    /// login page of a captive portal, or a truncated download.
+    ///
+    /// Note that `SEQUENCE { SEQUENCE, ... }` is also the shape of an X.509
+    /// *certificate*. Telling them apart would mean walking into the
+    /// `tbsCertList` looking for a `UTCTime`/`GeneralizedTime`, which guards a
+    /// scenario – this endpoint serving the wrong DER object – with no
+    /// realistic trigger.
+    static func isX509CRL(_ data: Data) -> Bool {
+        let bytes = [UInt8](data)
+
+        // DER `SEQUENCE` tag.
+        guard bytes.count >= 2, bytes[0] == 0x30 else {
+            return false
+        }
+
+        let headerSize: Int
+        let length: Int
+
+        if bytes[1] & 0x80 == 0 {
+            // Short form: the length fits in the byte itself.
+            headerSize = 2
+            length = Int(bytes[1])
+
+        } else {
+            // Long form: the low bits give the number of length bytes. 0x80 is
+            // the indefinite form, illegal in DER, and 0xFF is reserved. We
+            // also reject lengths wider than 4 bytes, way beyond any CRL.
+            let lengthSize = Int(bytes[1] & 0x7F)
+            guard (1 ... 4).contains(lengthSize), bytes.count >= 2 + lengthSize else {
+                return false
+            }
+            headerSize = 2 + lengthSize
+            length = bytes[2 ..< headerSize].reduce(0) { $0 << 8 | Int($1) }
+        }
+
+        // Rejects both a truncated download and trailing garbage.
+        guard headerSize + length == bytes.count else {
+            return false
+        }
+
+        // `tbsCertList` `SEQUENCE`.
+        return bytes.count > headerSize && bytes[headerSize] == 0x30
     }
 
     /// Caches the given CRL.

--- a/Sources/LCP/Services/CRLService.swift
+++ b/Sources/LCP/Services/CRLService.swift
@@ -8,7 +8,7 @@ import Foundation
 import ReadiumShared
 
 /// Certificate Revocation List
-final class CRLService: Sendable {
+actor CRLService {
     /// Number of days before the CRL cache expires.
     private static let expiration = 7
 
@@ -19,38 +19,66 @@ final class CRLService: Sendable {
     private static let dateKey = "org.readium.r2-lcp-swift.CRLDate"
 
     private let httpClient: HTTPClient
+    private let defaults: UserDefaults
 
-    init(httpClient: HTTPClient) {
+    /// Refresh currently in flight, if any.
+    private var refreshTask: Task<String, Error>?
+
+    init(httpClient: HTTPClient, defaults: UserDefaults = .standard) {
         self.httpClient = httpClient
+        self.defaults = defaults
     }
 
-    /// Retrieves the CRL either from the cache, or from EDRLab if the cache is outdated.
+    /// Warms the cache so that opening a publication does not have to wait on
+    /// the network.
+    func preload() {
+        guard readLocal()?.isExpired ?? true else {
+            return
+        }
+        _ = refresh()
+    }
+
+    /// Retrieves the CRL either from the cache, or from EDRLab if the cache is
+    /// missing or invalid.
+    ///
+    /// An expired cache is returned as is and refreshed in the background, as
+    /// waiting on the network would delay the opening of a publication.
     func retrieve() async throws -> String {
-        let localCRL = readLocal()
-        if let (crl, date) = localCRL, daysSince(date) < CRLService.expiration {
-            return crl
+        guard let (crl, isExpired) = readLocal() else {
+            return try await refresh().value
         }
 
-        // Short timeout to avoid blocking the License, since we can always fall back on the cached CRL.
-        let timeout: TimeInterval? = (localCRL == nil) ? nil : 8
+        if isExpired {
+            _ = refresh()
+        }
+        return crl
+    }
 
-        do {
-            let crl = try await fetch(timeout: timeout)
+    /// Starts a CRL refresh, or returns the one already in flight.
+    private func refresh() -> Task<String, Error> {
+        if let refreshTask {
+            return refreshTask
+        }
+
+        let task = Task {
+            defer { refreshTask = nil }
+
+            let crl = try await fetch()
             saveLocal(crl)
             return crl
-
-        } catch {
-            // Fallback on the locally cached CRL if available
-            guard let (crl, _) = localCRL else {
-                throw error
-            }
-            return crl
         }
+        refreshTask = task
+        return task
     }
 
     /// Fetches the updated Certificate Revocation List from EDRLab.
-    private func fetch(timeout: TimeInterval? = nil) async throws -> String {
+    private func fetch() async throws -> String {
         let url = HTTPURL(string: "http://crl.edrlab.telesec.de/rl/EDRLab_CA.crl")!
+
+        // Timeout for a CRL fetch. Generous enough for a slow connection,
+        // where a failure means the publication cannot be opened at all, but
+        // bounded so that a captive portal cannot hang the open too long.
+        let timeout: TimeInterval = 20
 
         let response = try await httpClient.fetch(HTTPRequest(url: url, timeoutInterval: timeout))
             .mapError { _ in LCPError.crlFetching }
@@ -65,8 +93,7 @@ final class CRLService: Sendable {
     }
 
     /// Reads the local CRL.
-    private func readLocal() -> (String, Date)? {
-        let defaults = UserDefaults.standard
+    private func readLocal() -> (crl: String, isExpired: Bool)? {
         guard let crl = defaults.string(forKey: CRLService.crlKey),
               let date = defaults.value(forKey: CRLService.dateKey) as? Date,
               let der = CRLService.decodePEM(crl),
@@ -75,7 +102,7 @@ final class CRLService: Sendable {
             return nil
         }
 
-        return (crl, date)
+        return (crl, isExpired: daysSince(date) >= CRLService.expiration)
     }
 
     /// Extracts the DER payload of a PEM-encoded CRL cached by ``saveLocal(_:)``.
@@ -138,7 +165,6 @@ final class CRLService: Sendable {
 
     /// Caches the given CRL.
     private func saveLocal(_ crl: String) {
-        let defaults = UserDefaults.standard
         defaults.set(crl, forKey: CRLService.crlKey)
         defaults.set(Date(), forKey: CRLService.dateKey)
     }

--- a/Tests/LCPTests/MockHTTPClient.swift
+++ b/Tests/LCPTests/MockHTTPClient.swift
@@ -1,0 +1,59 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+import ReadiumShared
+
+/// An `HTTPClient` returning a canned response to every request.
+final class MockHTTPClient: HTTPClient {
+    private let body: Data
+    private let status: HTTPStatus
+    private let mediaType: MediaType?
+
+    private let responsesStream = AsyncStream.makeStream(of: HTTPResponse.self)
+    private let _requestCount = Mutex(0)
+
+    init(body: Data, status: HTTPStatus = .ok, mediaType: MediaType? = nil) {
+        self.body = body
+        self.status = status
+        self.mediaType = mediaType
+    }
+
+    /// Yields each response returned, to await a request made in the
+    /// background.
+    var responses: AsyncStream<HTTPResponse> {
+        responsesStream.stream
+    }
+
+    /// Number of requests received.
+    var requestCount: Int {
+        _requestCount.withLock { $0 }
+    }
+
+    func stream(
+        _ request: any HTTPRequestConvertible,
+        onReceiveResponse: (@Sendable (HTTPResponse) async -> HTTPResult<Void>)?,
+        consume: @Sendable (Data, Double?) -> HTTPResult<Void>
+    ) async -> HTTPResult<HTTPResponse> {
+        guard let request = try? request.httpRequest().get() else {
+            return .failure(.malformedResponse(nil))
+        }
+        _requestCount.withLock { $0 += 1 }
+
+        let response = HTTPResponse(
+            request: request,
+            url: request.url,
+            status: status,
+            headers: [:],
+            mediaType: mediaType
+        )
+        _ = await onReceiveResponse?(response)
+        _ = consume(body, 1.0)
+        responsesStream.continuation.yield(response)
+
+        return .success(response)
+    }
+}

--- a/Tests/LCPTests/MockHTTPClient.swift
+++ b/Tests/LCPTests/MockHTTPClient.swift
@@ -38,21 +38,30 @@ final class MockHTTPClient: HTTPClient {
         onReceiveResponse: (@Sendable (HTTPResponse) async -> HTTPResult<Void>)?,
         consume: @Sendable (Data, Double?) -> HTTPResult<Void>
     ) async -> HTTPResult<HTTPResponse> {
-        guard let request = try? request.httpRequest().get() else {
-            return .failure(.malformedResponse(nil))
+        let httpRequest: HTTPRequest
+        switch request.httpRequest() {
+        case let .success(request):
+            httpRequest = request
+        case let .failure(error):
+            return .failure(error)
         }
         _requestCount.withLock { $0 += 1 }
 
         let response = HTTPResponse(
-            request: request,
-            url: request.url,
+            request: httpRequest,
+            url: httpRequest.url,
             status: status,
             headers: [:],
             mediaType: mediaType
         )
-        _ = await onReceiveResponse?(response)
-        _ = consume(body, 1.0)
         responsesStream.continuation.yield(response)
+
+        if let onReceiveResponse = onReceiveResponse, case let .failure(error) = await onReceiveResponse(response) {
+            return .failure(error)
+        }
+        if case let .failure(error) = consume(body, 1.0) {
+            return .failure(error)
+        }
 
         return .success(response)
     }

--- a/Tests/LCPTests/Services/CRLServiceTests.swift
+++ b/Tests/LCPTests/Services/CRLServiceTests.swift
@@ -6,56 +6,135 @@
 
 import Foundation
 @testable import ReadiumLCP
+@testable import ReadiumShared
 import Testing
 
-struct CRLServiceTests {
-    /// The real CRL served by EDRLab at
-    /// http://crl.edrlab.telesec.de/rl/EDRLab_CA.crl, captured on 2026-09-09.
-    private let realCRL = Data(base64Encoded: """
-    MIICkTCCAXkCAQEwDQYJKoZIhvcNAQELBQAwQjETMBEGA1UEChMKZWRybGFiLm9yZzEXMBUGA1UE
-    CxMOZWRybGFiLm9yZyBMQ1AxEjAQBgNVBAMTCUVEUkxhYiBDQRcNMjYwOTA5MTQxNzEyWhcNMjYw
-    OTE0MTQxNzExWjCB0DAnAgg9/PrnYyy4ABcNMjYwODA1MjAyMTEzWjAMMAoGA1UdFQQDCgEBMCgC
-    CQCoPyWN9DqSBhcNMjYwNTI1MDc1NTAwWjAMMAoGA1UdFQQDCgEGMCgCCQCwrtK1lYNPKhcNMjYw
-    ODI4MTcyNzQ1WjAMMAoGA1UdFQQDCgEGMCcCCAD7am95HSWbFw0yNjAzMjMxMjQ1NThaMAwwCgYD
-    VR0VBAMKAQYwKAIJAKjr9Zx5OfipFw0yNjAyMTIxMDE0MDJaMAwwCgYDVR0VBAMKAQagMDAuMB8G
-    A1UdIwQYMBaAFNxc/JPkH5/usLrqUgsrylJc4MmHMAsGA1UdFAQEAgIN+jANBgkqhkiG9w0BAQsF
-    AAOCAQEAVbgTkkd9dCzzEACaKDZMSgMulGJPsR15EXDS6WJ1oGf/rnEeyEfw1EBS50hU9LQkXAY1
-    XPLzS6Yd+X2BTsEvMcDDZJis5qottJhk6/o58qyhwdXt0wjs3p4l0rHI1qh8CpXpTJ+DaOwoHwU1
-    sqQECrk6FYtvGshSmNMA3CjqlcsS42UYWzgxKXOZruHkrqkxTTf5t0yo84DZ8dXIIJi2UU4L/Hi8
-    Y3JAADbQFvX0NTa8oj7BT0Y06wTSZRtYQIMNMgCOOOl4mRaI3YFv5KNG/eBfPVHAGwA0eDvgbyvz
-    cRCpyRJbvFlQVNsnlNZotD6eWItXNVYCie1FobRNAMPnYw==
-    """, options: .ignoreUnknownCharacters)!
+enum CRLServiceTests {
+    struct IsX509CRL {
+        /// Also covers the long form length header, `0x30 0x82 ...`.
+        @Test func acceptsTheRealCRL() {
+            #expect(CRLService.isX509CRL(realCRL))
+        }
 
-    /// Also covers the long form length header, `0x30 0x82 ...`.
-    @Test func acceptsTheRealCRL() {
-        #expect(CRLService.isX509CRL(realCRL))
+        @Test func rejectsACaptivePortalPage() {
+            #expect(!CRLService.isX509CRL(captivePortalPage))
+        }
+
+        @Test func rejectsEmptyData() {
+            #expect(!CRLService.isX509CRL(Data()))
+        }
+
+        @Test func rejectsATruncatedCRL() {
+            #expect(!CRLService.isX509CRL(realCRL.dropLast(8)))
+        }
+
+        @Test func rejectsTrailingBytes() {
+            #expect(!CRLService.isX509CRL(realCRL + Data([0x00, 0x01])))
+        }
+
+        /// 0x30 is also the ASCII digit `0`, so a text body can pass the tag check.
+        @Test func rejectsTextStartingWithAZero() {
+            #expect(!CRLService.isX509CRL("0".data(using: .utf8)!))
+            #expect(!CRLService.isX509CRL("0 requests served".data(using: .utf8)!))
+        }
+
+        /// The indefinite length form is illegal in DER.
+        @Test func rejectsIndefiniteLength() {
+            #expect(!CRLService.isX509CRL(Data([0x30, 0x80, 0x30, 0x00, 0x00, 0x00])))
+        }
     }
 
-    @Test func rejectsACaptivePortalPage() {
-        let html = "<!DOCTYPE html><html><body>Please sign in</body></html>"
-        #expect(!CRLService.isX509CRL(html.data(using: .utf8)!))
-    }
+    struct Retrieve {
+        /// A cache poisoned by a previous version must not be served for the
+        /// seven days of its expiration.
+        @Test func refetchesAPoisonedCache() async throws {
+            let defaults = makeDefaults()
+            seedCache(defaults, crl: pem(captivePortalPage), daysAgo: 0)
+            let client = MockHTTPClient(body: realCRL)
+            let service = CRLService(httpClient: client, defaults: defaults)
 
-    @Test func rejectsEmptyData() {
-        #expect(!CRLService.isX509CRL(Data()))
-    }
+            let crl = try await service.retrieve()
 
-    @Test func rejectsATruncatedCRL() {
-        #expect(!CRLService.isX509CRL(realCRL.dropLast(8)))
-    }
+            #expect(crl == pem(realCRL))
+            #expect(client.requestCount == 1)
+        }
 
-    @Test func rejectsTrailingBytes() {
-        #expect(!CRLService.isX509CRL(realCRL + Data([0x00, 0x01])))
-    }
+        @Test func returnsAFreshCacheWithoutFetching() async throws {
+            let defaults = makeDefaults()
+            seedCache(defaults, crl: pem(realCRL), daysAgo: 1)
+            let client = MockHTTPClient(body: otherCRL)
+            let service = CRLService(httpClient: client, defaults: defaults)
 
-    /// 0x30 is also the ASCII digit `0`, so a text body can pass the tag check.
-    @Test func rejectsTextStartingWithAZero() {
-        #expect(!CRLService.isX509CRL("0".data(using: .utf8)!))
-        #expect(!CRLService.isX509CRL("0 requests served".data(using: .utf8)!))
-    }
+            let crl = try await service.retrieve()
 
-    /// The indefinite length form is illegal in DER.
-    @Test func rejectsIndefiniteLength() {
-        #expect(!CRLService.isX509CRL(Data([0x30, 0x80, 0x30, 0x00, 0x00, 0x00])))
+            #expect(crl == pem(realCRL))
+            #expect(client.requestCount == 0)
+        }
+
+        @Test func aCaptivePortalRefreshLeavesTheCacheIntact() async throws {
+            let defaults = makeDefaults()
+            seedCache(defaults, crl: pem(realCRL), daysAgo: 8)
+            let client = MockHTTPClient(body: captivePortalPage)
+            let service = CRLService(httpClient: client, defaults: defaults)
+
+            let crl = try await service.retrieve()
+            #expect(crl == pem(realCRL))
+
+            // Waits for the background refresh to receive the portal page.
+            var responses = client.responses.makeAsyncIterator()
+            _ = await responses.next()
+
+            #expect(cachedCRL(in: defaults) == pem(realCRL))
+        }
     }
 }
+
+// MARK: - Fixtures
+
+/// The real CRL served by EDRLab at
+/// http://crl.edrlab.telesec.de/rl/EDRLab_CA.crl, captured on 2026-09-09.
+private let realCRL = Data(base64Encoded: """
+MIICkTCCAXkCAQEwDQYJKoZIhvcNAQELBQAwQjETMBEGA1UEChMKZWRybGFiLm9yZzEXMBUGA1UE
+CxMOZWRybGFiLm9yZyBMQ1AxEjAQBgNVBAMTCUVEUkxhYiBDQRcNMjYwOTA5MTQxNzEyWhcNMjYw
+OTE0MTQxNzExWjCB0DAnAgg9/PrnYyy4ABcNMjYwODA1MjAyMTEzWjAMMAoGA1UdFQQDCgEBMCgC
+CQCoPyWN9DqSBhcNMjYwNTI1MDc1NTAwWjAMMAoGA1UdFQQDCgEGMCgCCQCwrtK1lYNPKhcNMjYw
+ODI4MTcyNzQ1WjAMMAoGA1UdFQQDCgEGMCcCCAD7am95HSWbFw0yNjAzMjMxMjQ1NThaMAwwCgYD
+VR0VBAMKAQYwKAIJAKjr9Zx5OfipFw0yNjAyMTIxMDE0MDJaMAwwCgYDVR0VBAMKAQagMDAuMB8G
+A1UdIwQYMBaAFNxc/JPkH5/usLrqUgsrylJc4MmHMAsGA1UdFAQEAgIN+jANBgkqhkiG9w0BAQsF
+AAOCAQEAVbgTkkd9dCzzEACaKDZMSgMulGJPsR15EXDS6WJ1oGf/rnEeyEfw1EBS50hU9LQkXAY1
+XPLzS6Yd+X2BTsEvMcDDZJis5qottJhk6/o58qyhwdXt0wjs3p4l0rHI1qh8CpXpTJ+DaOwoHwU1
+sqQECrk6FYtvGshSmNMA3CjqlcsS42UYWzgxKXOZruHkrqkxTTf5t0yo84DZ8dXIIJi2UU4L/Hi8
+Y3JAADbQFvX0NTa8oj7BT0Y06wTSZRtYQIMNMgCOOOl4mRaI3YFv5KNG/eBfPVHAGwA0eDvgbyvz
+cRCpyRJbvFlQVNsnlNZotD6eWItXNVYCie1FobRNAMPnYw==
+""", options: .ignoreUnknownCharacters)!
+
+/// A second payload with the shape of a CRL, to tell a fetched CRL apart from a
+/// cached one.
+private let otherCRL = Data([0x30, 0x04, 0x30, 0x02, 0x05, 0x00])
+
+private let captivePortalPage = "<!DOCTYPE html><html><body>Please sign in</body></html>"
+    .data(using: .utf8)!
+
+// MARK: - Helpers
+
+/// Wraps `der` the way `CRLService` caches a fetched CRL.
+private func pem(_ der: Data) -> String {
+    "-----BEGIN X509 CRL-----\(der.base64EncodedString())-----END X509 CRL-----"
+}
+
+/// Returns defaults isolated from the other tests and from the real ones.
+private func makeDefaults() -> UserDefaults {
+    UserDefaults(suiteName: "crl-tests-\(UUID().uuidString)")!
+}
+
+private func seedCache(_ defaults: UserDefaults, crl: String, daysAgo: Int) {
+    defaults.set(crl, forKey: crlKey)
+    defaults.set(Date().addingTimeInterval(-Double(daysAgo) * 24 * 60 * 60), forKey: crlDateKey)
+}
+
+private func cachedCRL(in defaults: UserDefaults) -> String? {
+    defaults.string(forKey: crlKey)
+}
+
+private let crlKey = "org.readium.r2-lcp-swift.CRL"
+private let crlDateKey = "org.readium.r2-lcp-swift.CRLDate"

--- a/Tests/LCPTests/Services/CRLServiceTests.swift
+++ b/Tests/LCPTests/Services/CRLServiceTests.swift
@@ -1,0 +1,61 @@
+//
+//  Copyright 2026 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+@testable import ReadiumLCP
+import Testing
+
+struct CRLServiceTests {
+    /// The real CRL served by EDRLab at
+    /// http://crl.edrlab.telesec.de/rl/EDRLab_CA.crl, captured on 2026-09-09.
+    private let realCRL = Data(base64Encoded: """
+    MIICkTCCAXkCAQEwDQYJKoZIhvcNAQELBQAwQjETMBEGA1UEChMKZWRybGFiLm9yZzEXMBUGA1UE
+    CxMOZWRybGFiLm9yZyBMQ1AxEjAQBgNVBAMTCUVEUkxhYiBDQRcNMjYwOTA5MTQxNzEyWhcNMjYw
+    OTE0MTQxNzExWjCB0DAnAgg9/PrnYyy4ABcNMjYwODA1MjAyMTEzWjAMMAoGA1UdFQQDCgEBMCgC
+    CQCoPyWN9DqSBhcNMjYwNTI1MDc1NTAwWjAMMAoGA1UdFQQDCgEGMCgCCQCwrtK1lYNPKhcNMjYw
+    ODI4MTcyNzQ1WjAMMAoGA1UdFQQDCgEGMCcCCAD7am95HSWbFw0yNjAzMjMxMjQ1NThaMAwwCgYD
+    VR0VBAMKAQYwKAIJAKjr9Zx5OfipFw0yNjAyMTIxMDE0MDJaMAwwCgYDVR0VBAMKAQagMDAuMB8G
+    A1UdIwQYMBaAFNxc/JPkH5/usLrqUgsrylJc4MmHMAsGA1UdFAQEAgIN+jANBgkqhkiG9w0BAQsF
+    AAOCAQEAVbgTkkd9dCzzEACaKDZMSgMulGJPsR15EXDS6WJ1oGf/rnEeyEfw1EBS50hU9LQkXAY1
+    XPLzS6Yd+X2BTsEvMcDDZJis5qottJhk6/o58qyhwdXt0wjs3p4l0rHI1qh8CpXpTJ+DaOwoHwU1
+    sqQECrk6FYtvGshSmNMA3CjqlcsS42UYWzgxKXOZruHkrqkxTTf5t0yo84DZ8dXIIJi2UU4L/Hi8
+    Y3JAADbQFvX0NTa8oj7BT0Y06wTSZRtYQIMNMgCOOOl4mRaI3YFv5KNG/eBfPVHAGwA0eDvgbyvz
+    cRCpyRJbvFlQVNsnlNZotD6eWItXNVYCie1FobRNAMPnYw==
+    """, options: .ignoreUnknownCharacters)!
+
+    /// Also covers the long form length header, `0x30 0x82 ...`.
+    @Test func acceptsTheRealCRL() {
+        #expect(CRLService.isX509CRL(realCRL))
+    }
+
+    @Test func rejectsACaptivePortalPage() {
+        let html = "<!DOCTYPE html><html><body>Please sign in</body></html>"
+        #expect(!CRLService.isX509CRL(html.data(using: .utf8)!))
+    }
+
+    @Test func rejectsEmptyData() {
+        #expect(!CRLService.isX509CRL(Data()))
+    }
+
+    @Test func rejectsATruncatedCRL() {
+        #expect(!CRLService.isX509CRL(realCRL.dropLast(8)))
+    }
+
+    @Test func rejectsTrailingBytes() {
+        #expect(!CRLService.isX509CRL(realCRL + Data([0x00, 0x01])))
+    }
+
+    /// 0x30 is also the ASCII digit `0`, so a text body can pass the tag check.
+    @Test func rejectsTextStartingWithAZero() {
+        #expect(!CRLService.isX509CRL("0".data(using: .utf8)!))
+        #expect(!CRLService.isX509CRL("0 requests served".data(using: .utf8)!))
+    }
+
+    /// The indefinite length form is illegal in DER.
+    @Test func rejectsIndefiniteLength() {
+        #expect(!CRLService.isX509CRL(Data([0x30, 0x80, 0x30, 0x00, 0x00, 0x00])))
+    }
+}

--- a/Tests/LCPTests/Services/CRLServiceTests.swift
+++ b/Tests/LCPTests/Services/CRLServiceTests.swift
@@ -48,10 +48,10 @@ enum CRLServiceTests {
         /// A cache poisoned by a previous version must not be served for the
         /// seven days of its expiration.
         @Test func refetchesAPoisonedCache() async throws {
-            let defaults = makeDefaults()
-            seedCache(defaults, crl: pem(captivePortalPage), daysAgo: 0)
+            let suite = makeSuite()
+            seedCache(suite, crl: pem(captivePortalPage), daysAgo: 0)
             let client = MockHTTPClient(body: realCRL)
-            let service = CRLService(httpClient: client, defaults: defaults)
+            let service = CRLService(httpClient: client, defaultsSuite: suite)
 
             let crl = try await service.retrieve()
 
@@ -60,10 +60,10 @@ enum CRLServiceTests {
         }
 
         @Test func returnsAFreshCacheWithoutFetching() async throws {
-            let defaults = makeDefaults()
-            seedCache(defaults, crl: pem(realCRL), daysAgo: 1)
+            let suite = makeSuite()
+            seedCache(suite, crl: pem(realCRL), daysAgo: 1)
             let client = MockHTTPClient(body: otherCRL)
-            let service = CRLService(httpClient: client, defaults: defaults)
+            let service = CRLService(httpClient: client, defaultsSuite: suite)
 
             let crl = try await service.retrieve()
 
@@ -72,10 +72,10 @@ enum CRLServiceTests {
         }
 
         @Test func aCaptivePortalRefreshLeavesTheCacheIntact() async throws {
-            let defaults = makeDefaults()
-            seedCache(defaults, crl: pem(realCRL), daysAgo: 8)
+            let suite = makeSuite()
+            seedCache(suite, crl: pem(realCRL), daysAgo: 8)
             let client = MockHTTPClient(body: captivePortalPage)
-            let service = CRLService(httpClient: client, defaults: defaults)
+            let service = CRLService(httpClient: client, defaultsSuite: suite)
 
             let crl = try await service.retrieve()
             #expect(crl == pem(realCRL))
@@ -84,7 +84,7 @@ enum CRLServiceTests {
             var responses = client.responses.makeAsyncIterator()
             _ = await responses.next()
 
-            #expect(cachedCRL(in: defaults) == pem(realCRL))
+            #expect(cachedCRL(in: suite) == pem(realCRL))
         }
     }
 }
@@ -122,18 +122,27 @@ private func pem(_ der: Data) -> String {
     "-----BEGIN X509 CRL-----\(der.base64EncodedString())-----END X509 CRL-----"
 }
 
-/// Returns defaults isolated from the other tests and from the real ones.
-private func makeDefaults() -> UserDefaults {
-    UserDefaults(suiteName: "crl-tests-\(UUID().uuidString)")!
+/// Returns the name of a defaults suite isolated from the other tests and from
+/// the real ones.
+///
+/// Every instance of a same suite shares its storage, so the tests and the
+/// service under test read and write the same cache.
+private func makeSuite() -> String {
+    "crl-tests-\(UUID().uuidString)"
 }
 
-private func seedCache(_ defaults: UserDefaults, crl: String, daysAgo: Int) {
+private func defaults(_ suite: String) -> UserDefaults {
+    UserDefaults(suiteName: suite)!
+}
+
+private func seedCache(_ suite: String, crl: String, daysAgo: Int) {
+    let defaults = defaults(suite)
     defaults.set(crl, forKey: crlKey)
     defaults.set(Date().addingTimeInterval(-Double(daysAgo) * 24 * 60 * 60), forKey: crlDateKey)
 }
 
-private func cachedCRL(in defaults: UserDefaults) -> String? {
-    defaults.string(forKey: crlKey)
+private func cachedCRL(in suite: String) -> String? {
+    defaults(suite).string(forKey: crlKey)
 }
 
 private let crlKey = "org.readium.r2-lcp-swift.CRL"


### PR DESCRIPTION
### Changed

#### LCP

* Opening an LCP publication is no longer delayed by the CRL used to validate its license. The CRL is now downloaded when creating the `LCPService`, and an expired one is refreshed in the background instead of making the user wait for the response.

### Fixed

#### LCP

* The CRL used to validate LCP licenses is now checked to be a genuine X.509 CRL before being cached. Networks with a captive portal (e.g. on a plane) could return their login page with a `200 OK` status, which was then cached for seven days and prevented opening LCP publications. An invalid CRL cached by a previous version is now ignored instead of waiting for its expiration.

---

Twin Kotlin PR: https://github.com/readium/kotlin-toolkit/pull/833