### PR TITLE
Update swiftformat

### DIFF
--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/nicklockwood/SwiftFormat",
         "state": {
           "branch": null,
-          "revision": "a5fa7a6a57abeb834df1b3fa43ea9133137d5ade",
-          "version": "0.61.1"
+          "revision": "0256422f1a5e967c68dc923f1905c0a155dca188",
+          "version": "0.63.0"
         }
       }
     ]

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     name: "BuildTools",
     platforms: [.macOS(.v10_11)],
     dependencies: [
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.61.0"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.63.0"),
     ],
     targets: [
         .target(name: "BuildTools", path: "", exclude: ["Sources"]),

--- a/Sources/LCP/Toolkit/DataCompression.swift
+++ b/Sources/LCP/Toolkit/DataCompression.swift
@@ -132,7 +132,9 @@ public extension Data {
 
         guard let inflated = cresult else { return nil }
 
-        if skipCheckSumValidation { return inflated }
+        if skipCheckSumValidation {
+            return inflated
+        }
 
         let cksum: UInt32 = withUnsafeBytes { (bytePtr: UnsafePointer<UInt8>) -> UInt32 in
             let last = bytePtr.advanced(by: count - 4)
@@ -399,9 +401,13 @@ public struct Adler32: CustomStringConvertible, Sendable {
 
         for byte in data {
             s1 += UInt32(byte)
-            if s1 >= prime { s1 = s1 % prime }
+            if s1 >= prime {
+                s1 = s1 % prime
+            }
             s2 += s1
-            if s2 >= prime { s2 = s2 % prime }
+            if s2 >= prime {
+                s2 = s2 % prime
+            }
         }
         return (s2 << 16) | s1
     }

--- a/Sources/Navigator/EditingAction.swift
+++ b/Sources/Navigator/EditingAction.swift
@@ -79,7 +79,9 @@ public struct EditingAction: Hashable, Sendable {
 
     /// Whether this is a custom (non-native) action.
     var isCustom: Bool {
-        if case .custom = kind { return true }
+        if case .custom = kind {
+            return true
+        }
         return false
     }
 }

--- a/Sources/Navigator/PDF/PDFNavigatorViewController.swift
+++ b/Sources/Navigator/PDF/PDFNavigatorViewController.swift
@@ -372,8 +372,11 @@ open class PDFNavigatorViewController:
         let locator = publication.normalizeLocator(locator)
 
         let readingOrderIndex: Int? =
-            if isPDFFile { 0 }
-            else { publication.readingOrder.firstIndexWithHREF(locator.href) }
+            if isPDFFile {
+                0
+            } else {
+                publication.readingOrder.firstIndexWithHREF(locator.href)
+            }
 
         guard let readingOrderIndex else {
             return false

--- a/Sources/Navigator/Toolkit/HTMLInjection.swift
+++ b/Sources/Navigator/Toolkit/HTMLInjection.swift
@@ -127,7 +127,9 @@ extension HTMLElement {
         for name in names {
             let escaped = NSRegularExpression.escapedPattern(for: name)
             let regex = regex(for: "\\s\(escaped)\\s*=")
-            if regex.firstMatch(in: tag, range: nsRange) != nil { return true }
+            if regex.firstMatch(in: tag, range: nsRange) != nil {
+                return true
+            }
         }
         return false
     }

--- a/Sources/OPDS/ParseData.swift
+++ b/Sources/OPDS/ParseData.swift
@@ -31,7 +31,9 @@ public struct ParseData: Sendable {
     public var feed: Feed? {
         didSet {
             // Publication is nil when feed is not
-            if feed != nil { publication = nil }
+            if feed != nil {
+                publication = nil
+            }
         }
     }
 
@@ -39,7 +41,9 @@ public struct ParseData: Sendable {
     public var publication: Publication? {
         didSet {
             // Feed is nil when publication is not
-            if publication != nil { feed = nil }
+            if publication != nil {
+                feed = nil
+            }
         }
     }
 

--- a/Sources/Shared/Toolkit/Extensions/UIImage.swift
+++ b/Sources/Shared/Toolkit/Extensions/UIImage.swift
@@ -71,7 +71,9 @@ extension UIImage {
         let pixelSize = CGSize(width: size.width * scale, height: size.height * scale)
         let renderSize: CGSize
         if pixelSize.width <= maxSize.width, pixelSize.height <= maxSize.height {
-            if scale == 1 { return self }
+            if scale == 1 {
+                return self
+            }
             renderSize = pixelSize
         } else {
             renderSize = AVMakeRect(aspectRatio: pixelSize, insideRect: CGRect(origin: .zero, size: maxSize)).size

--- a/Sources/Shared/Toolkit/JSONValue.swift
+++ b/Sources/Shared/Toolkit/JSONValue.swift
@@ -82,21 +82,27 @@ public enum JSONValue: Hashable, Sendable, Loggable {
 
     /// Returns the associated `Bool` if this value is `.bool`, otherwise `nil`.
     public var bool: Bool? {
-        if case let .bool(v) = self { return v }
+        if case let .bool(v) = self {
+            return v
+        }
         return nil
     }
 
     /// Returns the associated `String` if this value is `.string`, otherwise
     /// `nil`.
     public var string: String? {
-        if case let .string(v) = self { return v }
+        if case let .string(v) = self {
+            return v
+        }
         return nil
     }
 
     /// Returns the associated `Int` if this value is `.integer`, otherwise
     /// `nil`.
     public var integer: Int? {
-        if case let .integer(v) = self { return v }
+        if case let .integer(v) = self {
+            return v
+        }
         return nil
     }
 
@@ -105,21 +111,29 @@ public enum JSONValue: Hashable, Sendable, Loggable {
     /// Returns the associated value for `.double`, or the integer value
     /// promoted to `Double` for `.integer`. Returns `nil` for all other cases.
     public var double: Double? {
-        if case let .double(v) = self { return v }
-        if case let .integer(v) = self { return Double(v) }
+        if case let .double(v) = self {
+            return v
+        }
+        if case let .integer(v) = self {
+            return Double(v)
+        }
         return nil
     }
 
     /// Returns the associated array if this value is `.array`, otherwise `nil`.
     public var array: [JSONValue]? {
-        if case let .array(v) = self { return v }
+        if case let .array(v) = self {
+            return v
+        }
         return nil
     }
 
     /// Returns the associated dictionary if this value is `.object`, otherwise
     /// `nil`.
     public var object: [String: JSONValue]? {
-        if case let .object(v) = self { return v }
+        if case let .object(v) = self {
+            return v
+        }
         return nil
     }
 }
@@ -470,7 +484,9 @@ extension [String: JSONValue]: JSONObjectEncodable, JSONValueEncodable {
 
         if filteringNull {
             dict = dict.filter { _, value in
-                if case .null = value { return false }
+                if case .null = value {
+                    return false
+                }
                 return true
             }
         }
@@ -602,9 +618,15 @@ public extension JSONValue {
             return T(exactly: value)
         case let .double(value):
             guard value >= 0 else { return nil }
-            if let t = value as? T { return t }
-            if let t = Float(value) as? T { return t }
-            if let t = UInt64(exactly: value) as? T { return t }
+            if let t = value as? T {
+                return t
+            }
+            if let t = Float(value) as? T {
+                return t
+            }
+            if let t = UInt64(exactly: value) as? T {
+                return t
+            }
             return Int64(exactly: value).flatMap { T(exactly: $0) }
         default:
             return nil

--- a/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
+++ b/Sources/Streamer/Parser/EPUB/EPUBMetadataParser.swift
@@ -40,7 +40,9 @@ final class EPUBMetadataParser: Loggable {
         }
 
         var other = metas.otherMetadata
-        if let mo = mediaOverlay() { other["mediaOverlay"] = .object(mo.jsonObject) }
+        if let mo = mediaOverlay() {
+            other["mediaOverlay"] = .object(mo.jsonObject)
+        }
 
         return Metadata(
             identifier: uniqueIdentifier,

--- a/Sources/Streamer/Parser/EPUB/OPFMeta.swift
+++ b/Sources/Streamer/Parser/EPUB/OPFMeta.swift
@@ -270,8 +270,12 @@ struct OPFMetaList {
 
         return metadata.compactMapValues { values in
             func toJSONValue(_ value: Any) -> JSONValue? {
-                if let v = value as? String { return .string(v) }
-                if let v = value as? [String: JSONValue] { return .object(v) }
+                if let v = value as? String {
+                    return .string(v)
+                }
+                if let v = value as? [String: JSONValue] {
+                    return .object(v)
+                }
                 return nil
             }
 

--- a/Sources/Streamer/Parser/EPUB/SMIL/SMILParser.swift
+++ b/Sources/Streamer/Parser/EPUB/SMIL/SMILParser.swift
@@ -215,7 +215,9 @@ private struct SMILGuidedNavigationDocumentParsing {
         while result.last == "0" {
             result.removeLast()
         }
-        if result.last == "." { result.removeLast() }
+        if result.last == "." {
+            result.removeLast()
+        }
         return result
     }
 

--- a/Sources/Streamer/Toolkit/DataCompression.swift
+++ b/Sources/Streamer/Toolkit/DataCompression.swift
@@ -132,7 +132,9 @@ public extension Data {
 
         guard let inflated = cresult else { return nil }
 
-        if skipCheckSumValidation { return inflated }
+        if skipCheckSumValidation {
+            return inflated
+        }
 
         let cksum: UInt32 = withUnsafeBytes { (bytePtr: UnsafePointer<UInt8>) -> UInt32 in
             let last = bytePtr.advanced(by: count - 4)
@@ -399,9 +401,13 @@ public struct Adler32: CustomStringConvertible, Sendable {
 
         for byte in data {
             s1 += UInt32(byte)
-            if s1 >= prime { s1 = s1 % prime }
+            if s1 >= prime {
+                s1 = s1 % prime
+            }
             s2 += s1
-            if s2 >= prime { s2 = s2 % prime }
+            if s2 >= prime {
+                s2 = s2 % prime
+            }
         }
         return (s2 << 16) | s1
     }

--- a/TestApp/Sources/OPDS/OPDSFeeds/OPDSFeedView.swift
+++ b/TestApp/Sources/OPDS/OPDSFeeds/OPDSFeedView.swift
@@ -63,22 +63,24 @@ struct OPDSFeedView: View {
             .navigationDestination(
                 isPresented: Binding(
                     get: { facetNavigationURL != nil },
-                    set: { if !$0 { facetNavigationURL = nil } }
+                    set: {
+                        if !$0 {
+                            facetNavigationURL = nil
+                        }
+                    }
                 )
             ) {
                 facetDestinationView()
             }
     }
 
+    @ViewBuilder
     private var mainContent: some View {
-        Group {
-            // If the feed is only publications, show a grid.
-            if viewModel.isPublicationOnly {
-                buildPublicationOnlyView(viewModel.publications)
-            } else {
-                // Otherwise, show a list view.
-                buildListView()
-            }
+        if viewModel.isPublicationOnly {
+            buildPublicationOnlyView(viewModel.publications)
+        } else {
+            // Otherwise, show a list view.
+            buildListView()
         }
     }
 

--- a/TestApp/Sources/Reader/Common/VisualReaderViewController.swift
+++ b/TestApp/Sources/Reader/Common/VisualReaderViewController.swift
@@ -271,7 +271,9 @@ class VisualReaderViewController<N: UIViewController & Navigator>: ReaderViewCon
     }
 
     private func addHighlightDecorationsObserverOnce() {
-        if highlights == nil { return }
+        if highlights == nil {
+            return
+        }
 
         if let decorator = navigator as? DecorableNavigator {
             decorator.observeDecorationInteractions(inGroup: highlightDecorationGroup) { [weak self] event in

--- a/Tests/LCPTests/Repositories/InMemoryLCPPassphraseRepository.swift
+++ b/Tests/LCPTests/Repositories/InMemoryLCPPassphraseRepository.swift
@@ -18,7 +18,9 @@ actor InMemoryLCPPassphraseRepository: LCPPassphraseRepository {
     func passphrasesMatching(userID: User.ID?, provider: LicenseDocument.Provider) async throws -> [LCPPassphraseHash] {
         entries.compactMap { hash, entry in
             guard entry.provider == provider else { return nil }
-            if let userID { return entry.userID == userID ? hash : nil }
+            if let userID {
+                return entry.userID == userID ? hash : nil
+            }
             return hash
         }
     }

--- a/Tests/NavigatorTests/Decorator/DiffableDecorationTests.swift
+++ b/Tests/NavigatorTests/Decorator/DiffableDecorationTests.swift
@@ -56,11 +56,17 @@ struct DiffableDecorationTests {
         for change in ch1 {
             switch change {
             case let .update(dec):
-                if dec.id == "1" { hasUpdate1 = true }
+                if dec.id == "1" {
+                    hasUpdate1 = true
+                }
             case let .remove(id):
-                if id == "2" { hasRemove2 = true }
+                if id == "2" {
+                    hasRemove2 = true
+                }
             case let .add(dec):
-                if dec.id == "4" { hasAdd4 = true }
+                if dec.id == "4" {
+                    hasAdd4 = true
+                }
             }
         }
 

--- a/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
+++ b/Tests/SharedTests/Publication/Services/Cover/CoverServiceTests.swift
@@ -69,7 +69,9 @@ private func makePublication(
     cover: CoverServiceFactory? = nil
 ) -> Publication {
     var builder = PublicationServicesBuilder()
-    if let cover { builder.setCoverServiceFactory(cover) }
+    if let cover {
+        builder.setCoverServiceFactory(cover)
+    }
     return Publication(
         manifest: Manifest(
             metadata: Metadata(title: "title"),

--- a/Tests/SharedTests/Toolkit/HTTP/DefaultHTTPClientTests.swift
+++ b/Tests/SharedTests/Toolkit/HTTP/DefaultHTTPClientTests.swift
@@ -1156,7 +1156,9 @@ private extension URLRequest {
             defer { buffer.deallocate() }
             while stream.hasBytesAvailable {
                 let bytesRead = stream.read(buffer, maxLength: 1024)
-                if bytesRead > 0 { data.append(buffer, count: bytesRead) }
+                if bytesRead > 0 {
+                    data.append(buffer, count: bytesRead)
+                }
             }
             stream.close()
             return data


### PR DESCRIPTION
Updates swiftformat to 0.63.0. The main change is that in 0.62.0, the `wrapConditionalBodies` rule was split into `wrapIfStatementBodies`, `wrapIfExpressionBodies`, `wrapGuardStatementBodies`, with `wrapIfStatementBodies` enabled by default. I think this looks better. But we can always change it.